### PR TITLE
rename #vetsgov-sentry-alerts slack channel to #vfs-sentry-alerts

### DIFF
--- a/teams/vsp/teams/triage/On-point Rotation.md
+++ b/teams/vsp/teams/triage/On-point Rotation.md
@@ -5,10 +5,10 @@ Not every bug can be fixed, but every bug _can_ be triaged.
 
 Triaging all the issues that come in is a team effort, but a little leadership goes a long way. Each week, a Triage team engineer will take point on triaging the issues from our intake sources.
 
-We'll give this process a test run by triaging Sentry alerts in the `#vetsgov-sentry-alerts` Slack channel.
+We'll give this process a test run by triaging Sentry alerts in the `#vfs-sentry-alerts` Slack channel.
 
 ## Responsibilities
-When we get an alert in the `#vetsgov-sentry-alerts` Slack channel, the on-point engineer will triage the issue by doing any of the following:
+When we get an alert in the `#vfs-sentry-alerts` Slack channel, the on-point engineer will triage the issue by doing any of the following:
 
 - Tweak the alert rule
 - Make the code fix


### PR DESCRIPTION
Renames depreciated channel name of #vetsgov-sentry-alerts to #vfs-sentry-alerts. No other occurrences of the prior slack channel name exist in the repo. 