### PR TITLE
Updating 508 issue closure documentation.

### DIFF
--- a/.github/ISSUE_TEMPLATE/508-issue.md
+++ b/.github/ISSUE_TEMPLATE/508-issue.md
@@ -35,6 +35,15 @@ assignees: ''
 
 **VFS Point of Contact:** _First name only. Delete if not applicable._
 
+## When Should the Issue be Reviewed by a 508 Specialist?
+
+Issue tickets that should be tested in pull request will include the label
+`508-test-pr`. This means the 508 specalist has asked to review your feature
+branch as part of the code review, before it is merged into `master` and
+deployed to Staging.
+
+`Staging server` or `Pull request`
+
 ## Acceptance Criteria
 
 <!-- As a keyboard user, I want to open the Level of Coverage widget by pressing Spacebar or pressing Enter. These keypress actions should not interfere with the mouse click event also opening the widget. -->
@@ -67,7 +76,7 @@ If the issue is one that can be fixed easily by changing HTML, CSS, or JavaScrip
 ```html
 <button
   aria-label="Open Level of Coverage Tool"
-  class="adc-c-button adc-c-button--large"
+  class="adc-c-button adc-c-button-large"
   type="button"
 >
   Level of Coverage

--- a/.github/ISSUE_TEMPLATE/508-issue.md
+++ b/.github/ISSUE_TEMPLATE/508-issue.md
@@ -10,7 +10,7 @@ assignees: ""
 
 1. Click or press the gear icon next to the "Labels" heading on the right. Search for your team in the labels list. If your team is not listed in the Labels menu, please leave a comment after you have created this issue. The Product Support team will create a new label for your team.
 2. If this issue is being opened by a VFS team, please add the `triage-incident` and `product support` labels.
-3. **Issue tickets should be tested when you have created a pull request.** This gives the 508 or quality assurance person time to review your code before it is merged into the `master` branch. Once code is merged into `master` it will be deployed to Staging. Reviewing and correcting issues becomes more difficult at this point.
+3. **Issue tickets should be tested when you have created a pull request.** This gives the 508, or quality assurance, person time to review your code before it is merged into the `master` branch. Once code is merged into `master` it will be deployed to Staging. Reviewing and correcting issues becomes more difficult at this point.
 4. Text inside `<-- comment -->` blocks will not appear in your issue ticket. These comments offer guidance on what information you should provide for each section.
 
 <!--
@@ -43,7 +43,7 @@ Enter an issue title using the format [ERROR TYPE]: Brief description of the pro
 
 <!--
 * Operating System, including `<VERSION>` or "latest"
-* Browser,including `<VERSION>` or "latest"
+* Browser, including `<VERSION>` or "latest"
 * Screenreading device, if applicable
 * Server destination (localhost, Docker container, staging, production)
 -->

--- a/.github/ISSUE_TEMPLATE/508-issue.md
+++ b/.github/ISSUE_TEMPLATE/508-issue.md
@@ -1,20 +1,20 @@
 ---
 name: 508 Accessibility Issue
 about: Describe an issue related to Section 508 Accessibility Standards
-title: ''
+title: ""
 labels: 508/Accessibility
-assignees: ''
-
+assignees: ""
 ---
 
 ## Instructions
 
 1. Click or press the gear icon next to the "Labels" heading on the right. Search for your team in the labels list. If your team is not listed in the Labels menu, please leave a comment after you have created this issue. The Product Support team will create a new label for your team.
 2. If this issue is being opened by a VFS team, please add the `triage-incident` and `product support` labels.
-3. Text inside `<-- comment -->` blocks will not appear in your issue ticket. These comments offer guidance on what information you should provide for each section.
+3. **Issue tickets should be tested when you have created a pull request.** This gives the 508 or quality assurance person time to review your code before it is merged into the `master` branch. Once code is merged into `master` it will be deployed to Staging. Reviewing and correcting issues becomes more difficult at this point.
+4. Text inside `<-- comment -->` blocks will not appear in your issue ticket. These comments offer guidance on what information you should provide for each section.
 
-<!--Issue Title
-[ERROR TYPE]: Brief description of the problem
+<!--
+Enter an issue title using the format [ERROR TYPE]: Brief description of the problem
 ---
 [SCREENREADER]: Edit buttons need aria-label for context
 [KEYBOARD]: Add another user link will not receive keyboard focus
@@ -34,15 +34,6 @@ assignees: ''
 -->
 
 **VFS Point of Contact:** _First name only. Delete if not applicable._
-
-## When Should the Issue be Reviewed by a 508 Specialist?
-
-Issue tickets that should be tested in pull request will include the label
-`508-test-pr`. This means the 508 specalist has asked to review your feature
-branch as part of the code review, before it is merged into `master` and
-deployed to Staging.
-
-`Staging server` or `Pull request`
 
 ## Acceptance Criteria
 

--- a/platform/accessibility/508-request-prelaunch-review.md
+++ b/platform/accessibility/508-request-prelaunch-review.md
@@ -25,9 +25,10 @@
 3. _If problems are found,_ DSVA will create a new Github issue for each Accesibility/508 problem found.
    - The new Github issues will be assigned to the person who requested the review in Step #3.
    1. Each issue will describe the specific changes required to make the code Accessible/508 compliant - what the problem is, where the problem occurs, how to fix it, and the issue severity.
-   2. **Your team is expected to make all the changes prior to launch.** When your team has completed the changes, update each Github issue with the following comment
-      - `Changes completed in this code [link to the working code on staging]`
-   3. Close all the issues.
+   2. **Your team is expected to make all changes prior to launch.** When your team has completed the changes, update each Github issue with the following comment:
+      - For issues that can be reviewed in Staging: `@<who opened the issue>` Changes completed in this code `[link to staging]`.
+      - For issues that should be reviewed in a pull request: `@<who opened the issue>` Changes completed in this code `[link to your pull request]`
+   3. The person who opened the issue will review your pull request or code. They will let you know if any changes are required. 
    4. After you've closed all the issues, this pre-launch activity is considered complete.
    5. DSVA will then do [Step #3](#step-3-va-508-office-review).
 4. _If no problems are found,_

--- a/platform/accessibility/508-request-prelaunch-review.md
+++ b/platform/accessibility/508-request-prelaunch-review.md
@@ -22,19 +22,18 @@
 1. File a [request for a pre-launch 508 review](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=1Copenut&labels=508%2FAccessibility%2C+launch+review%2C+product+support&template=508-review-template.md&title=Request+accessibility%2F508+review+for+ENTER_PRODUCT_NAME). This will generate an issue and then a Zenhub epic will manually be created.
 2. **Within 5 business days**, DSVA will review your code and let you know the results of your review.
    - If you don't hear anything after 5 business days, reach out to your DSVA contact.
-3. _If problems are found,_ DSVA will create a new Github issue for each Accesibility/508 problem found.
-   - The new Github issues will be assigned to the person who requested the review in Step #3.
+3. _If problems are found,_ DSVA will create a new Zenhub issue for each Accesibility/508 problem found.
+   - The new Zenhub issues will be assigned to the person who requested the review in Step #3.
    1. Each issue will describe the specific changes required to make the code Accessible/508 compliant - what the problem is, where the problem occurs, how to fix it, and the issue severity.
-   2. **Your team is expected to make all changes prior to launch.** When your team has completed the changes, update each Github issue with the following comment:
-      - For issues that can be reviewed in Staging: `@<who opened the issue>` Changes completed in this code `[link to staging]`.
-      - For issues that should be reviewed in a pull request: `@<who opened the issue>` Changes completed in this code `[link to your pull request]`
-   3. The person who opened the issue will review your pull request or code. They will let you know if any changes are required. 
+   2. **Your team is expected to make all changes prior to launch.** When your team has issued a pull reqeust for each change, update the Zenhub issue with the following comment:
+      - `@<who opened the issue>` Changes completed in this code `[link to your pull request]`
+   3. The person who opened the issue will review your pull request or code. They will let you know if any changes are required.
    4. After you've closed all the issues, this pre-launch activity is considered complete.
    5. DSVA will then do [Step #3](#step-3-va-508-office-review).
 4. _If no problems are found,_
-   1. DSVA will update the original Github issue with this comment: `No issues found`
+   1. DSVA will update the original Zenhub issue with this comment: `No issues found`
    2. DSVA will close the issue.
-   3. Github will send the issue creator a notification. This is your team's signal that this pre-launch activity is complete.
+   3. Zenhub will send the issue creator a notification. This is your team's signal that this pre-launch activity is complete.
    - DSVA will then do [Step #3](#step-3-va-508-office-review).
 
 ## Step 3: VA 508 Office Review
@@ -43,17 +42,17 @@
 
 Because all Veteran-facing Services Platform code goes through rigorous manual and automated 508 testing, the VA 508 office has approved DSVA to launch code before the VA 508 office reviews it.
 
-1. Once a month, DSVA meets with the VA 508 office. At the meeting, DSVA presents all code submitted in the preceding 30 days.
+1. Once a month, DSVA and the product support team meet with the VA 508 office. At the meeting, DSVA presents all code submitted in the preceding 30 days.
 
-2. After the meeting, the VA 508 Office reviews the code and provides feedback/instructions to DSVA.
+2. After the meeting, the VA 508 Office reviews the code and provides feedback/instructions to DSVA and product support.
 
-3. The VA 508 office may request additional changes to your code. If this happens, DSVA will create a new Github issue for each Accesibility/508 problem found by the VA 508 Office.
+3. The VA 508 office may request additional changes to your code. If this happens, DSVA will create a new Zenhub issue for each Accesibility/508 problem found by the VA 508 Office.
 
    - The issues will be assigned to the person who requested the [initial review in Step #2](#step-2-request-an-accessibility508-review).
    - Each issue will describe the specific changes required to make the code Accessible/508 compliant - what the problem is, where the problem occurs, how to fix it, and the issue severity.
 
 4. **Your team is expected to make all the changes as quickly as possible, for example, in the next sprint following receipt of the requested changes.**
-   - When you've completed the changes, update each Github issue with the following comment
+   - When you've completed the changes, update each Zenhub issue with the following comment
      - `Changes completed in this code [link to the working code on staging]`
    - **DO NOT** close the issue.
    - DSVA will confirm the changes have been made, close the issue, and notify the VA 508 Office that the problem has been resolved.


### PR DESCRIPTION
Updating the process and ownership chain for 508 issue tickets to clarify who should close issues, and when they should be reviewed.