### PR TITLE
Updates release freeze schedule for 2020

### DIFF
--- a/platform/working-with-vsp/policies-work-norms/deployment-policy.md
+++ b/platform/working-with-vsp/policies-work-norms/deployment-policy.md
@@ -17,6 +17,9 @@ During holiday release freezes:
 * Automated deploys will not occur
 * All code deploys require approval via the "Requesting out-of-band-deploys" process below
 * Content-only deploys may continue without explicit approval, but need to be manually triggered
+* Limited support will be available from VSP team.
+
+*There may be a change in this policy as VA dictates.*
 
 The holiday release freeze is in effect during the following dates:
 

--- a/platform/working-with-vsp/policies-work-norms/deployment-policy.md
+++ b/platform/working-with-vsp/policies-work-norms/deployment-policy.md
@@ -12,7 +12,13 @@ If there are days or periods of time when many people will be out of the office 
 
 ### Holiday release freeze schedule
 
-Automated deploys will not occur on the following days, due to holidays:
+During holiday release freezes:
+
+* Automated deploys will not occur
+* All code deploys require approval via the "Requesting out-of-band-deploys" process below
+* Content-only deploys may continue without explicit approval, but need to be manually triggered
+
+The holiday release freeze is in effect during the following dates:
 
 #### 2020
 

--- a/platform/working-with-vsp/policies-work-norms/deployment-policy.md
+++ b/platform/working-with-vsp/policies-work-norms/deployment-policy.md
@@ -1,4 +1,4 @@
-*Last updated 2020-01-17*
+*Last updated 2020-01-27*
 
 # Automated Deploys
 
@@ -14,16 +14,14 @@ If there are days or periods of time when many people will be out of the office 
 
 Automated deploys will not occur on the following days, due to holidays:
 
-#### 2019
-
-* 9/2 - **Labor Day**
-* 11/11 - **Veterans Day**
-* 11/27 - 11/29 - **Thanksgiving**
-* 12/23 - 1/3/2020 - **Winter holiday freeze** (Note: *two weeks*)
-
 #### 2020
 
-*Holiday release freeze schedule update coming soon*
+* 05/25 - **Memorial Day**
+* 07/03 - **Independence Day** (observed)
+* 09/07 - **Labor Day**
+* 11/11 - **Veteran's Day**
+* 11/25 - 11/27 - **Thanksgiving**
+* 12/23 - 1/1/2020 - **Winter holiday freeze** (note: *eight business days*)
 
 # Requesting out-of-band deploys
 


### PR DESCRIPTION
The update is basically:
* Oddball's holiday schedule (proper subset of the VA's holiday schedule, proper superset of Ad Hoc's holiday schedule), since that leaves us less than half staffed on those days
* extra days around Thanksgiving / Christmas. Slightly shorter Christmas deploy break this year.