### PR TITLE
Update position on PII in GitHub

### DIFF
--- a/Administrative/Policies and work norms/sensitive-guidance.md
+++ b/Administrative/Policies and work norms/sensitive-guidance.md
@@ -10,7 +10,7 @@ All content related to development on VA.gov belongs in the public [`va.gov-team
 
 ### PII
 
-Veteran PII should generally not be checked into GitHub, but in some cases (i.e. investigating bugs related to specific users) can be checked in here if needed.
+Veteran PII should not be checked into GitHub. 
 
 [OMB memorandum M-07-16](https://www.whitehouse.gov/sites/whitehouse.gov/files/omb/memoranda/2007/m07-16.pdf) includes extensive details about securing PII, including this brief definition:
 


### PR DESCRIPTION
## Summary of changes

Removes language allowing special cases of PII in GitHub.

Why: it's my understanding that GitHub is approved at a low impact SaaS rating (LI-SaaS), and that PII cannot be stored in products with this rating. 

GitHub approved as LI-SaaS: 
  - https://github.blog/2018-10-24-github-is-fedramp-authorized/

Specs on LI-SaaS: 
  - https://tailored.fedramp.gov/policy/#fedramp-tailored-lisaas-requirements 
  - https://www.fedramp.gov/understanding-baselines-and-impact-levels