### PR TITLE
Update the automated testing section

### DIFF
--- a/platform/accessibility/508-accessibility-best-practices.md
+++ b/platform/accessibility/508-accessibility-best-practices.md
@@ -20,9 +20,13 @@
   - The H1 should convey the page's purpose
   - H2s should be used to semantically define the high-level content groups
   - H3 through H6 should be used to define sub-points
+- Design system utility classes should be used to style headings
+  - [Font family](https://design.va.gov/utilities/font-family) should be used to adjust typefaces
+  - [Font size](https://design.va.gov/utilities/font-size) should be used to adjust size in pixels
 - Page `<title>` tags should update on every URL change.
   - H1 text should be included in the page title
   - Page title may be longer or more descriptive than the H1
+  - For example the `<h1>` might read "Learn about benefits" and the `<title>` might read "Learn more about benefits | VA.gov"
 
 ## Formation Design System
 
@@ -33,11 +37,12 @@
 
 1. axe Scans
 
-   1. Front-end engineering should install the [axe plugin for Chrome or Firefox](https://deque.com/axe) and run it periodically during their daily work.
-   2. This manual process should be repeated in automated processes that scan rendered pages for regressions every time a build is initiated. These end-to-end (e2e) 508 scans should be looking for `['Section 508', 'WCAG 2 Level A', 'WCAG 2 Level AA']` errors.
+   1. Front-end engineers should install the [axe plugin for Chrome or Firefox](https://deque.com/axe) and run it periodically during their daily work.
+   2. The build server will run an axe scan on all rendered pages in Step 2. The axe check scans for Section 508, WCAG2 A and WCAG2 AA [ruleset](https://dequeuniversity.com/rules/axe/) violations.
    3. **Each rendered page must pass an axe check.**
-      * Static pages will be tested as part of Step 2.
-      * Client-side applications **must include an axe check** as part of their e2e suite. The engineering team has created a [Nightwatch helper function](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/axeCheck.js) for this purpose.
+      * Static Markdown pages should be checked for violations using the axe plugin.
+      * Pages created with the content management system (CMS) should also be checked using the axe plugin.
+      * Client-side applications **must include an axe check** in their end-to-end tests. The engineering team has created a [Nightwatch helper function](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/axeCheck.js) for this purpose.
 
 2. When you push your code to a feature branch or merge to master, the automated build process will test for Accessibility/508 compliance.
    1. Static content created by Markdown files or the Content Management System (CMS) will be tested as part of the build step.

--- a/platform/accessibility/508-accessibility-best-practices.md
+++ b/platform/accessibility/508-accessibility-best-practices.md
@@ -20,6 +20,9 @@
   - The H1 should convey the page's purpose
   - H2s should be used to semantically define the high-level content groups
   - H3 through H6 should be used to define sub-points
+- Page `<title>` tags should update on every URL change.
+  - H1 text should be included in the page title
+  - Page title may be longer or more descriptive than the H1
 
 ## Formation Design System
 
@@ -31,9 +34,14 @@
 1. Axe Scans
 
    1. Front-end engineering should install the [axe plugin for Chrome or Firefox](https://deque.com/axe) and run it periodically during their daily work.
-   2. This manual process should be repeated in end-to-end tests that scan rendered pages for regressions every time a build is initiated. These e2e 508 scans should be looking for `['Section 508', 'WCAG 2 Level A', 'WCAG 2 Level AA']` errors.
+   2. This manual process should be repeated in automated processes that scan rendered pages for regressions every time a build is initiated. These e2e 508 scans should be looking for `['Section 508', 'WCAG 2 Level A', 'WCAG 2 Level AA']` errors.
+   3. **Each rendered page must pass an aXe check.**
+      * Static pages will be tested as part of Step 2.
+      * Client-side applications **must include an aXe check** as part of their end-to-end (e2e) suite. The engineerring team has created a [Nightwatch helper function](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/axeCheck.js) for this purpose.
 
 2. When you push your code to a feature branch or merge to master, the automated build process will test for Accessibility/508 compliance.
+   1. Static content created by Markdown files or the content management system (CMS) will be tested as part of the build step.
+   2. Client-side applications will be tested for accessibility as part of their larger e2e test suite.
 
 3. If a build error occurs, fix the issue and submit your code again.
 

--- a/platform/accessibility/508-accessibility-best-practices.md
+++ b/platform/accessibility/508-accessibility-best-practices.md
@@ -51,8 +51,7 @@
 
 - Set browser width to 1280px
 - Zoom in by pressing `Ctrl and +` on Windows or `Cmd and +` on Mac, until browser shows 400% zoom.
-- Most layouts should not scroll sideways or have content to the edges. Horizontal scrolling is permitted for content like images, maps, diagrams,
-  presentations, and data tables.
+- Most layouts should not scroll sideways or have content to the edges. Horizontal scrolling is permitted for content like images, maps, diagrams, presentations, and data tables.
 - [Understanding Success Criterion 1.4.10: Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html)
 - [WCAG: Understanding Reflow](https://www.w3.org/WAI/WCAG21/Understanding/reflow.html)
 
@@ -60,13 +59,8 @@
 
 - Ensure focusable elements (links, form inputs, buttons, radios, checkboxes) are all reachable by keyboard. Ensure any elements with a `tabIndex="0"` can be focused in the normal document flow.
 - Whenever possible, use proper semantic elements. For instance, it is better to use a `<button>` than re-create events and focus behaviors using custom tags.
-- Avoid keyboard traps. These are situations where users can tab into an
-  interface, but cannot tab out of it by pressing `TAB` or `SHIFT+TAB`.
-- Ensure your application has a predictable tabbing order. In left-right
-  languages like English, this is assumed to be left to right, top to bottom.
-  In multi-column layouts, use your best judgment. Interfaces that include a left
-  navigation bar would likely allow users to focus each link or button in the left
-  nav, then move focus to the main content area.
+- Avoid keyboard traps. These are situations where users can tab into an interface, but can't tab out of it by pressing `TAB` or `SHIFT+TAB`.
+- Ensure your application has a predictable tabbing order. In left-right languages like English, this is assumed to be left to right, top to bottom. In multi-column layouts, use your best judgment. Interfaces that include a left navigation bar would likely allow users to focus each link or button in the left nav, then move focus to the main content area.
 - Offer ways to skip large groups of links like a [skip to content link](https://webaim.org/techniques/skipnav/)
 - Review the [WebAIM keyboard accessibility guide](https://webaim.org/techniques/keyboard/) for keyboard navigation patterns.
 

--- a/platform/accessibility/508-accessibility-best-practices.md
+++ b/platform/accessibility/508-accessibility-best-practices.md
@@ -31,16 +31,16 @@
 
 ## Automated Accessibility/508 Testing
 
-1. Axe Scans
+1. axe Scans
 
    1. Front-end engineering should install the [axe plugin for Chrome or Firefox](https://deque.com/axe) and run it periodically during their daily work.
-   2. This manual process should be repeated in automated processes that scan rendered pages for regressions every time a build is initiated. These e2e 508 scans should be looking for `['Section 508', 'WCAG 2 Level A', 'WCAG 2 Level AA']` errors.
-   3. **Each rendered page must pass an aXe check.**
+   2. This manual process should be repeated in automated processes that scan rendered pages for regressions every time a build is initiated. These end-to-end (e2e) 508 scans should be looking for `['Section 508', 'WCAG 2 Level A', 'WCAG 2 Level AA']` errors.
+   3. **Each rendered page must pass an axe check.**
       * Static pages will be tested as part of Step 2.
-      * Client-side applications **must include an aXe check** as part of their end-to-end (e2e) suite. The engineerring team has created a [Nightwatch helper function](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/axeCheck.js) for this purpose.
+      * Client-side applications **must include an axe check** as part of their e2e suite. The engineering team has created a [Nightwatch helper function](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/testing/e2e/nightwatch-commands/axeCheck.js) for this purpose.
 
 2. When you push your code to a feature branch or merge to master, the automated build process will test for Accessibility/508 compliance.
-   1. Static content created by Markdown files or the content management system (CMS) will be tested as part of the build step.
+   1. Static content created by Markdown files or the Content Management System (CMS) will be tested as part of the build step.
    2. Client-side applications will be tested for accessibility as part of their larger e2e test suite.
 
 3. If a build error occurs, fix the issue and submit your code again.


### PR DESCRIPTION
* Adding a re-written automated test section to call out the need for teams to write accessibility tests into e2e suites, and identify how static content is tested by the build process.
* Added a section about page `<title>` to the semantic HTML outline