### PR TITLE
Self-close tags

### DIFF
--- a/platform/working-with-vsp/README.md
+++ b/platform/working-with-vsp/README.md
@@ -7,7 +7,7 @@
 * See [Questions to be answered](questions.md)
 * See [In-progess POVs (not yet decided)](in-progress-povs)
 
-<hr>
+<hr/>
 
 ## Other Decisions
 

--- a/platform/working-with-vsp/documentation-general.md
+++ b/platform/working-with-vsp/documentation-general.md
@@ -1,6 +1,6 @@
 # POV - Documentation in general
 
-<hr>
+<hr/>
 
 * [Problem/Solution](#problemsolution)
 * [Current situation](#current-situation---see-image)
@@ -9,7 +9,7 @@
 * [Revised process for filing issues](#revised-process-for-filing-issues)
 * [Rename/Consolidate repos](#renameconsolidate-repos)
 
-<hr>
+<hr/>
 
 ## Problem/Solution
 
@@ -48,7 +48,7 @@
 * When we move content from repo to repo (or delete it), we want to retain Github history.
 
 
-<hr>
+<hr/>
 
 ## Current situation - [see image](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/documentation-current2.png)
 
@@ -71,7 +71,7 @@
 * **Current READ access to repo:** Yes
   * Process was changed so we don't need external teams to access this repo anymore. ~~They only have access to this because this is where Liz files an issue for SSH keys to be added. The issue then pings the developer when Brian has added their key in the devops repo.~~
 
-<hr>
+<hr/>
 
 ### vets.gov-team repo
 
@@ -87,7 +87,7 @@
     * External teams need access to "Products" folder to learn/share with other teams working on the Veteran Tools Platform.
     * *Note:* External teams have WRITE access in order to create and upload files to document their work for historical and compliance reasons.
 
-<hr>
+<hr/>
 
 ### platform-docs repo
 
@@ -105,7 +105,7 @@
     * Technically they have READ access to the repo content, but they're not doing that (tmk).
     * External teams are using the public-facing website to view content.
 
-<hr>
+<hr/>
 
 ### Development-related repos
 
@@ -123,7 +123,7 @@
 * **Current READ access to repo:** Yes
     * External developers have WRITE access to do their work
 
-<hr>
+<hr/>
 
 ### vets-api-mockdata repo
 
@@ -138,7 +138,7 @@
 * **Current READ access to repo:** Yes
     * External teams have READ access to order to use the mockdata
 
-<hr>
+<hr/>
 
 ### devops repo
 
@@ -153,7 +153,7 @@
 * **Current READ access to repo:** Yes
     * External teams have READ access in order to get the SSH config file they need in order to set up their local environment
 
-<hr>
+<hr/>
 
 ### vets-ato repo
 
@@ -170,8 +170,8 @@
     * External teams have READ access to view the current ATO documents
 
 
-<hr>
-<hr>
+<hr/>
+<hr/>
 
 ## Proposal - [see image](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/documentation-proposed2.png)
 
@@ -191,7 +191,7 @@
   * Include only the the code supporting the site, the developer process documentation needed to support the site, and all "work practices" documentation surrounding work on the VA APIs (exclude vets.gov APIs, for now)
   * Move (or remove) all other content
 
-<hr>
+<hr/>
 
 ### vets.gov team repo
 
@@ -207,7 +207,7 @@
   * Give external teams WRITE access to this repo so they can store their own documents.
     * WRITE access is whitelisted, so people not on the whitelist have to submit a PR in order to make changes.
 
-<hr>
+<hr/>
 
 ### platform-docs repo
 
@@ -220,7 +220,7 @@
   * The repo and the site goes away. Instead content will be located in the new "work practices" location and referenced from the Handbook (or from other documentation).
 
 
-<hr>
+<hr/>
 
 ### Development-related repos
 
@@ -233,7 +233,7 @@
 * **Proposed:**
   * Repos continue to work as they do today.
 
-<hr>
+<hr/>
 
 ### vets-api-mockdata repo
 
@@ -248,7 +248,7 @@
   * Repo (and its access) continues to work as it does today.
 
 
-<hr>
+<hr/>
 
 ### devops repo
 
@@ -263,7 +263,7 @@
   * In particular, move the ssh config file into the existing private "Work Practices folder" in vets.gov-team repo. External teams need access to this file. They already have access to vets.gov-team repo, so it's easier to move the ssh config file here than to manage multiple team's access to the devops repo. Devops team is responsible for maintaining the ssh config file.
 
 
-<hr>
+<hr/>
 
 ### vets-ato repo
 
@@ -278,7 +278,7 @@
   * We will find a different method for external developers to request an ATO review.
 
 
-<hr>
+<hr/>
 
 ### Location for "work practices" documentation
 
@@ -305,7 +305,7 @@
     * Subfolders are not supported, but can be mimicked with a sidebar.
     * Given the amount of "work practices" docs, this isn't a good solution - massive list of pages and massive sidebar
 
-<hr>
+<hr/>
 
 ## Impact of proposal
 

--- a/platform/working-with-vsp/external-team-access.md
+++ b/platform/working-with-vsp/external-team-access.md
@@ -6,7 +6,7 @@ This document explains the rationale behind the access we've granted (or not gra
 * Includes permission level
 * Includes whether access+permission applies to the Github Parent Team or Github Subteam
 
-<hr>
+<hr/>
 
 * [Slack](#slack)
 * [Github repos - Current](#github-repos---current)
@@ -14,7 +14,7 @@ This document explains the rationale behind the access we've granted (or not gra
 * [GovCloud](#govcloud)
 * [Github repos - Previous](#github-repos---previous---jul-aug-2018)
 
-<hr>
+<hr/>
 
 
 ## Slack
@@ -28,7 +28,7 @@ This document explains the rationale behind the access we've granted (or not gra
 
 * **<i>#devops</i> channel - NO access**. DSVA/AdHoc want this channel to remain internal only.
 
-<hr>
+<hr/>
 
 ## Github repos - Current 
 
@@ -55,7 +55,7 @@ This document explains the rationale behind the access we've granted (or not gra
 * **vets-contrib - NO access**
   * Process to get SSH keys added to the authorized list has been revised so external teams do not need access to this repo.
   
-<hr>
+<hr/>
 
 ### Github Repos - Future
 
@@ -80,7 +80,7 @@ This document explains the rationale behind the access we've granted (or not gra
 * **vets-contrib - NO access** - Subteam
   * Process to get SSH keys added to the authorized list has been revised so external teams do not need access to this repo.
 
-<hr>
+<hr/>
 
 ### Other Github access
 
@@ -92,7 +92,7 @@ Access to additional Github repos can be considered on a case-by-case basis by t
 
 * Limit to **READ access** unless external team can demonstrate they need unsupervised ability to add/edit information in the repo.
 
-<hr>
+<hr/>
 
 ## GovCloud
 
@@ -127,7 +127,7 @@ GovCloud does handle logging, which could be useful for external contractors. Ho
 External teams who need to provision a new service need to do so through the DSVA Product Manager, who will talk with the appropriate DSVA/AdHoc people to make it happen.
 
 
-<hr>
+<hr/>
 
 ## Github repos - Previous - Jul-Aug 2018
 

--- a/platform/working-with-vsp/faqs.md
+++ b/platform/working-with-vsp/faqs.md
@@ -1,12 +1,12 @@
 # Frequently Asked Questions
 
-<hr>
+<hr/>
 
 * [Github FAQs](#github)
 * [Internal Developer Tools FAQs](#internal-developer-tools)
 * [Recruiting for Research FAQs](#recruiting-for-research)
 
-<hr>
+<hr/>
 
 ## Github
 

--- a/platform/working-with-vsp/onboarding/repo-guidelines.md
+++ b/platform/working-with-vsp/onboarding/repo-guidelines.md
@@ -20,19 +20,19 @@ Determine where your file should go and how to name them...
 ### About the /platform, /products and /teams folders
 There are 3 areas of the va.gov-teams repo that you will be working with - `platform`, `products` and `teams`.  
 
-**/platform** <br>
+**/platform** <br/>
 This area includes all platform-level products and services that support va.gov product development. 
 - All documentation and artifacts created by the platform teams (VSP teams) that support and help teams working on the platform and va.gov.
 - Examples of content you will find in this area include best practices, how to request reviews with different practice areas, onboarding materials for all VFS teams, and documentation on tools and services provided by VSP. 
 - The primary contributor to this area is the VSP team. 
 
-**/product**<br>
+**/product**<br/>
 This area includes documentation on all va.gov user-facing products.  This includes any tool, content page or piece of functionality that a va.gov visitor interacts with directly. 
 - All documentation and artifacts created as part of the product development process should be stored here. 
 - Examples of content/files you will find in this area include product outlines, design comps, content decks, discovery docs, user research files, etc. 
 - The primary contributor to this area are the VFS teams. For historical and tracking purposes, your team must store its project documents in your assigned /products folder.
 
-**/teams**<br>
+**/teams**<br/>
 This area includes information on all teams working on the platform.  
 - Teams can utilize this space to manage their teams and workflow.
 - Examples of content/files for this area include team charters, org charts, project planning information, workflow documents, etc. 
@@ -55,7 +55,7 @@ We encourage you to browse content in other /products and /teams folders to see 
 ## <a id="naming-guidelines"></a>Guidelines for Creating and Naming Folders and Files
 
 ## <a id="naming-conventions"></a>Folder and File Naming Conventions
-When  naming a new folder or markdown file in this repo, please adhere to the guidelines below.  This helps to keep our repo file URLs short and readable as well as ensure the repo can be cloned easily without errors. <br>
+When  naming a new folder or markdown file in this repo, please adhere to the guidelines below.  This helps to keep our repo file URLs short and readable as well as ensure the repo can be cloned easily without errors. <br/>
 
 *While these are specific to GitHub folders and markdown files, these guidelines are good rules to follow with any file uploaded to the repo as well.*
 

--- a/platform/working-with-vsp/policies-work-norms/README.md
+++ b/platform/working-with-vsp/policies-work-norms/README.md
@@ -1,6 +1,6 @@
 # Norms for using Github
 
-<hr>
+<hr/>
 
 * [Background](#background)
 * [Tips for creating a Github account](#tips-for-creating-a-github-account)
@@ -10,7 +10,7 @@
   * [Managing agile workflow](#managing-agile-workflow)
 * [Get help with Github](#get-help-with-github)
 
-<hr>
+<hr/>
 
 ## Background
 

--- a/platform/working-with-vsp/policies-work-norms/github-primer.md
+++ b/platform/working-with-vsp/policies-work-norms/github-primer.md
@@ -1,6 +1,6 @@
 # Github Primer
 
-<hr>
+<hr/>
 
 * [What is Github?](#what-is-github)
 * [Github web interface tour](#github-web-interface-tour)
@@ -14,7 +14,7 @@
   * [Delete a folder](#delete-a-folder)
   * [Create a pull request](#create-a-pull-request)
 
-<hr>
+<hr/>
 
 ## What is Github?
 

--- a/platform/working-with-vsp/policies-work-norms/how-to-write-your-slos.md
+++ b/platform/working-with-vsp/policies-work-norms/how-to-write-your-slos.md
@@ -132,8 +132,6 @@ Each row should have an availability target, and one or more latency targets. In
 
 <li>[percentile] @ [target latency]
 
-<li>[percentile] @ [target latency]
-
 [If relevant, notes on how this latency is measured]
 </li>
 </ul>

--- a/platform/working-with-vsp/questions.md
+++ b/platform/working-with-vsp/questions.md
@@ -1,6 +1,6 @@
 # Managing External Contractors - Strategic Challenges and Questions
 
-<hr>
+<hr/>
 
 ## To Dos
 - [ ] Melissa C will see if there's anything else we can automate wrt code reviews - will reach out to experts across Ad Hoc to collaborate
@@ -14,7 +14,7 @@
 - [ ] James and Liz: to talk through some of the technical parts of the deploy puzzle, so Liz can write it up
 
 
-<hr>
+<hr/>
 
 ## How do we improve code isolation, so it's clear who's responsible for what features?
 


### PR DESCRIPTION
The Gatsby documentation site pulls down the content from the `platform/working-with-vsp` dir (https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/7b94d9d0c97d21df2526f9566bc43e84e12e618b/packages/documentation/gatsby-config.js#L14-L20) and processes the markdown with the `gatsby-mdx` plugin. It throws multiple errors due to unclosed tags in the source Markdown. This PR closes those unclosed tags.