### PR TITLE
Add prohibition on gmail.com addresses to template

### DIFF
--- a/.github/ISSUE_TEMPLATE/analytics-access-request-template.md
+++ b/.github/ISSUE_TEMPLATE/analytics-access-request-template.md
@@ -10,7 +10,9 @@ assignees: joanneesteban, jonwehausen, nedierecel
 # Analytics Access Request
 
 ## User Email Address
-_Provide email address(es) for user(s) requesting access to the Insights team on the DSVA Slack channel: #VSP-Analytics. Please also link this issue. Email addresses ending in `@gmail.com`_ **may not** _be used. If the user has a VA.gov email address or does not yet have a google account, they will need to create one by visiting [this link](https://accounts.google.com/signup/v2/webcreateaccount?continue=https%3A%2F%2Faccounts.google.com%2FManageAccount&gmb=exp&biz=false&flowName=GlifWebSignIn&flowEntry=SignUp). VA.gov users and external users with email accounts that are not Google based should select the option "Use my current email address instead". 
+_Provide email address(es) for user(s) requesting access to the Insights team on the DSVA Slack channel: #VSP-Analytics. Please also link this issue. Email addresses ending in `@gmail.com` _**may not**_ be used. If the user has a VA.gov or work email address that is not linked to a Google account, they will need to create one by visiting [this link](https://accounts.google.com/signup/v2/webcreateaccount?continue=https%3A%2F%2Faccounts.google.com%2FManageAccount&gmb=exp&biz=false&flowName=GlifWebSignIn&flowEntry=SignUp). VA.gov users and external users with email accounts that are not Google based should select the option "Use my current email address instead"._
+
+_If the user already has a Google account that is not yet linked to their VA.gov email, they can link it using [these instructions](https://support.google.com/accounts/answer/176347?co=GENIE.Platform%3DDesktop&hl=en)._
 
 ## Access Requirements
 _What properties does the user need access to? E.G. eBenefits, MHV, WBC, a single modernized product area view, developer.va.gov, etc._

--- a/.github/ISSUE_TEMPLATE/analytics-access-request-template.md
+++ b/.github/ISSUE_TEMPLATE/analytics-access-request-template.md
@@ -10,7 +10,7 @@ assignees: joanneesteban, jonwehausen, nedierecel
 # Analytics Access Request
 
 ## User Email Address
-_Provide email address(es) for user(s) requesting access to the Insights team on the DSVA Slack channel: #VSP-Analytics. Please also link this issue. If the user has a VA.gov email address or does not yet have a google account, they will need to create one by visiting [this link](https://accounts.google.com/signup/v2/webcreateaccount?continue=https%3A%2F%2Faccounts.google.com%2FManageAccount&gmb=exp&biz=false&flowName=GlifWebSignIn&flowEntry=SignUp). VA.gov users and external users with email accounts that are not google based should select the option "Use my current email address instead"._
+_Provide email address(es) for user(s) requesting access to the Insights team on the DSVA Slack channel: #VSP-Analytics. Please also link this issue. Email addresses ending in `@gmail.com`_ **may not** _be used. If the user has a VA.gov email address or does not yet have a google account, they will need to create one by visiting [this link](https://accounts.google.com/signup/v2/webcreateaccount?continue=https%3A%2F%2Faccounts.google.com%2FManageAccount&gmb=exp&biz=false&flowName=GlifWebSignIn&flowEntry=SignUp). VA.gov users and external users with email accounts that are not Google based should select the option "Use my current email address instead". 
 
 ## Access Requirements
 _What properties does the user need access to? E.G. eBenefits, MHV, WBC, a single modernized product area view, developer.va.gov, etc._


### PR DESCRIPTION
As a analytics access requester, I need to know the type of email addresses for which I may not request access so I can gain access to GA faster and with less effort.