### PR TITLE
Updated ROE to new global reporting incident

### DIFF
--- a/.github/ISSUE_TEMPLATE/triage-incident-template.md
+++ b/.github/ISSUE_TEMPLATE/triage-incident-template.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-### Please read the [Triage Rules of Engagement](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/triage/Rules%20of%20Engagement%20with%20Triage.md) for instructions on what types of issue should be submitted using this template.
+### Please read the [Reporting an incident to the Platform](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/policies-work-norms/reporting-an-incident-to-the-platform) for instructions on what types of issue should be submitted using this template.
 
 ### Status
 


### PR DESCRIPTION
Moving the deprecated "Triage ROE" document that was in the triage VFS folder and linking the new global "how to report an incident to the platform" document that now resides in the work norms folder in the product folder.