### PR TITLE
Moves onboarding docs from `va.gov-vfs-teams` to `va.gov-team`.

### DIFF
--- a/.github/ISSUE_TEMPLATE/onboarding-epic.md
+++ b/.github/ISSUE_TEMPLATE/onboarding-epic.md
@@ -17,15 +17,15 @@ As a new VA.gov team member, I need to complete onboarding activities so I can s
 ## Definition of Done
 
 - [ ] Attend general onboarding meeting
-- [ ] [Request Access to Tools](https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/Onboarding/request-access-to-tools.md)
+- [ ] [Request Access to Tools](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Administrative/Onboarding/request-access-to-tools.md)
 - [ ] Review the [Guidelines for Working Safely in an Open Source Repo](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/README.md)
-- [ ] Review the [Norms for Using Tools](https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/Norms/norms-tools.md)
-- [ ] Review the [Code of Conduct](https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/code-of-conduct.md)
-- [ ] Review the [Platform Principles](https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/Norms/platform-principles.md)
-- [ ] Review the [Norms for Communication](https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/Norms/norms-communication.md)
+- [ ] Review the [Norms for Using Tools](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Administrative/Policies%20and%20work%20norms/norms-tools.md)
+- [ ] Review the [Code of Conduct](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Administrative/Policies%20and%20work%20norms/code-of-conduct.md)
+- [ ] Review the [Platform Principles](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Administrative/Policies%20and%20work%20norms/platform-principles.md)
+- [ ] Review the [Norms for Communication](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Administrative/Policies%20and%20work%20norms/norms-communication.md)
 - [ ] Review the [GitHub Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) to learn the syntax for formatting documents in GitHub
 - [ ] Designers: Review [Design & Research Onboarding Documentation](https://design.va.gov/documentation/designers)
-- [ ] Engineers: [Set Up Local Dev Environment](https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/DeveloperDocs/getting-started.md)
+- [ ] Engineers: [Set Up Local Dev Environment](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Practice%20Areas/Engineering/getting-started.md)
   - [ ] [Set Up Front-end](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/)
   - [ ] [Set Up Back-end](https://github.com/department-of-veterans-affairs/vets-api#vets-api-)
   - [ ] [Confirm that You Can Log In as a Test User](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/internal-tools)

--- a/Administrative/Onboarding/request-access-to-tools.md
+++ b/Administrative/Onboarding/request-access-to-tools.md
@@ -1,0 +1,97 @@
+# Request access to tools
+
+## Configure your Github and Slack accounts
+
+To work on the Veteran-facing Services Platform, each team member needs to use the VA Github organization and to DSVA Slack channels.
+
+## Slack
+1. If you haven't already, check your email for an invitation to join Digital Service at VA on Slack, and join!
+
+1. Add information to your Slack profile:
+    * Profile image
+    * Full name
+    * What I do (i.e. your practice area: Front-end Engineer, Designer, etc)
+    * Time zone
+    * Pronouns
+    * GitHub (i.e. the account handle / username you created when you set up your GitHub account)
+
+## GitHub
+
+1. If you haven't already, check your email for an invitation to the Department of Veterans Affairs GitHub Organization, and join!
+ 
+1. Make sure you have "Read" access (not just "Write" access) to the [va.gov-team GitHub repository](https://github.com/department-of-veterans-affairs/va.gov-team). If you don't have the appropriate access, or if you're unsure, let VSP know in the #vfs-platform-support Slack channel.
+
+1. Add information to your Github profile:
+    * Organization: ```Your company name```
+    * Working on: ```The project your team is working on```, e.g., "526 ancillary forms"
+
+1. Developers, complete the [additional onboarding steps](#additional-onboarding-steps-for-developers) below to access the code repositories and tools you'll need for development and deployment.
+
+## Additional onboarding steps for developers
+
+The internal tools available include Grafana, Sentry, Prometheus and Jenkins. These tools are hosted internally and
+available for developers via proxy access. We use `ssh` and the Chrome plugin SwitchyOmega to route web requests from
+your browser to the SOCKS5 proxy for these private domains. For this we require the use of an `ssh` key pair to secure
+access which we will be walking through in the steps below. Please remember **do not initiate** the issue until your
+PIV background check is underway. Opening the issue prematurely will slow down our ability to respond to you in a
+timely manner.
+
+#### 1. Create [new SSH keys](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#create-ssh-public-key).
+
+#### 2. Request that your SSH keys be authorized so that you can use the developer tools such as Jenkins, Grafana and Sentry.
+* File an issue in [va.gov-team repo](https://github.com/department-of-veterans-affairs/va.gov-team).
+* Use the issue template `Environment Access Request Template`
+  * Follow the template instructions
+    * Provide the name of your Contracting Officer's Representative (COR)
+    * Provide your name, role and company
+    * Paste the public portion of your ssh key. The template has an example.
+    * Grant AWS Console Access? Yes or No.
+  * Tag group `@department-of-veterans-affairs/vsp-operations` to review
+  * Monitor the issue for updates and respond to any questions from the operations group.
+  * Occasionally operations will need to reach out via Slack for additional information.
+
+#### 3. When your key has been added, the Github issue will be closed, which will send a notification to you. This is your signal that you can continue to the next step.
+
+#### 4. Configure [the SOCKS proxy](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#configure-the-socks-proxy).
+
+#### 5. Understand [how to use the SOCKS proxy from inside the VA network and from the internet](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#accessing-socks-proxy-from-va-network).
+
+#### 6. [Test and use the SOCKS proxy](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Internal%20Tools.md#accessing-socks-proxy-from-the-internet).
+
+#### 7. Jenkins, Grafana, and Sentry
+
+Jenkins, Grafana, and Sentry have been linked to GitHub for user authentication.
+* The services will not be accessible until the SOCKS proxy is configured and working properly.
+* When logging into these services for the first time click the button `Login with GitHub` or similar
+  * You will be prompted to link your GitHub account and presented with a permissions dialog
+  * Allow the service to access your account and view your Organization membership
+
+#### 8. For AWS Console access
+##### 8A. When your account has been setup, you will receive a Slack private message with your temporary password and login URL.
+##### 8B. You are required to login and change the temporary password immediately.
+* AWS will prompt you to change your password during first login
+* Additionally you are required to setup a virtual MFA device in order to access services in the AWS cloud and programmatically via the CLI.
+  * Follow the walk through for MFA setup [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/AWS%20Account%20Setup.md#mfa-virtual-device)
+
+
+## Tools overview
+
+### Jenkins
+
+With the Socks proxy set up and running, go to http://jenkins.vfs.va.gov. You can see the builds without logging in, but will need to authenticate (with GitHub OAuth) to re-run failed builds.
+
+### Sentry
+
+With the Socks proxy set up and running, go to http://sentry.vfs.va.gov.
+
+We do not really use Sentry teams except to separate production, staging, and dev errors. To view the most recent production errors, which is the most common thing to do while on call, go to http://sentry.vfs.va.gov/vets-gov/platform-api-production/
+
+### Grafana
+With the Socks proxy set up and running, go to http://grafana.vfs.va.gov/login. You can sign in using your GitHub account by clicking the "GitHub" button on the login page.
+
+There are many dashboards and you should click around to get familiar with the variety of metrics being collected and visualized (make sure Data Source is set to Production). A few highlights are:
+
+- [Site](http://grafana.vfs.va.gov/dashboard/db/site) to see overall metrics about the health of the site
+- [External Service Status](http://grafana.vfs.va.gov/dashboard/db/external-service-status) to see the availability of the services vets.gov depends on.
+- [RDS](http://grafana.vfs.va.gov/dashboard/db/rds) to see the database statistics.
+- [Rev Proxy](http://grafana.vfs.va.gov/dashboard/db/revproxy) to see metrics on the reverse proxies.

--- a/Administrative/Policies and work norms/code-of-conduct.md
+++ b/Administrative/Policies and work norms/code-of-conduct.md
@@ -1,0 +1,17 @@
+# Veteran-facing Services Platform Code of Conduct
+
+## Background
+
+This document is not all encompassing, nor does it supersede any laws. It is designed to explicitly state what we all should already know to be true.
+
+## Code of Conduct
+
+The Veteran-facing Services Platform (VSP) team believes in active inclusivity and creating friendly and welcoming environments for all -- free from discrimination for any reason.
+
+The VSP team is absolutely dedicated to providing a harassment-free work experience for everyone.  Harassment includes statements or actions related to gender identity (including history and expression), age, sexual orientation, disability, physical appearance, body size, race, religion, or other protected status that we reasonably determine offend, demean, intimidate or harm another person, whether those statements occur in public or in private.
+
+Examples of conduct that may be considered to violate this code of conduct include the following: the use of sexual language or imagery; unwanted sexual attention; failure to maintain reasonable personal space boundaries; refusing to end conversation when requested; unauthorized access to computer equipment, including keylogging, screenshotting or tampering.
+
+## What to do if an incident arises
+
+If you notice or experience this code of conduct being violated, either towards yourself or someone else, immediately alert your supervisor. If an event occurs that you believe violates the law or which jeopardizes your safety, you should contact 911.

--- a/Administrative/Policies and work norms/norms-communication.md
+++ b/Administrative/Policies and work norms/norms-communication.md
@@ -1,0 +1,75 @@
+# Norms for Communication
+
+## Communicating "breaking changes"
+
+Breaking changes are changes to design, content, or code that have the potential to affect (break) the work of other teams currently working on the Veteran-facing Services Platform (VSP).
+
+For example:
+
+* A new design pattern is added to the design system
+* The Sketch file has been updated
+* A change to how the feature flag works
+* A change to how the website build process works
+* A significant change to the content style guide
+
+**All instances of breaking changes should be posted to *#vfs-all-teams*.**
+
+The post needs to provide enough information that a designer, developer, or content person can know what they need to do in order to accommodate the change in their work. Some examples:
+
+> Sketch file has been updated to include new treatment for X. Find the Sketch file here [link].
+
+> We changed how the feature flag works. Instead of doing [describe the old way], you need to do X [describe the new way].
+
+## DSVA and platform responsibilities
+
+### DSVA authorizes access for VFS teams
+
+* To ensure we limit VA access to the right people, a DSVA person will add VFS team members.
+  * If a new need arises (e.g., access to a new Github repo is needed), direct the request to the DSVA contact, who will determine access and permissions.
+
+### DSVA and the platform team provide support
+* DSVA and the platform team will monitor the #vfs-platform-support Slack channel for product-focused questions/inquiries from VFS teams.
+
+### The platform team cannot direct VFS teams
+
+The platform team cannot direct the roadmaps of VFS teams or tell them what project they should work on next. For example:
+
+* What should I be working on?
+* What task should I do next?
+
+If these questions come up, the platform team will ask the VFS team to contact their DSVA product contact.
+
+However, we do want the platform team and all VFS teams to collaborate because their projects will have dependencies and connections. For example, the platform team may provide guidance or feedback on a VFS team's architecture so that adjustments can be made to allow dependent tools to work well together.
+
+#### Gray areas
+
+Questions are bound to come up that fall somewhere between "How do I?" and "What do I?" In these cases, the platform team will direct VFS teams to their DSVA product contact, who will decide how to handle the question or request.
+
+## VFS team responsibilities
+
+### Look for documentation before posting a question in Slack (or contacting DSVA).
+* See your team's Github "Product" folder or onboarding guides.
+* If you don't find an answer, post in #vfs-platform-support.
+
+### Use Slack channels for different purposes.
+
+* **For product questions** use your team's "product" Slack channel.
+  * Example question: "Where can I find previous research?"
+* **For process questions**, use the *#vfs-platform-support* Slack channel.
+  * Example questions: "I can't get the proxy to work" or "How do I integrate this into that?" or "How do I use Zenhub to do X?"
+* **For practice area questions** use your practice area Slack channel (e.g., *#design*)
+
+### Use best communication method.
+
+#### Slack - best communication method
+* Slack channels allow us to do our work in the open so that others can learn from the questions asked and the answers provided. Please do the same.
+* We discourage private Slack conversations (DMs) for the same reason.
+* **VFS teams should use public Slack channels as their first method of communication.**
+
+#### Meetings - slowest communication method
+* If your team has a question about something, ask it in a Slack channel.
+* Don't wait to organize a meeting to ask a question; this will slow your team down.
+
+#### Email - least effective communication method
+* Email communications are not easily searchable or archivable.
+* Use this as a last resort for communication.

--- a/Administrative/Policies and work norms/norms-tools.md
+++ b/Administrative/Policies and work norms/norms-tools.md
@@ -1,0 +1,49 @@
+# Norms for using tools
+
+## Using Slack
+
+* **Product channel** - Your whole team will be added to a product-focused Slack channel.
+
+  * This where you can ask questions and share **product-related information** with other teams working in a similar area.
+
+* **Support channel** - Your whole team will be added to the *#vfs-platform-support* channel.
+
+  * This is where you can ask **process questions about onboarding, development, deployment, and project management**.
+
+* Refer to [the communication norms](norms-communication.md) for the best way to use Slack to communicate with DSVA and Internal Contractors.
+
+
+## Understanding Github access
+
+The [VA Github organization](https://github.com/department-of-veterans-affairs) contains many repos from teams across the VA. To make it easier for VFS teams working on the Veteran-facing Services Platform, we've listed the repos that are relevant to your work.
+
+After your team has been added to the VA Github organization (see [requesting access to tools](../Onboarding/request-access-to-tools.md), your team will have access to these repos:
+
+* [vets.gov-team](https://github.com/department-of-veterans-affairs/vets.gov-team) (private, write access)
+    * We'll set up a "Product" folder for your team, which you'll use to store and share project documents.
+    * Your team will use Github issues in this repo to manage your agile workflow and to request tasks from the DSVA team.
+    * See [using the vets.gov-team repo](#using-the-vetsgov-team-repo).
+* [vets-ato](https://github.com/department-of-veterans-affairs/vets.gov-ato) (private, read access)
+    * Provided so your team can review the current ATO documents.
+* [devops](https://github.com/department-of-veterans-affairs/devops) (private, developers have read access)
+    * Provided so your team can obtain the ```ssh-config``` file.    
+* [vets-website](https://github.com/department-of-veterans-affairs/vets-website) (public, developers have Write access)
+* [vets-api](https://github.com/department-of-veterans-affairs/vets-api) (public, developers have Write access)
+* [vets-json-schema](https://github.com/department-of-veterans-affairs/vets-json-schema) (public, developers have Write access)
+* [vets-api-mockdata](https://github.com/department-of-veterans-affairs/vets-api-mockdata) (private, developers have Read access)
+
+
+## Using the vets.gov-team repo
+
+* **Most of the folders in this repo are not relevant or useful to VFS teams.** So please don't get distracted by them!
+* **VFS teams only need to pay attention to the "Products" folder.**
+
+### The vets.gov-team Products folder
+
+The "Products" folder contains information about each product (application or feature) on the Veteran-facing Services Platform. Your team will be assigned a "Products" folder (or sub-folder) to work in.
+
+* We encourage you to browse content in other "Products" folders to see how other teams have organized their content or presented their findings.
+  * This is especially important if your team is working on adding a feature to an existing application. You'll want to learn the history of the application by seeing what's happened so far.
+* Your project may be slightly different, so you don't need to exactly copy what other teams have done. Use your best judgement about what works for your project!
+* If you have any questions, ask your DSVA contact.
+* For historical and tracking purposes, your team must store its project documents in your assigned "Products" folder. If you don't know which folder that is, ask your DSVA contact.

--- a/Administrative/Policies and work norms/platform-principles.md
+++ b/Administrative/Policies and work norms/platform-principles.md
@@ -1,0 +1,42 @@
+# Platform Principles
+
+These principles guide us in creating appropriate policies, process, and procedures for teams working on the Veteran-facing Services Platform (VSP). They are touchstones to be revisited when we need to make decisions about policy, process, or procedure.
+
+### Service design, not bureaucracy.
+
+* We're here to improve Veteran-facing services and the way the VA builds them, not create better bureaucracy.
+* For process improvements, we start by researching and documenting the problem and user stories. Then, we use our journey map to discuss and prioritize potential solutions.
+
+### Work in the open.
+
+* We work in the open so all teams can learn from us. All teams work in the open so they can learn from each other.
+* For anything new, we default to open repos. If that's not possible, we document why.
+
+### Assume competence and best intentions.
+
+* The people we work with—from any team—are our peers. We treat them as such.
+
+### Trust, but verify.
+
+* We ensure the quality of Veteran-facing Services. But we do not operate as helicopter parents for teams building VFS.
+* We create the lightest weight process possible. Our goal is forward movement, not process.
+
+### More trust can be earned.
+
+* We extend more trust as teams demonstrate that they can maintain our quality standards.
+
+### Carrots, not sticks.
+
+* We empower all teams building VFS. We do not block teams’ forward progress with our bureaucracy or our own internal process. We design our processes so that the best option for teams is also the easiest option.
+
+### Don’t make perfect the enemy of the good.
+
+* We make space for all teams to create their own solutions. We evaluate these solutions for consistency, not whether or not we would have created the same solution.
+
+### Ask for forgiveness, not permission.
+
+* We empower all teams building VFS to make their own decisions, as long as they align with our quality standards.
+
+### Be kind to each other.
+
+* This work is too hard to not be nice to each other.

--- a/Practice Areas/Engineering/getting-started.md
+++ b/Practice Areas/Engineering/getting-started.md
@@ -1,0 +1,74 @@
+# Getting Started
+
+
+To build a service on the Veteran-facing Services Platform, which can be anything from a digital form to a map-based facility locator, developers will create a Frontend experience in React on Vets-Website, and connect it to an Integration on Vets-API, which manages the data flow to and from VA systems.
+
+<hr>
+
+* [Get started](#get-started)
+* [Development](#development)
+* [Get help](#get-help)
+
+<hr>
+
+## Get started
+
+1. Confirm that your team's Project Manager has added your name, email address, and Github username to the team spreadsheet and sent it to DSVA. You'll know when you can visit [this Github repo and see the content](https://github.com/department-of-veterans-affairs/vets.gov-team).
+
+1. Follow the steps to [create new SSH keys, configure, and test the SOCKS proxy](../Onboarding/request-access-to-tools.md#additional-onboarding-steps-for-developers).
+
+1. Verify that you have
+
+    * Have access to the [Veteran-facing Services Platform code repositories](#code-repositories)
+
+    * Have credentials for the shared testing environments &mdash;  [dev.va.gov](https://dev.va.gov) and [staging.va.gov](https://staging.va.gov).
+
+    * Have access to [Internal Tools](internal-tools-access.md)
+
+    * **Tip**: If you have a problem or can't get access, post in the *#vfs-platform-support* Slack channel or reach out to your DSVA contact.
+
+1. Review all the content this folder &mdash; ```DeveloperDocs```
+
+1. Review the frontend documentation for [Vets-Website](vets-website/README.md).
+
+1. Review the backend documentation for [Vets-API](vets-api/README.md).
+
+<hr>
+
+## Development
+
+#### Code repositories
+
+The Veteran-facing Services Platform is broken into three parts:
+
+1. [Vets-Website](https://github.com/department-of-veterans-affairs/vets-website), which contains frontend applications and components users interact with
+
+1. [Vets-API](https://github.com/department-of-veterans-affairs/vets-api), a JSON-based API used by the frontend to provide data to and from VA systems
+
+1. [Vets-JSON-Schema](https://github.com/department-of-veterans-affairs/vets-json-schema), which contains shared resources used to structure and validate form data between Vets-Website and Vets-API.
+
+#### Local development environment setup
+
+1. [How to setup your front end VA.gov local environment](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started)
+1. [How to setup your back end VA.gov local environment](https://github.com/department-of-veterans-affairs/vets-api)
+1. After you are setup and running both front-end and back-end servers, try logging in using a mock user. Information on how to login with a mock user can be found [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/2d03fbabafe9c4840596e6687795a1906e4596ec/Administrative/Accessing-Staging.md).
+1. [Mock test users](https://github.com/department-of-veterans-affairs/vets-api-mockdata/blob/master/mock_data_table.md)
+1. Once you can seccessfully login you should be setup for developing on VA.gov.
+
+#### Internal Tools
+
+To get access to metrics, build logs, deployment information and exception details, see [Internal Tools Access](internal-tools-access.md) documentation.
+
+<hr>
+
+## Get help
+
+DSVA engineering resources are available to provide guidance and support through the development effort.
+
+If you encounter issues or have any questions, raise them in the *#vfs-platform-support* Slack channel, or reach out to your DSVA contact.
+
+<hr>
+
+Next: [Environments](environments.md)
+
+Back: [Developer Docs Introduction](README.md)


### PR DESCRIPTION
These files were taken from:
* https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/6e51ee6a6f4db791981bc0e7b00f78505037bfab/Onboarding/request-access-to-tools.md
* https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/6e51ee6a6f4db791981bc0e7b00f78505037bfab/Norms/norms-tools.md
* https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/6e51ee6a6f4db791981bc0e7b00f78505037bfab/code-of-conduct.md
* https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/6e51ee6a6f4db791981bc0e7b00f78505037bfab/Norms/platform-principles.md
* https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/6e51ee6a6f4db791981bc0e7b00f78505037bfab/Norms/norms-communication.md
* https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/6e51ee6a6f4db791981bc0e7b00f78505037bfab/DeveloperDocs/getting-started.md