### PR TITLE
add grafana link to triage README TOC

### DIFF
--- a/platform/triage/README.md
+++ b/platform/triage/README.md
@@ -19,4 +19,5 @@ The following is a set of resources to help you work with the VSP Triage team. S
 - [Learn how Sentry is used within the VSP](sentry-usage-overview.md)
 - [Learn how to use Sentry tags](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/sentry-tagging-standards.md)
 - [Learn about the various upstream services](upstream-services.md)
+- [Add a grafana dashboard](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Practice%20Areas/Engineering/Infrastructure/Grafana%20Overview.pdf)
 


### PR DESCRIPTION
This PR adds a link to the Table of Contents for information related to creating new grafana graphs