### PR TITLE
adds triage incident template

### DIFF
--- a/.github/ISSUE_TEMPLATE/508-issue.md
+++ b/.github/ISSUE_TEMPLATE/508-issue.md
@@ -2,7 +2,7 @@
 name: 508 Accessibility
 about: To describe issues related to Section 508 Accessibility Standards
 title: ''
-labels: '508/Accessibility'
+labels: 508/Accessibility
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/bug-issue.md
@@ -1,7 +1,10 @@
 ---
 name: Bug Template
 about: For filing bugs found on VSP
+title: ''
 labels: bug
+assignees: ''
+
 ---
 
 ## What happened?

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/epic-issue.md
+++ b/.github/ISSUE_TEMPLATE/epic-issue.md
@@ -1,6 +1,10 @@
 ---
 name: Epic Template
 about: For filing Epics on VSP
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 ## High Level User Story

--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -1,6 +1,10 @@
 ---
 name: Standard Issue Template
 about: For filing standard issues on VSP.
+title: ''
+labels: ''
+assignees: ''
+
 ---
 
 ## User Story

--- a/.github/ISSUE_TEMPLATE/triage-incident-template.md
+++ b/.github/ISSUE_TEMPLATE/triage-incident-template.md
@@ -1,0 +1,69 @@
+---
+name: Triage Incident Template
+about: For incident triage on VSP
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Status
+
+[UNRESOLVED, RESOLVED]
+
+### Severity Analysis
+
+*Estimate of how critical this bug is*
+
+- `sev 1` 
+    - Immediate resolution needed
+    - Critical incident
+- `sev 2` 
+    - Needs a special deploy
+    - Needs SME
+    - Regression that went uncaught in dev/staging
+- `sev 3` 
+    - Can go out in a regular deploy but still needs fixed ASAP
+    - Can be put into the owning team's backlog and scheduled by PM
+
+### User Impact 
+
+- *Who is the user impacted by this problem?*
+- *How does this problem affect the user?*
+
+### Description
+
+- *In one or two sentences, what is happening?*
+
+### Steps to Reproduce
+
+- *List steps required to reproduce the issue in question*
+
+#### Expected Results
+
+- *example:* 
+
+  > The user is redirected to `profile`
+
+
+#### Actual Results
+
+- *example:* 
+
+  > The user is redirected to `/` (the home page)
+
+
+### Further Details
+*Add any of the following as available:*
+
+- Sentry Issue Link
+- ServiceNow (or other source) link
+- Components, Transaction, URL
+- Platform, User Agent, Browser, Version
+- Screen size, viewport, zoom level
+- Screenshots
+
+### Proposed Solution
+
+- *Summary of solution*
+- *Link to related tickets*


### PR DESCRIPTION
## summary of changes
- adds a template for incident triage (connects to #412)
- updates older templates to have `title`, `labels`, and `assignees` (these were applied when I used GitHub's UI for adding the incident triage template)