### PR TITLE
Update Rules of Engagement with Triage.md

### DIFF
--- a/Platform/Teams/Triage/Rules of Engagement with Triage.md
+++ b/Platform/Teams/Triage/Rules of Engagement with Triage.md
@@ -1,26 +1,22 @@
 # Preface
 This document will help all team members working on VA.gov understand when it is appropriate to engage the Triage team for support and provide relevant information to assist in routing reported issues to other appropriate teams.  Because of the limited number of resources on Triage, they cannot be a "catch-all" for every issue reported on the platform and every application.  Please read the following document carefully in order to determine the appropriate path for your incident.
 
-## Is this is a Severity 1 Issue? - Notify On Call Immediately
+## Is this is a Severity 1 Issue? - Notify On-call Immediately
 
 When the incident is believed to be **Severity 1** which can be defined as (but not limited to)
- * Issue resolution is required in a 24 hour period
- * Part of (or all of) va.gov is severely disrupted
-  
+* Issue resolution is required in a 24 hour period
+* Part of (or all of) va.gov is severely disrupted
+
+In these cases, immediately escalate to [#oncall](https://dsva.slack.com/messages/oncall/).
+
 Examples:
 - va.gov is unresponsive
 - Platform errors causing extreme delays for users
 - Login to va.gov is unavailable
   
-If you believe the issue falls into the Severity 1 category, there is no need to follow the Triage process.  Immediate notification to On Call is the best path to resolution.
-
-Slack - [#oncall](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Practice%20Areas/Engineering/OnCall)
-
-[Instructions on escalting to On Call can be found here](https://github.com/department-of-veterans-affairs/devops/blob/master/docs/Incident%20Response%20Playbook.md)
-
 ## When to engage the Triage Team
   
-**General Rule:** Any issue that is discovered that is outside your teams scope of work can be reported to Triage
+**General Rule:** Any issue that is discovered that is outside your team's scope of work can be reported to Triage.
 
 Examples:
 - An internal load testing tool is broken
@@ -28,32 +24,38 @@ Examples:
 - Metrics are being reported incorrectly or not reported at all
 
 **How to Report the Issue:**
-Reach out on our [Slack Channel](https://dsva.slack.com/messages/CK1FA11H8)
 
-Submit a GitHub issue using our [Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=triage%2C+triage-incident&template=triage-incident-template.md&title=)
+Choose one of the following:
 
-Is there already a GitHub Issue? Add the following tags and notify the Slack Channel for visibility:
-* triage
-* triage-incident
+* If you know which team the issue should be routed to, reach out to their point of contact to confirm and directly assign the issue to that team.
+
+* If you aren't sure which team owns the issue and would like to send it directly to them without the assistance of Triage, the [Product Owner Mapping Document](https://docs.google.com/spreadsheets/d/1hzz6whEGoQJQbiNvIggirhydYYdv57nfOZfLvFqZ1pQ/edit?ts=5d28958a#gid=1535759874) can help guide you in the right direction.
+
+* If you aren't sure which team owns the issue and want to send it to Triage team, choose one of the following:
+
+  * Reach out on [`#vsp-triage`](https://dsva.slack.com/messages/CK1FA11H8)
+
+  * Submit a GitHub issue using our [Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=triage%2C+triage-incident&template=triage-incident-template.md&title=)
+
+    * _NOTE_: Is there already a GitHub Issue? Add the following labels and post in `#vsp-triage` for visibility:
+      * `triage`
+      * `triage-incident`
  
-If you know which team the issue should be routed to, reach out to their pont of contact to confirm and directly asssign the issue to that team.  If you aren't sure which team owns the issue and would like to send it directly to them without the assistance of Triage, the [Product Owner Mapping Document](https://docs.google.com/spreadsheets/d/1hzz6whEGoQJQbiNvIggirhydYYdv57nfOZfLvFqZ1pQ/edit?ts=5d28958a#gid=1535759874) can help guide you in the right direction.
+_NOTE_: Assigning an issue to Triage using the [Triage Incident Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=triage%2C+triage-incident&template=triage-incident-template.md&title=) does not guarantee that the work will be completed by the Triage team.  Triage will do their own investigation, prioritization and scoping to determine the best team responsible for resolution.
 
-*The Product Owner Mapping Document listed above is a living document.  If you would like to suggest edits to add or change owner to products please reach out to the PM of Triage (Alex Pappas).  It is also protected as this is a public repo*
- 
-NOTE: Assigning an issue to Triage using the [Triage Incident Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=triage%2C+triage-incident&template=triage-incident-template.md&title=) does not guarentee the work will be completed by the triage team.  Triage will do their own investigation, priotization and scoping to determine the best team to be resonsible for resolution.
-
-## When is it NOT ok to engage the Triage Team
+## When to NOT engage the Triage Team
 
 * Bugs that belong within your own team
 * Feature Improvements that belong within your own team
 
 ## Still not sure?
-If you still have a doubt about where to report your incident for whatever reason, please reach out to the #vsp-triage slack channel and we would be happy to assist you.
+
+If you still have a doubt about where to report your incident for whatever reason, please reach out to the [`#vsp-triage`](https://dsva.slack.com/messages/CK1FA11H8) Slack channel and we would be happy to assist you.
 
 When in doubt, submit any issue through our [Triage Incident Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=triage%2C+triage-incident&template=triage-incident-template.md&title=) and the Triage team will ensure it gets through the process correctly!
 
 
 # NOTES on improvements to this doc:
 
-Create a process flow diagram to compliment what is being said in a visual manner
+Create a process flow diagram to complement what is being said in a visual manner
 


### PR DESCRIPTION
Making a number of adjustments to the Triage RoE:

* Trimming down "send emergencies to oncall" section
* Rearranging "How to report to triage" section to be a little more step-by-step
* Fixing up links / formatting / text