### PR TITLE
Clarify when 24 hour review clock starts

### DIFF
--- a/Practice Areas/Engineering/code_review_guidelines.md
+++ b/Practice Areas/Engineering/code_review_guidelines.md
@@ -15,7 +15,7 @@ Before sending your code to a VSP team for review, your code should meet all of 
     * Before sending code to VSP team have it reviewed by your team (see **First review** below) using a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/).  
       * This prevents [code owners](https://help.github.com/en/articles/about-code-owners) from being notified before pull request is ready for review.
     * After having your pull request reviewed by your team you can click the *Ready for review* button in the merge section of your pull request.
-      * An engineer from the VSP team will aim to review within 24 hours (business days) and each additional round of changes will be reviewed within 24 hours.  If you need a review faster, escalate via your DSVA product owner.
+      * An engineer from the VSP team will aim to review within 24 hours (business days) after the pull request has been reviewed by your team and you have been marked it *Ready for review*. Each additional round of changes will be reviewed within 24 hours.  If you need a review faster, escalate via your DSVA product owner.
       * **Do not post in Slack channels requesting VSP code reviews** unless it has been more than 24 hours since requesting review on GitHub.
     * After sending your code for review, don't add additional changes! Code needs to be stable for a safe review.
     * If non-trivial changes to your code are made *after approval by VSP team* and submitted without a re-review, your change is subject to being reverted.


### PR DESCRIPTION
See unnecessary [Slack ping](https://dsva.slack.com/archives/CJ34D8TPB/p1565732442222200) that was based on it being > 24 hours from when PR was _created_ but < 24 hours from when it was internally approved and marked for review. This might be a bit nit picky, but I'd rather err on the side of specificity :-)