### PR TITLE
Updating template to include link to ROE doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/triage-incident-template.md
+++ b/.github/ISSUE_TEMPLATE/triage-incident-template.md
@@ -7,6 +7,8 @@ assignees: ''
 
 ---
 
+### Pleae read the [Triage Rules of Engagement](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Platform/Teams/Triage/Rules%20of%20Engagement%20with%20Triage.md) for instructions on what types of issue should be submitted using this template.
+
 ### Status
 
 [UNRESOLVED, RESOLVED]


### PR DESCRIPTION
Added a single line at the top with a link to the Triage Rules of Engagement document.