### PR TITLE
Design Doc/RFC - Multi-repo Documentation Search

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,17 @@ version: 2
 jobs:
   scrape:
     docker:
+      - image: ubuntu:14.04
+
+      - image: stedolan/jq
+
       - image: algolia/docsearch-scraper
+
   working_directory: ~/va.gov-team
+
   steps:
     - checkout
+
     - run:
       name: Scrape public documentation sources
       command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: ubuntu:14.04
 
+      # install `jq` because it's required by `algolia/docsearch-scraper`
       - image: stedolan/jq
 
       - image: algolia/docsearch-scraper
@@ -15,6 +16,7 @@ jobs:
 
     - run:
       name: Scrape public documentation sources
+      # use ALGOLIA_API_KEY and ALGOLIA_APP_ID env variables that were set in CircleCI UI
       command: |
         docker run -it -e "API_KEY=$ALGOLIA_API_KEY" -e "APPLICATION_ID=$ALGOLIA_APP_ID" -e "CONFIG=$(cat docs/docsearch-scraper-config.json | jq -r tostring)" algolia/docsearch-scraper
 
@@ -23,7 +25,8 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          # every night around midnight in eastern time
+          cron: "0 5 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,21 @@
+version: 2
+jobs:
+  scrape:
+    docker:
+      - image: algolia/docsearch-scraper
+  working_directory: ~/va.gov-team
+  steps:
+    - checkout
+
+workflows:
+  version: 2
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - scrape

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
   working_directory: ~/va.gov-team
   steps:
     - checkout
+    - run:
+      name: Scrape public documentation sources
+      command: |
+        docker run -it -e "API_KEY=$ALGOLIA_API_KEY" -e "APPLICATION_ID=$ALGOLIA_APP_ID" -e "CONFIG=$(cat docs/docsearch-scraper-config.json | jq -r tostring)" algolia/docsearch-scraper
 
 workflows:
   version: 2

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Public - This is your unique application identifier. It's used to identify you when using Algolia's API.
+# This is also sent to the client to be used by the DocSearch JS snippet.
+APPLICATION_ID=APPLICATION_ID
+
+# Private - This is the ADMIN API key. Please keep it secret and use it ONLY from your backend: 
+# This key is used to create, update and DELETE your indices. You can also use it to manage your API keys.
+API_KEY=API_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 scripts/node_modules
 scripts/repo-replace-url.log.csv
 scripts/repo-deprecation.log.csv
+.env

--- a/docs/docsearch-scraper-config.json
+++ b/docs/docsearch-scraper-config.json
@@ -5,25 +5,19 @@
       "url": "https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/",
       "selectors_key": "folder",
       "page_rank": 0,
-      "tags": [
-        "folder"
-      ]
+      "tags": ["folder"]
     },
     {
       "url": "https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/.+$",
       "selectors_key": "folder",
       "page_rank": 0,
-      "tags": [
-        "folder"
-      ]
+      "tags": ["folder"]
     },
     {
       "url": "https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.+\\.md$",
       "selectors_key": "file",
       "page_rank": 5,
-      "tags": [
-        "file"
-      ]
+      "tags": ["file"]
     }
   ],
   "selectors": {
@@ -40,14 +34,9 @@
       "text": "article p, article li"
     }
   },
-  "selectors_exclude": [
-    ".up-tree"
-  ],
+  "selectors_exclude": [".up-tree"],
   "custom_settings": {
-    "attributesForFaceting": [
-      "language",
-      "version"
-    ]
+    "attributesForFaceting": ["language", "version"]
   },
   "stop_urls": [
     "https://raw.githubusercontent.com",

--- a/docs/docsearch-scraper-config.json
+++ b/docs/docsearch-scraper-config.json
@@ -1,0 +1,63 @@
+{
+  "index_name": "dev_docs",
+  "start_urls": [
+    {
+      "url": "https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/",
+      "selectors_key": "folder",
+      "page_rank": 0,
+      "tags": [
+        "folder"
+      ]
+    },
+    {
+      "url": "https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/.+$",
+      "selectors_key": "folder",
+      "page_rank": 0,
+      "tags": [
+        "folder"
+      ]
+    },
+    {
+      "url": "https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.+\\.md$",
+      "selectors_key": "file",
+      "page_rank": 5,
+      "tags": [
+        "file"
+      ]
+    }
+  ],
+  "selectors": {
+    "folder": {
+      "text": ".js-navigation-item td.content"
+    },
+    "file": {
+      "lvl0": "article h1",
+      "lvl1": "article h2",
+      "lvl2": "article h3",
+      "lvl3": "article h4",
+      "lvl4": "article h5",
+      "lvl5": "article h6",
+      "text": "article p, article li"
+    }
+  },
+  "selectors_exclude": [
+    ".up-tree"
+  ],
+  "custom_settings": {
+    "attributesForFaceting": [
+      "language",
+      "version"
+    ]
+  },
+  "stop_urls": [
+    "https://raw.githubusercontent.com",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/commits/*",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/blame",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/pulls",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/pull/*",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/issues/*",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/branches",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/graphs",
+    "https://github.com/department-of-veterans-affairs/va.gov-team/find"
+  ]
+}

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -72,6 +72,16 @@ Subject to review, we will run the crawler in a scheduled job once every 24 hour
 
 It's possible that running the scraper once per day would consume a significant number of operations.
 
+#### Public repos
+
+We will crawl and scrape the following public documentation sources:
+
+- [`va.gov-team` repo](https://github.com/department-of-veterans-affairs/va.gov-team)
+- [`veteran-facing-services-tools` repo](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/)
+- [`vets-contrib` repo](https://github.com/department-of-veterans-affairs/vets-contrib/)
+- [design.va.gov](https://design.va.gov/)
+- [developer.va.gov](https://developer.va.gov/)
+
 #### Private repos
 
 ---
@@ -200,11 +210,11 @@ The recommendation from the discovery sprint is to build a custom documentation 
 
 ### Revision History
 
-| Date         | Revisions Made                                                              | Author        | Reviewed By |
-| ------------ | --------------------------------------------------------------------------- | ------------- | ----------- |
-| Jan 27, 2020 | Initial Draft                                                               | Bill Fienberg |             |
-| Feb 10, 2020 | Update Detailed Design                                                      | Bill Fienberg |             |
-| Feb 11, 2020 | Answer open questions                                                       | Bill Fienberg |             |
-| Feb 12, 2020 | Expand on where/when to run crawler                                         | Bill Fienberg |             |
-| Feb 13, 2020 | Add Usage Limits section, and update Code Location & Work Estimate sections | Bill Fienberg |             |
-| Feb 17, 2020 | Add open question about crawler diffing capabilities                        | Bill Fienberg |             |
+| Date         | Revisions Made                                                                | Author        | Reviewed By |
+| ------------ | ----------------------------------------------------------------------------- | ------------- | ----------- |
+| Jan 27, 2020 | Initial Draft                                                                 | Bill Fienberg |             |
+| Feb 10, 2020 | Update Detailed Design                                                        | Bill Fienberg |             |
+| Feb 11, 2020 | Answer open questions                                                         | Bill Fienberg |             |
+| Feb 12, 2020 | Expand on where/when to run crawler                                           | Bill Fienberg |             |
+| Feb 13, 2020 | Add Usage Limits section, and update Code Location & Work Estimate sections   | Bill Fienberg |             |
+| Feb 17, 2020 | Add list of public docs, and open question about crawler diffing capabilities | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -26,7 +26,7 @@ We are adding a public landing page that will contain a search input where users
 
 ### Detailed Design
 
-For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/), [Algolia's Search API](https://www.algolia.com/products/search/), and [Algolia's scraper](https://github.com/algolia/docsearch-scraper).
+For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/). This will use [Algolia's Search API](https://www.algolia.com/products/search/) to query Algolia's Hosted database (link needed), which will be populated by [Algolia's scraper](https://github.com/algolia/docsearch-scraper) using a configuration we supply (link needed).
 
 In general, this kind of system requires the following components:
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -84,7 +84,7 @@ The DocSearch JS snippet doesn't seem to use any debouncing. I noted the number 
 
 Since each crawl wipes and repopulates the index, that means each crawl will produce a number of operations approximately equal to the previous number of records. The number of operations may be larger due to new lines/files in the repos, and it may be smaller due to deleted lines/files in the repo.
 
-If the `va.gov-team` repo currently produces ~150K records, then the crawler `va.gov-team` would produce ~150K operations every time it runs. If the `va.gov-team` repo is crawler once per day, then that would produce ~150K operations every day. At that rate, we'd have approximately ~4.5M operations every month from crawling the `va.gov-team` repo alone.
+If the `va.gov-team` repo currently produces ~150K records, then crawling `va.gov-team` would produce ~150K operations every time it runs. If the `va.gov-team` repo is crawler once per day, then that would produce ~150K operations every day. At that rate, we'd have approximately ~4.5M operations every month from crawling the `va.gov-team` repo alone.
 
 ##### Recommended Plan for Our Usage
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -50,15 +50,15 @@ By leveraging the following existing technologies, we should only need to add th
 
 ##### The Community Plan
 
-The free tier, the Community plan, includes up to 10K records and 50K operations (read/write/edit/delete). After hitting the limit, we'd have to upgrade to a paid plan.
+The free tier, the Community plan, includes up to 10K records and 50K operations (read/write/edit/delete). If we exceed the limits of the free tier, we'd have to upgrade to a paid tier.
 
 ##### The Starter Plan
 
-The middle tier, the Starter plan, includes up to 50K records and 250k operations. It costs an extra $10/month to get 100K additional operations, and it costs an extra $10/month to get an extra 20K records.
+The middle tier, the Starter plan, includes up to 50K records and 250k operations. If we exceed the limits of the Starter plan, it would cost an extra $10/month for every additional 100K operations, and an extra $10/month for every additional 20K records.
 
 ##### The Pro Plan
 
-And the upper tier, the Pro plan, includes up to 1M records and 5M operations. It costs an extra $5/month to get 100K additional operations, and it costs an extra $5/month to get an extra 20K records.
+The upper tier, the Pro plan, includes up to 1M records and 5M operations. If we exceed the limits of the Pro plan, it would cost an extra $5/month foe every 100K additional operations, and an extra $5/month for every additional 20K records.
 
 ---
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -6,7 +6,7 @@
 
 **Status:** **Draft**
 
-**Approvers:** Andrew G., Megan K., Rian F., DevOps
+**Approvers:** Andrew G., Megan K., Rian F., VSP Ops
 
 ## Overview
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -84,6 +84,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - What is the Not-Invented-Here risk? How likely is that we're reinventing the wheel?
 - What is the inexperience risk? Have any of the team members involved ever built/deployed/maintained this type of system before?
 - It's possible that work estimates are materially inaccurate.
+- What is the documentation debt risk? At least one person interviewed during the discovery sprint said that we need a solution ASAP. Is there a risk that people are deferring documentation in the present until the custom documentation solution is shipped?
 
 ### Work Estimates
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -18,25 +18,17 @@ _The intended audience for this document is software engineers, but it should ma
 
 ### Objective
 
-We want to implement a public landing page where VFS/VSP team members can search multiple documentation source from a single entrypoint.
+We want to implement a public landing page where VFS/VSP team members can search multiple documentation sources from a single entrypoint.
 
 ### Background
 
-_The background section should contain information the reader needs to know to understand the problem being solved. This can be a combination of text and links to other documents._
-
-_Do **NOT** describe the solution here. That goes in High Level Design._
+The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, etc). There currently is not a way for VFS/VSP users to search all of the sources with a single query.
 
 ### High Level Design
 
-_A high-level description of the system. This is the most valuable section of the document and will probably receive the most attention. You should explain, at a high level, how your system will work. Don't get bogged down with details; those belong later in the document._
-
-_A diagram showing how the major components communicate is very useful and a great way to start this section. If this system is intended to be a component in a larger system, a diagram showing how it fits in to the larger system will also be appreciated by your readers._
-
-_Most diagrams will need to be updated over time as the design evolves, so please create your diagrams with a program that is easily (and freely) available and attach the diagram source to the document to make it easy for a future maintainer (who could be you) to update the diagrams along with the document._
+We are adding a public landing page that will contain a form where users can search all of our public documentation in one location.
 
 ## Specifics
-
-_Nothing goes here; all the content belongs in the subsections._
 
 ### Detailed Design
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -162,16 +162,13 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 
 ### Work Estimates
 
-1. Provision and configure data store to house records that will be returned from the Search API. - 1 week
-
-- I estimate one week because I suspect we'll either need to get approval to use Algolia's hosted API or get approval to provision a custom data store.
-
-1. Configure crawler to seed the initial data store. - 2 days
-1. Run the crawler to populate the data store. - 2 days
-1. Build a landing page that will contain a search input that submits requests to the Search API. - 2 days
-1. Deploy the landing page to a publicly available location. - 2 days
-
-- I estimate this may take longer if we need to need to coordinate with other teams.
+1. Convert `va.gov-team`'s `docs/index.md` from markdown to HTML - <1 hour
+1. Add a search input to `va.gov-team`'s `docs/index.html` - <5 minutes
+1. Add the DocSearch `<style>` and `<script>` tags to `va.gov-team`'s `docs/index.html` - <5 minutes
+1. Write the config file for the scraper - <1 day
+1. Add CircleCI to `va.gov-team` - <1 day
+1. Add a scheduled job to run the scraper once every 24 hours in `va.gov-team`'s CircleCI pipeline - <1 day
+1. Run the scraper - <1 day
 
 ### Alternatives
 
@@ -199,10 +196,10 @@ The recommendation from the discovery sprint is to build a custom documentation 
 
 ### Revision History
 
-| Date         | Revisions Made                                            | Author        | Reviewed By |
-| ------------ | --------------------------------------------------------- | ------------- | ----------- |
-| Jan 27, 2020 | Initial Draft                                             | Bill Fienberg |             |
-| Feb 10, 2020 | Update Detailed Design                                    | Bill Fienberg |             |
-| Feb 11, 2020 | Answer open questions                                     | Bill Fienberg |             |
-| Feb 12, 2020 | Expand on where/when to run crawler                       | Bill Fienberg |             |
-| Feb 13, 2020 | Add Usage Limits section and update Code Location section | Bill Fienberg |             |
+| Date         | Revisions Made                                                              | Author        | Reviewed By |
+| ------------ | --------------------------------------------------------------------------- | ------------- | ----------- |
+| Jan 27, 2020 | Initial Draft                                                               | Bill Fienberg |             |
+| Feb 10, 2020 | Update Detailed Design                                                      | Bill Fienberg |             |
+| Feb 11, 2020 | Answer open questions                                                       | Bill Fienberg |             |
+| Feb 12, 2020 | Expand on where/when to run crawler                                         | Bill Fienberg |             |
+| Feb 13, 2020 | Add Usage Limits section, and update Code Location & Work Estimate sections | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -95,8 +95,6 @@ _Features you'd like to (or will need to) add but aren't required for the curren
 
 ### Revision History
 
-_The table below should record the major changes to this document. You don't need to add an entry for typo fixes, other small changes or changes before finishing the initial draft._
-
-| Date         | Revisions Made                                                                                                                                   | Author         | Reviewed By |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ----------- |
-| Jan 19, 2016 | Initial Draft based off [Arvados's template](https://dev.arvados.org/projects/arvados/wiki/Design_Doc_Template) which is reminiscent of Google's | Albert J. Wong |
+| Date         | Revisions Made | Author        | Reviewed By |
+| ------------ | -------------- | ------------- | ----------- |
+| Jan 27, 2020 | Initial Draft  | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -136,7 +136,11 @@ We could search for the same term in both the Algolia UI and the landing page to
 
 ### Security Concerns
 
-If the search input dispatched a request directly to the Algolia API, then there'd be minimal risk of the documentation search negatively affecting other systems. If the request was proxied through our API, then we should be able to rely on any existing DOS protections.
+The [DocSearch JS snippet](https://docsearch.algolia.com/docs/dropdown) requires four pieces of data; the `appId` (public), search `apiKey` (public), `indexName`, and `inputSelector`.
+
+The `appId` and search `apiKey` are both public. The search `apiKey` only allows read access. There is a separate admin API key that the crawler will use, and that admin API key will need to be configured in an environment variable in CircleCI.
+
+We don't currently have any custom private attributes on the records in our index. If we did, we could configure [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes/), which is a list of attributes that cannot be retrieved at query time.
 
 ### Privacy Concerns
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -6,29 +6,37 @@
 
 **Status:** **Draft**
 
-**Approvers:** Andrew G., Megan K.
+**Approvers:** Andrew G., Megan K., Rian F., DevOps
 
 ## Overview
 
 ### Objective
 
-We want to implement a landing page where VFS/VSP team members can search multiple documentation sources from a single entrypoint.
+Search multiple documentation sources from a single, public entrypoint.
 
 ### Background
 
-The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, etc). There currently is not a way for VFS/VSP users to search all of the documentation sources with a single query.
+The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, handbooks, etc). There currently is not a way for VFS/VSP users to search all of the documentation sources with a single query.
 
 ### High Level Design
 
-We are adding a landing page that will contain a form where users can search multiple documentation sources in one location.
+We are adding a public landing page that will contain a form where users can search multiple, public documentation sources with a single query.
 
 ## Specifics
 
 ### Detailed Design
 
-_Designs that are too detailed for the above High Level Design section belong here. Anything that will require a day or more of work to implement should be described here._
+We are adding a public landing page (on a custom domain, if possible) that will contain a search input. That search input will query multiple, public documentation sources with one query.
 
-_This is a great place to put APIs, communication protocols, file formats, and the like._
+A successful implementation will have these components.
+
+1. Page with Input Textbox - We need a public page with a search input where users can input their search term(s).
+1. Index/Database - We need a place to store the records that will be returned to the user.
+1. Crawler/Scraper - We need a crawler to frequently scan our documentation sources for additions/deletions/modifications.
+
+We do not currently have an index of our target documentation sources. And we do not currently have infrastructure to crawl our target documentation sources to build said index.
+
+Algolia appears to be the leader when it comes to searching documentation.
 
 _It is important to include assumptions about what external systems will provide. For example if this system has a method that takes a user id as input, will your implementation assume that the user id is valid? Or if a method has a string parameter, does it assume that the parameter has been sanitized against injection attacks? Having such assumptions explicitly spelled out here before you start implementing increases the chances that misunderstandings will be caught by a reviewer before they lead to bugs or vulnerabilities. Please reference the external system's documentation to justify your assumption whenever possible (and if such documentation doesn't exist, ask the external system's author to document the behavior or at least confirm it in an email)._
 
@@ -42,6 +50,10 @@ _The path of the source code in the repository._
 
 _How you will verify the behavior of your system. Once the system is written, this section should be updated to reflect the current state of testing and future aspirations._
 
+#### Testing the search input
+
+#### Testing the crawler
+
 ### Logging
 
 By logging the term(s) that users are querying, we could theoretically identify trends to help increase the quality of our search results.
@@ -52,15 +64,19 @@ _How users can debug interactions with your system. When designing a system it's
 
 ### Caveats
 
-- Access Control: By making the documentation landing page public, it becomes difficult to impossible to allow an unauthenticated user to search documentation from private sources (like a private Github repo). One suggestion is that search results lead to public documentation sources, and we include links to private documentation in the public sources. That way, we can rely on existing access control solutions, while still providing a decent solution. One of the major downsides of that approach is auditing, adding, updating, and maintaining links to/from the public and private sources.
+- Access Control: By making the documentation landing page public, it becomes difficult, if not impossible, to allow an unauthenticated user to search documentation from private sources (like a private Github repo). One suggestion is that search results lead to public documentation sources, and we include links to private documentation in the public sources. That way, we can rely on existing access control solutions, while still providing a decent solution. One of the major downsides of that approach is auditing, adding, updating, and maintaining links to/from the public and private sources.
 
 ### Security Concerns
 
-_This section should describe possible threats (denial of service, malicious requests, etc) and what, if anything, is being done to protect against them. Be sure to list concerns for which you don't have a solution or you believe don't need a solution. Security concerns that we don't need to worry about also belong here (e.g. we don't need to worry about denial of service attacks for this system because it only receives requests from the api server which already has DOS attack protections)._
+The search input would need to be sanitized.
+
+If the search input dispatched a request directly to the Algolia API, then there'd be minimal risk of the documentation search negatively affecting other systems. If the request was proxied through our API, then we should be able to rely on any existing DOS protections.
 
 ### Privacy Concerns
 
-_This section should describe any risks related to user data, PII that are added by this new application. Think about flows of user data through systems, places data is stored and logged, places data is displayed to users. Where is user data stored or logged? How long is it stored?_
+Since the initial implementation will be an unauthenticated landing page, we will have little, if any, data about the user.
+
+While there shouldn't be any PII in our public documentation sources, it is possible it exists, and hasn't been discovered yet. Therefore, it is possible that our search results could lead public users to sources that contain PII.
 
 ### Open Questions and Risks
 
@@ -93,7 +109,7 @@ _Split the work into milestones that can be delivered, put them in the order tha
 
 ### Future Work
 
-_Features you'd like to (or will need to) add but aren't required for the current release. This is a great place to speculate on potential features and performance improvements._
+- Ability to search private documentation sources
 
 ### Revision History
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,7 +2,7 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-02-10
+**Last Updated:** 2020-02-11
 
 **Status:** **Draft**
 
@@ -26,7 +26,7 @@ We are adding a public landing page that will contain a search input where users
 
 ### Detailed Design
 
-For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/), [Algolia's Search API](https://www.algolia.com/products/search/), and [Algolia's scraper](https://github.com/algolia/docsearch-scraper). 
+For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/), [Algolia's Search API](https://www.algolia.com/products/search/), and [Algolia's scraper](https://github.com/algolia/docsearch-scraper).
 
 In general, this kind of system requires the following components:
 
@@ -36,13 +36,21 @@ In general, this kind of system requires the following components:
 - Crawler/Scraper - We need a crawler to scan our documentation sources and push data to our index.
 - Pipeline - We need a way to routinely run the crawler
 
-Each one of the above components could be a separate buy-or-build decision. 
+Each one of the above components could be a separate buy-or-build decision.
 
-By leveraging the following existing technologies, we should only need to add the search input to the landing page, configure the scraper, and configure when to run the scraper. 
+By leveraging the following existing technologies, we should only need to add the search input to the landing page, configure the scraper, and configure when to run the scraper.
 
-- Algolia's Search API product will satisfy the index and API components. 
-- Algolia's open source JavaScript snippet will display search results to the user. 
-- Algolia's open source scraper will crawl and scrape our public documentation sources to push records into our index. 
+- Algolia's Search API product will satisfy the index and API components.
+- Algolia's open source JavaScript snippet will display search results to the user.
+- Algolia's open source scraper will crawl and scrape our public documentation sources to push records into our index.
+
+#### Where/when to run the scraper
+
+For the MVP, we will run the crawler in a scheduled job once every 24 hours in Circle CI.
+
+#### Private repos
+
+---
 
 ### Code Location
 
@@ -110,19 +118,19 @@ If the search input dispatched a request directly to the Algolia API, then there
 
 While there shouldn't be any PII in our public documentation sources, it is possible it exists, and hasn't been discovered yet. Therefore, it is possible that our search results could lead public users to sources that contain PII. If PII is discovered in a repo, we have a [checklist](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/removing-sensitive-data-from-a-repository.md#checklist-for-removing-pii-in-md-file-from-a-documentation-repo) for how to remove it.
 
+#### Removing a record from Algolia
+
+1. Login to Algolia
+1. Navigate to the **Indices** page
+1. Use the search input to find the sensitive record(s)
+1. Click the trash can icon to open the deletion modal
+1. Click the delete button
+
+---
+
 ### Open Questions and Risks
 
-- Since the documentation landing page will be public only, we will not be able to search private sources of documentation. If searching private documentation becomes a necessary feature in the future, the proposed implementation will likely not be sufficient.
-- How often should we reindex our documentation sources? For perspective, Algolia's open source crawler runs every 24 hours.
-- What should the URL of the documentation landing page be? Since we have `design.va.gov`, does something like `docs.va.gov` make sense?
-- What is the current opportunity cost of building a custom solution? What are we choosing to delay right now by building a custom solution?
-- What is the future opportunity cost of maintaining a custom solution? What will we have to delay in the future by maintaining a custom solution?
-- What is the key person risk? How disruptive would it be if the author(s) of the custom solution were temporarily/permanently unavailable?
-- What is the Not-Invented-Here risk? How likely is that we're reinventing the wheel?
-- What is the inexperience risk? Have any of the team members involved ever built/deployed/maintained this type of system before?
-- It's possible that work estimates are materially inaccurate.
-- What is the documentation debt risk? At least one person interviewed during the discovery sprint said that we need a solution ASAP. Currently, the default documentation location is the [`va.gov-team` repo](https://github.com/department-of-veterans-affairs/va.gov-team). Is there a risk that people are deferring documentation in the present until the custom documentation solution is shipped, and/or adding/referencing/changing in the wrong place because they don't know where to find the correct documentation?
-- [Algolia's pricing](https://www.algolia.com/pricing/) includes a free tier called the Community plan. The Community plan includes 50k operations and 10k records, and doesn't include analytics (like recent search patterns). We currently have ~3k `*.md` files in the `va.gov-team` repo. If we exceeded those usage limits and/or wanted analytics, we would need a paid account.
+---
 
 ### Work Estimates
 
@@ -163,7 +171,8 @@ The recommendation from the discovery sprint is to build a custom documentation 
 
 ### Revision History
 
-| Date         | Revisions Made | Author        | Reviewed By |
-| ------------ | -------------- | ------------- | ----------- |
-| Jan 27, 2020 | Initial Draft  | Bill Fienberg |             |
+| Date         | Revisions Made         | Author        | Reviewed By |
+| ------------ | ---------------------- | ------------- | ----------- |
+| Jan 27, 2020 | Initial Draft          | Bill Fienberg |             |
 | Feb 10, 2020 | Update Detailed Design | Bill Fienberg |             |
+| Feb 11, 2020 | Answer open questions  | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -215,13 +215,19 @@ We could search for the same term in both the Algolia UI and the landing page to
 
 ### Security Concerns
 
+We don't currently have any custom private attributes on the records in our index. If we did, we could configure [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes/), which is a list of attributes that cannot be retrieved at query time.
+
 The [DocSearch JS snippet](https://docsearch.algolia.com/docs/dropdown) requires four pieces of data; the `appId` (public), search `apiKey` (public), `indexName`, and `inputSelector`.
 
 The `appId` and search `apiKey` are both public. The search `apiKey` only allows read access. There is a separate admin API key that the crawler will use, and that admin API key will need to be configured in an environment variable in CircleCI.
 
 CircleCI explains how to use environment variables in their [docs](https://circleci.com/docs/2.0/env-vars/).
 
-We don't currently have any custom private attributes on the records in our index. If we did, we could configure [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes/), which is a list of attributes that cannot be retrieved at query time.
+According to [CircleCI's docs](https://circleci.com/docs/2.0/oss/#security):
+
+> If your repository is public, your CircleCI project and its build logs are also public. Pay attention to the information you choose to print.
+
+Fortunately, CircleCI introduced [secret masking](https://circleci.com/blog/keep-environment-variables-private-with-secret-masking/) which will scan logs and replace environment variables or contexts with `XXXXX`.
 
 ### Privacy Concerns
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -103,8 +103,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 
 ### Open Questions and Risks
 
-- Should we index private documentation sources? If so, what private documentation sources can we expose to public users, if any?
-- Should the landing page be public only, or should it also support authenticated users?
+- Since the documentation landing page will be public only, we will not be able to search private sources of documentation. If searching private documentation becomes a necessary feature in the future, the proposed implementation will likely not be sufficient.
 - How often should we reindex our documentation sources? For perspective, Algolia's open source crawler runs every 24 hours.
 - What should the URL of the documentation landing page be? Since we have `design.va.gov`, does something like `docs.va.gov` make sense?
 - What is the current opportunity cost of building a custom solution? What are we choosing to delay right now by building a custom solution?

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -131,7 +131,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 
 #### Ready-made alternatives
 
-- [Slab](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#slab) supports multi-repo search, but was considered too expensive (about \$24k/year for the current number of users in the #general channel of the DSVA Slack workspace).
+- [Slab](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#slab) is a full-featured documentation solution that includes search (powered by Algolia). Slab's search feature is able to search across multiple repos. However, there are concerns about requiring users to sign in to a Slab account to browse documentation, which is something that is not part of their current workflow. Additionally, Slab's pricing is non-trivial. Using the number of users in the #general channel of the DSVA Slack workspace, we estimate Slab would cost approximately \$24k per year. And since this design doc is focused on an MVP for documentation searching, Slab is far more than an MVP. Slab is currently being viewed as a post-MVP solution, if the MVP doesn't meet expectations.
 - [GitBook](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#gitbook) includes a decent search feature, but it unfortunately only searches a single repo at a time. It doesn't support multi-repo/organization search, and didn't appear to be customizable.
 
 #### Open source alternatives

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -1,4 +1,4 @@
-# Global Documentation Search
+# Documentation Search MVP
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
@@ -32,7 +32,8 @@ A successful implementation will have these components.
 
 1. Page with Input Textbox - We need a public page with a search input where users can input their search term(s).
 1. Index/Database - We need a place to store the records that will be returned to the user.
-1. Crawler/Scraper - We need a crawler to frequently scan our documentation sources for additions/deletions/modifications.
+1. Crawler/Scraper - We need a crawler to scan our documentation sources and push data to our index.
+1. Cron job - We need a cron job to run the crawler at a reasonable interval (e.g. every 24 hours)
 
 ### Code Location
 
@@ -40,11 +41,39 @@ The code will live in a new repo (tentatively titled something like `docs-landin
 
 ### Testing Plan
 
-_How you will verify the behavior of your system. Once the system is written, this section should be updated to reflect the current state of testing and future aspirations._
+#### Environments
 
-#### Testing the search input
+For an MVP, I'm not certain it's necessary to have different environments for the search input and the scraper.
 
-#### Testing the crawler
+##### Testing the scraper
+
+###### New records should appear in index after a crawl
+
+1. Search for term that returns zero results
+1. Add document that contains term
+1. Run crawler
+1. Search for recently added term
+1. Assert that term is in index
+
+###### Old records should disappear from index after a crawl
+
+1. Search for term that exists in index
+1. Remove document that contains term from index
+1. Run crawler
+1. Search for recently deleted term
+1. Assert that term isn't in index
+
+###### Records should reflect edits after a crawl
+
+1. Search for record that exists in index
+1. Edit document
+1. Run crawler
+1. Search for recently edited record
+1. Assert that record reflects recent edit
+
+##### Testing the search functionality
+
+Once we have records in our Algolia index and the DocSearch frontend library on a page, we should be able to test the search functionality the same way the end user would use it.
 
 ### Logging
 
@@ -52,7 +81,13 @@ Algolia includes analytics, such as ["Most popular searches and results most oft
 
 ### Debugging
 
-_How users can debug interactions with your system. When designing a system it's important to think about what tools you can provide to make debugging problems easier. Sometimes it's unclear whether the problem is in your system at all, so a mechanism for isolating a particular interaction and examining it to see if your system behaved as expected is very valuable. Once a system is in use, this is a great place to put tips and recipes for debugging. If this section grows too large, the mechanisms can be summarized here and individual tips can be moved to another document._
+The Docker image for the scraper is available on [Docker Hub](https://hub.docker.com/r/algolia/docsearch-scraper). Once we have a config file, we can [run the scraper locally](https://community.algolia.com/docsearch/run-your-own.html#run-the-crawl-from-the-docker-image).
+
+#### Debugging the scraper
+
+#### Debugging the search functionality
+
+We could search for the same term in both the Algolia UI and the landing page to confirm if they both return the same results.
 
 ### Caveats
 
@@ -105,6 +140,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - Open source crawler: https://github.com/internetarchive/heritrix3
 - Open source document search engine with automated crawling, OCR, tagging and instant full-text search: https://ambar.cloud/
 - Open source search engine: Elasticsearch
+  - Configuring/deploying/maintaining our own Elasticsearch instance would likely be more expensive and less robust than using Algolia's Search API
 
 #### Custom alternatives
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -219,6 +219,8 @@ The [DocSearch JS snippet](https://docsearch.algolia.com/docs/dropdown) requires
 
 The `appId` and search `apiKey` are both public. The search `apiKey` only allows read access. There is a separate admin API key that the crawler will use, and that admin API key will need to be configured in an environment variable in CircleCI.
 
+CircleCI explains how to use environment variables in their [docs](https://circleci.com/docs/2.0/env-vars/).
+
 We don't currently have any custom private attributes on the records in our index. If we did, we could configure [`unretrievableAttributes`](https://www.algolia.com/doc/api-reference/api-parameters/unretrievableAttributes/), which is a list of attributes that cannot be retrieved at query time.
 
 ### Privacy Concerns

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -1,15 +1,105 @@
 # Global Documentation Search
 
-Author: Bill Fienberg
-Last Updated: 2020-01-23
-Reviewers: TBD
+**Author:** Bill Fienberg
+**Last Updated:** 2020-01-23
+_Replace the previous line with the the title of your project or component and replace the following lines with your name(s), email and the date._
 
-## Objective
+_For the rest of the document, replace all the italicized text. The document is designed to guide your thinking through a general design process. Not all sections are always applicable. If a section is not applicable, just say so._
 
-## Background
+_You should complete the Overview section first. If your design is elaborate, you may want to pause after this section to wait for review comments before investing time into planning details that may get changed in the review._
+
+_Remember, a design document introduces a system or component to a fellow engineer. It should be written before implementing the system to aid in planning and to facilitate discussions about design decisions. After implementation, the design doc will serve as a reference for users, maintainers, and anyone else interested in the system (and for that reason it is still useful to write design docs for systems that have already been written)._
+
+_A design document is not a press release, a vision statement, a research report, or a business plan._
+
+_The intended audience for this document is software engineers, but it should make sense to anyone familiar with software development._
 
 ## Overview
 
-## Detailed Design
+### Objective
 
-## Project Information
+We want to implement a public landing page where VFS/VSP team members can search multiple documentation source from a single entrypoint.
+
+### Background
+
+_The background section should contain information the reader needs to know to understand the problem being solved. This can be a combination of text and links to other documents._
+
+_Do **NOT** describe the solution here. That goes in High Level Design._
+
+### High Level Design
+
+_A high-level description of the system. This is the most valuable section of the document and will probably receive the most attention. You should explain, at a high level, how your system will work. Don't get bogged down with details; those belong later in the document._
+
+_A diagram showing how the major components communicate is very useful and a great way to start this section. If this system is intended to be a component in a larger system, a diagram showing how it fits in to the larger system will also be appreciated by your readers._
+
+_Most diagrams will need to be updated over time as the design evolves, so please create your diagrams with a program that is easily (and freely) available and attach the diagram source to the document to make it easy for a future maintainer (who could be you) to update the diagrams along with the document._
+
+## Specifics
+
+_Nothing goes here; all the content belongs in the subsections._
+
+### Detailed Design
+
+_Designs that are too detailed for the above High Level Design section belong here. Anything that will require a day or more of work to implement should be described here._
+
+_This is a great place to put APIs, communication protocols, file formats, and the like._
+
+_It is important to include assumptions about what external systems will provide. For example if this system has a method that takes a user id as input, will your implementation assume that the user id is valid? Or if a method has a string parameter, does it assume that the parameter has been sanitized against injection attacks? Having such assumptions explicitly spelled out here before you start implementing increases the chances that misunderstandings will be caught by a reviewer before they lead to bugs or vulnerabilities. Please reference the external system's documentation to justify your assumption whenever possible (and if such documentation doesn't exist, ask the external system's author to document the behavior or at least confirm it in an email)._
+
+_Here's an easy rule of thumb for deciding what to write here: Think of anything that would be a pain to change if you were requested to do so in a code review. If you put that implementation detail in here, you'll be less likely to be asked to change it once you've written all the code._
+
+### Code Location
+
+_The path of the source code in the repository._
+
+### Testing Plan
+
+_How you will verify the behavior of your system. Once the system is written, this section should be updated to reflect the current state of testing and future aspirations._
+
+### Logging
+
+_What your system will record and how._
+
+### Debugging
+
+_How users can debug interactions with your system. When designing a system it's important to think about what tools you can provide to make debugging problems easier. Sometimes it's unclear whether the problem is in your system at all, so a mechanism for isolating a particular interaction and examining it to see if your system behaved as expected is very valuable. Once a system is in use, this is a great place to put tips and recipes for debugging. If this section grows too large, the mechanisms can be summarized here and individual tips can be moved to another document._
+
+### Caveats
+
+_Gotchas, differences between the design and implementation, other potential stumbling blocks for users or maintainers, and their implications and workarounds. Unless something is known to be tricky ahead of time, this section will probably start out empty._
+
+_Rather than deleting it, it's recommended that you keep this section with a simple place holder, since caveats will almost certainly appear down the road._
+
+_To be determined._
+
+### Security Concerns
+
+_This section should describe possible threats (denial of service, malicious requests, etc) and what, if anything, is being done to protect against them. Be sure to list concerns for which you don't have a solution or you believe don't need a solution. Security concerns that we don't need to worry about also belong here (e.g. we don't need to worry about denial of service attacks for this system because it only receives requests from the api server which already has DOS attack protections)._
+
+### Open Questions and Risks
+
+_This section should describe design questions that have not been decided yet, research that needs to be done and potential risks that could make make this system less effective or more difficult to implement._
+
+_Some examples are: Should we communicate using TCP or UDP? How often do we expect our users to interrupt running jobs? This relies on an undocumented third-party API which may be turned off at any point._
+
+_For each question you should include any relevant information you know. For risks you should include estimates of likelihood, cost if they occur and ideas for possible workarounds._
+
+### Work Estimates
+
+_Split the work into milestones that can be delivered, put them in the order that you think they should be done, and estimate roughly how much time you expect it each milestone to take. Ideally each milestone will take one week or less._
+
+### Alternatives
+
+_This section contains alternative solutions to the stated objective, as well as explanations for why they weren't used. In the planning stage, this section is useful for understanding the value added by the proposed solution and why particular solutions were discarded. Once the system has been implemented, this section will inform readers of alternative solutions so they can find the best system to address their needs._
+
+### Future Work
+
+_Features you'd like to (or will need to) add but aren't required for the current release. This is a great place to speculate on potential features and performance improvements._
+
+### Revision History
+
+_The table below should record the major changes to this document. You don't need to add an entry for typo fixes, other small changes or changes before finishing the initial draft._
+
+| Date         | Revisions Made                                                                                                                                   | Author         | Reviewed By |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ----------- |
+| Jan 19, 2016 | Initial Draft based off [Arvados's template](https://dev.arvados.org/projects/arvados/wiki/Design_Doc_Template) which is reminiscent of Google's | Albert J. Wong |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -1,18 +1,9 @@
 # Global Documentation Search
 
-**Author:** Bill Fienberg
+**Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 **Last Updated:** 2020-01-23
-_Replace the previous line with the the title of your project or component and replace the following lines with your name(s), email and the date._
-
-_For the rest of the document, replace all the italicized text. The document is designed to guide your thinking through a general design process. Not all sections are always applicable. If a section is not applicable, just say so._
-
-_You should complete the Overview section first. If your design is elaborate, you may want to pause after this section to wait for review comments before investing time into planning details that may get changed in the review._
-
-_Remember, a design document introduces a system or component to a fellow engineer. It should be written before implementing the system to aid in planning and to facilitate discussions about design decisions. After implementation, the design doc will serve as a reference for users, maintainers, and anyone else interested in the system (and for that reason it is still useful to write design docs for systems that have already been written)._
-
-_A design document is not a press release, a vision statement, a research report, or a business plan._
-
-_The intended audience for this document is software engineers, but it should make sense to anyone familiar with software development._
+**Status:** **Draft**
+**Approvers:** Andrew G., Megan K.
 
 ## Overview
 
@@ -22,7 +13,7 @@ We want to implement a public landing page where VFS/VSP team members can search
 
 ### Background
 
-The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, etc). There currently is not a way for VFS/VSP users to search all of the sources with a single query.
+The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, etc). There currently is not a way for VFS/VSP users to search all of the documentation sources with a single query.
 
 ### High Level Design
 
@@ -67,6 +58,10 @@ _To be determined._
 ### Security Concerns
 
 _This section should describe possible threats (denial of service, malicious requests, etc) and what, if anything, is being done to protect against them. Be sure to list concerns for which you don't have a solution or you believe don't need a solution. Security concerns that we don't need to worry about also belong here (e.g. we don't need to worry about denial of service attacks for this system because it only receives requests from the api server which already has DOS attack protections)._
+
+### Privacy Concerns
+
+_This section should describe any risks related to user data, PII that are added by this new application. Think about flows of user data through systems, places data is stored and logged, places data is displayed to users. Where is user data stored or logged? How long is it stored?_
 
 ### Open Questions and Risks
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,7 +2,7 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-02-17
+**Last Updated:** 2020-02-18
 
 **Status:** **Draft**
 
@@ -60,7 +60,7 @@ The middle tier, the Starter plan, includes up to 50K records and 250k operation
 
 ##### The Pro Plan
 
-The upper tier, the Pro plan, includes up to 1M records and 5M operations. If we exceed the limits of the Pro plan, it would cost an extra $5/month foe every 100K additional operations, and an extra $5/month for every additional 20K records.
+The upper tier, the Pro plan, includes up to 1M records and 5M operations. If we exceed the limits of the Pro plan, it would cost an extra $5/month for every 100K additional operations, and an extra $5/month for every additional 20K records.
 
 ---
 
@@ -218,3 +218,4 @@ The recommendation from the discovery sprint is to build a custom documentation 
 | Feb 12, 2020 | Expand on where/when to run crawler                                           | Bill Fienberg |             |
 | Feb 13, 2020 | Add Usage Limits section, and update Code Location & Work Estimate sections   | Bill Fienberg |             |
 | Feb 17, 2020 | Add list of public docs, and open question about crawler diffing capabilities | Bill Fienberg |             |
+| Feb 18, 2020 | Fix typo                                                                      | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -68,8 +68,9 @@ _This section should describe any risks related to user data, PII that are added
 - Should the landing page be public only, or should it also support authenticated users?
 - How often should we reindex our documentation sources? For perspective, Algolia's open source crawler runs every 24 hours.
 - What should the URL of the documentation landing page be? Since we have `design.va.gov`, does something like `docs.va.gov` make sense?
-
-_For each question you should include any relevant information you know. For risks you should include estimates of likelihood, cost if they occur and ideas for possible workarounds._
+- What is the current opportunity cost of building a custom solution? What are we choosing to delay right now by building a custom solution?
+- What is the future opportunity cost of maintaining a custom solution? What will we have to delay in the future by maintaining a custom solution?
+- What is the key person risk? How disruptive would it be if the author(s) of the custom solution were unavailable?
 
 ### Work Estimates
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,7 +2,7 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-01-23
+**Last Updated:** 2020-01-29
 
 **Status:** **Draft**
 
@@ -111,7 +111,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 
 #### Custom solutions
 
-- Continue iterating on existing Gatsby site
+- Continue iterating on existing Gatsby site.
 
 ### Future Work
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -84,6 +84,8 @@ We will crawl and scrape the following public documentation sources:
 
 #### Private repos
 
+For the MVP, we will not be indexing private documentation sources.
+
 ---
 
 ### Code Location
@@ -126,7 +128,10 @@ For an MVP, I'm not certain it's necessary to have different environments for th
 
 ##### Testing the search functionality
 
-Once we have records in our Algolia index and the DocSearch frontend library on a page, we should be able to test the search functionality the same way the end user would use it.
+We can test the search functionality the following ways:
+
+- [Algolia's Docsearch Preview page](https://community.algolia.com/docsearch-preview/)
+- On the actual page where the search input lives
 
 ### Logging
 
@@ -218,4 +223,4 @@ The recommendation from the discovery sprint is to build a custom documentation 
 | Feb 12, 2020 | Expand on where/when to run crawler                                           | Bill Fienberg |             |
 | Feb 13, 2020 | Add Usage Limits section, and update Code Location & Work Estimate sections   | Bill Fienberg |             |
 | Feb 17, 2020 | Add list of public docs, and open question about crawler diffing capabilities | Bill Fienberg |             |
-| Feb 18, 2020 | Fix typo                                                                      | Bill Fienberg |             |
+| Feb 18, 2020 | Fix typo, update search testing instructions, exclude private repos           | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -144,7 +144,7 @@ The search input, JS snippet, and scraper config file will all live in the `va.g
 
 The search input and DocSearch JS snippet will live in the `docs/index.html` file.
 
-The config file for the scraper will live in the `docs/docsearch-scraper-config.json`) file.
+The config file for the scraper will live in the `docs/docsearch-scraper-config.json` file.
 
 ### Testing Plan
 
@@ -195,7 +195,7 @@ Algolia includes analytics, such as ["Most popular searches and results most oft
 
 The Docker image for the scraper is available on [Docker Hub](https://hub.docker.com/r/algolia/docsearch-scraper). We can [run the scraper locally](https://community.algolia.com/docsearch/run-your-own.html#run-the-crawl-from-the-docker-image) with the config file, and a `.env` file containing the `APPLICATION_ID` and `API_KEY`.
 
-I've added a [sample `.env` file](.env.sample).
+I've added a [sample `.env` file](../../../../.env.sample).
 
 If you don't have an `.env` file, you'll need to create one. If you do have an `.env` file, then you'll need to add/edit the `APPLICATION_ID` and `API_KEY` keys to include the corresponding values from the Algolia website.
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -38,10 +38,6 @@ We do not currently have an index of our target documentation sources. And we do
 
 Algolia appears to be the leader when it comes to searching documentation.
 
-_It is important to include assumptions about what external systems will provide. For example if this system has a method that takes a user id as input, will your implementation assume that the user id is valid? Or if a method has a string parameter, does it assume that the parameter has been sanitized against injection attacks? Having such assumptions explicitly spelled out here before you start implementing increases the chances that misunderstandings will be caught by a reviewer before they lead to bugs or vulnerabilities. Please reference the external system's documentation to justify your assumption whenever possible (and if such documentation doesn't exist, ask the external system's author to document the behavior or at least confirm it in an email)._
-
-_Here's an easy rule of thumb for deciding what to write here: Think of anything that would be a pain to change if you were requested to do so in a code review. If you put that implementation detail in here, you'll be less likely to be asked to change it once you've written all the code._
-
 ### Code Location
 
 _The path of the source code in the repository._

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -70,8 +70,6 @@ If the search input dispatched a request directly to the Algolia API, then there
 
 ### Privacy Concerns
 
-Since the initial implementation will be an unauthenticated landing page, we will have little, if any, data about the user.
-
 While there shouldn't be any PII in our public documentation sources, it is possible it exists, and hasn't been discovered yet. Therefore, it is possible that our search results could lead public users to sources that contain PII. If PII is discovered in a repo, we have a [checklist](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/removing-sensitive-data-from-a-repository.md#checklist-for-removing-pii-in-md-file-from-a-documentation-repo) for how to remove it.
 
 ### Open Questions and Risks

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -1,6 +1,6 @@
 # Documentation Search MVP
 
-**Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
+**Author(s):** Bill Fienberg \<bill.fienberg@oddball.io\>
 
 **Last Updated:** 2020-02-18
 
@@ -201,7 +201,7 @@ If you don't have an `.env` file, you'll need to create one. If you do have an `
 
 ##### Dependencies to run `docsearch-scraper` locally
 
-- [Docker](https://docs.docker.com/install/).
+- [Docker](https://docs.docker.com/install/)
 - [`docsearch-scraper` Docker image](https://hub.docker.com/r/algolia/docsearch-scraper)
 - [`jq`](https://github.com/stedolan/jq/wiki/Installation)
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -12,7 +12,7 @@
 
 ### Objective
 
-Add search functionality to a public documentation landing page
+Add search functionality to a public documentation landing page.
 
 ### Background
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,7 +2,7 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-01-29
+**Last Updated:** 2020-02-04
 
 **Status:** **Draft**
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -12,7 +12,7 @@
 
 ### Objective
 
-Run our own instance of [Algolia's DocSearch](https://community.algolia.com/docsearch/what-is-docsearch.html) on a custom landing page.
+Add search functionality to a public documentation landing page
 
 ### Background
 
@@ -26,14 +26,23 @@ We are adding a public landing page that will contain a search input where users
 
 ### Detailed Design
 
-We are adding a public landing page that will contain the [DocSearch frontend library](https://github.com/algolia/docsearch), and running our own instance of the [`docsearch-scraper`](https://github.com/algolia/docsearch-scraper) to extract content from our documentation sources and push it to an Algolia index.
+For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/), [Algolia's Search API](https://www.algolia.com/products/search/), and [Algolia's scraper](https://github.com/algolia/docsearch-scraper). 
 
-A successful implementation will have these components.
+In general, this kind of system requires the following components:
 
-1. Page with Input Textbox - We need a public page with a search input where users can input their search term(s).
-1. Index/Database - We need a place to store the records that will be returned to the user.
-1. Crawler/Scraper - We need a crawler to scan our documentation sources and push data to our index.
-1. Cron job - We need a cron job to run the crawler at a reasonable interval (e.g. every 24 hours)
+- Page with Input Textbox - We need a public page with a search input where users can input their search term(s).
+- Index/Database - We need a place to store the records that will be returned to the user.
+- Search API - We need a way to get data out of the index.
+- Crawler/Scraper - We need a crawler to scan our documentation sources and push data to our index.
+- Pipeline - We need a way to routinely run the crawler
+
+Each one of the above components could be a separate buy-or-build decision. 
+
+By leveraging the following existing technologies, we should only need to add the search input to the landing page, configure the scraper, and configure when to run the scraper. 
+
+- Algolia's Search API product will satisfy the index and API components. 
+- Algolia's open source JavaScript snippet will display search results to the user. 
+- Algolia's open source scraper will crawl and scrape our public documentation sources to push records into our index. 
 
 ### Code Location
 
@@ -157,3 +166,4 @@ The recommendation from the discovery sprint is to build a custom documentation 
 | Date         | Revisions Made | Author        | Reviewed By |
 | ------------ | -------------- | ------------- | ----------- |
 | Jan 27, 2020 | Initial Draft  | Bill Fienberg |             |
+| Feb 10, 2020 | Update Detailed Design | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,7 +2,7 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-02-13
+**Last Updated:** 2020-02-17
 
 **Status:** **Draft**
 
@@ -160,6 +160,8 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 
 ### Open Questions and Risks
 
+- Does Algolia's scraper include any diffing feature? If it crawls a page and the result is identical to the previous crawl, does that still count towards our operation usage limit? If it has to read every record every day, that means we'd have at least 150k operations every day in `va.gov-team` alone. If the crawler has to execute a read operation to calculate a diff, and then execute a write operation to create a new record or edit an existing record, then that could be up to 300k operations every day in `va.gov-team` alone.
+
 ---
 
 ### Work Estimates
@@ -205,3 +207,4 @@ The recommendation from the discovery sprint is to build a custom documentation 
 | Feb 11, 2020 | Answer open questions                                                       | Bill Fienberg |             |
 | Feb 12, 2020 | Expand on where/when to run crawler                                         | Bill Fienberg |             |
 | Feb 13, 2020 | Add Usage Limits section, and update Code Location & Work Estimate sections | Bill Fienberg |             |
+| Feb 17, 2020 | Add open question about crawler diffing capabilities                        | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,9 +2,11 @@
 
 **Author(s):** Bill Fienberg \<bill.fienberg@oddball.io\>
 
-**Last Updated:** 2020-02-18
+**Last Updated:** 2020-02-19
 
-**Status:** **Draft**
+**Status:** **On Hold**
+
+This Design Doc is on hold while we wait for approval to sign up for Algolia.
 
 **Approvers:** Andrew G., Megan K., Rian F., Wyatt W.
 
@@ -293,3 +295,4 @@ The recommendation from the discovery sprint is to build a custom documentation 
 | Feb 17, 2020 | Add list of public docs, and open question about crawler diffing capabilities | Bill Fienberg |             |
 | Feb 18, 2020 | Fix typo, update search testing instructions, exclude private repos           | Bill Fienberg |             |
 | Feb 18, 2020 | Add Records section, add Operations section, and plan recommendation          | Bill Fienberg |             |
+| Feb 19, 2020 | Update status from "Draft" to "On Hold"                                       | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -70,7 +70,9 @@ _This section should describe any risks related to user data, PII that are added
 - What should the URL of the documentation landing page be? Since we have `design.va.gov`, does something like `docs.va.gov` make sense?
 - What is the current opportunity cost of building a custom solution? What are we choosing to delay right now by building a custom solution?
 - What is the future opportunity cost of maintaining a custom solution? What will we have to delay in the future by maintaining a custom solution?
-- What is the key person risk? How disruptive would it be if the author(s) of the custom solution were unavailable?
+- What is the key person risk? How disruptive would it be if the author(s) of the custom solution were temporarily/permanently unavailable?
+- What is the Not-Invented-Here risk? How likely is that we're reinventing the wheel?
+- What is the inexperience risk? Have any of the team members involved ever built/deployed/maintained this type of system before?
 
 ### Work Estimates
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -12,7 +12,7 @@
 
 ### Objective
 
-Add search functionality to a public documentation landing page.
+Sign up for Algolia, add a search input and Algolia's DocSearch JS snippet to the root page of `va.gov-team`'s GitHub Pages site, and configure CircleCI to run's Algolia's scraper to crawl our docs once per day.
 
 ### Background
 
@@ -20,13 +20,11 @@ The documentation we have is spread across many different locations (public repo
 
 ### High Level Design
 
-We are adding a public landing page that will contain a search input where users can search multiple sources of documentation with one query.
-
 ## Specifics
 
 ### Detailed Design
 
-For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/). This will use [Algolia's Search API](https://www.algolia.com/products/search/) to query Algolia's hosted database (https://www.algolia.com/pricing/), which will be populated by [Algolia's scraper](https://github.com/algolia/docsearch-scraper) using a configuration we supply (link needed).
+For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/). This will use [Algolia's Search API](https://www.algolia.com/products/search/) to query Algolia's hosted database (https://www.algolia.com/pricing/), which will be populated by [Algolia's scraper](https://github.com/algolia/docsearch-scraper) using a [configuration we supply](docs/docsearch-scraper-config.json).
 
 In general, this kind of system requires the following components:
 
@@ -36,13 +34,17 @@ In general, this kind of system requires the following components:
 - Crawler/Scraper - We need a crawler to scan our documentation sources and push data to our index.
 - Pipeline - We need a way to routinely run the crawler
 
-Each one of the above components could be a separate buy-or-build decision.
+By using Algolia's Search API product with their open source Dropdown Search-UI and open source scraper, we can avoid building/maintaining the database, API, UI, and crawler components.
 
-By leveraging the following existing technologies, we should only need to add the search input to the landing page, configure the scraper, and configure when to run the scraper.
+That means we'd be responsible for:
 
-- Algolia's Search API product will satisfy the index and API components.
-- Algolia's open source JavaScript snippet will display search results to the user.
-- Algolia's open source scraper will crawl and scrape our public documentation sources to push records into our index.
+- Converting `va.gov-team`'s `docs/index.md` from markdown to HTML
+- Adding a search input to `va.gov-team`'s `docs/index.html`
+- Adding the DocSearch `<style>` and `<script>` tags to `va.gov-team`'s `docs/index.html`
+- Writing the config file for the scraper
+- Adding CircleCI to `va.gov-team`
+- Adding a scheduled job to `va.gov-team`'s CircleCI pipeline to run the scraper once every 24 hours
+- Manually triggering the initial scraper run to populate our Algolia index
 
 #### Usage limits
 
@@ -62,7 +64,7 @@ The upper tier, the Pro plan, includes up to 1M records and 5M operations. If we
 
 ---
 
-Essentially, every line of text (`<p>`, `<li>`, `<h1-6>`, etc) in a markdown file ends up as a separate record in the Algolia index. We have approximately 3K `.md` files in the `va.gov-team` repo. We ran a test crawler to estimate how many elements would match our selectors, and it found almost 150K matching elements, which would translate to 150K records.
+Essentially, every line of text (`<p>`, `<li>`, `<h1-6>`, etc) in a markdown file ends up as a separate record in the Algolia index. We have approximately 3K `.md` files in the `va.gov-team` repo. We ran a test crawler on the `va.gov-team` repo to estimate how many elements would match our selectors, and it found almost 150K matching elements, which equates to almost 150K records.
 
 #### Where/when to run the scraper
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -118,9 +118,7 @@ If we crawled the `va.gov-team` repo every day, our minimum usage would be ~150K
 
 #### Where/when to run the scraper
 
-Subject to review, we will run the crawler in a scheduled job once every 24 hours in a Circle CI pipeline for the `va.gov-team` repo.
-
-It's possible that running the scraper once per day would consume a significant number of operations.
+We will run the crawler in a scheduled job once every 24 hours in a Circle CI pipeline for the `va.gov-team` repo.
 
 #### Public repos
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -20,6 +20,8 @@ The documentation we have is spread across many different locations (public repo
 
 ### High Level Design
 
+We will use [Algolia's Search API](https://www.algolia.com/products/search/) coupled with [Algolia's DocSearch scraper](https://github.com/algolia/docsearch-scraper) and Algolia's [Dropdown Search-UI](https://docsearch.algolia.com/docs/dropdown) to index and search our public documentation sources.
+
 ## Specifics
 
 ### Detailed Design

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -86,7 +86,7 @@ The DocSearch JS snippet doesn't seem to use any debouncing. I noted the number 
 
 Since each crawl wipes and repopulates the index, that means each crawl will produce a number of operations approximately equal to the previous number of records. The number of operations may be larger due to new lines/files in the repos, and it may be smaller due to deleted lines/files in the repo.
 
-If the `va.gov-team` repo currently produces ~150K records, then crawling `va.gov-team` would produce ~150K operations every time it runs. If the `va.gov-team` repo is crawler once per day, then that would produce ~150K operations every day. At that rate, we'd have approximately ~4.5M operations every month from crawling the `va.gov-team` repo alone.
+If the `va.gov-team` repo currently produces ~150K records, then crawling `va.gov-team` would produce ~150K operations every time it runs. If the `va.gov-team` repo is crawled once per day, then that would produce ~150K operations every day. At that rate, we'd have approximately ~4.5M operations every month from crawling the `va.gov-team` repo alone.
 
 ##### Recommended Plan for Our Usage
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -122,9 +122,9 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - I estimate one week because I suspect we'll either need to get approval to use Algolia's hosted API or get approval to provision a custom data store.
 
 1. Configure crawler to seed the initial data store. - 2 days
-1. Run the crawler to populate the data store. - 2 day
-1. Build a landing page that will contain a search input that submits requests to the Search API. - 2 day
-1. Deploy the landing page to a publicly available location. - 2 day
+1. Run the crawler to populate the data store. - 2 days
+1. Build a landing page that will contain a search input that submits requests to the Search API. - 2 days
+1. Deploy the landing page to a publicly available location. - 2 days
 
 - I estimate this may take longer if we need to need to coordinate with other teams.
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -12,21 +12,21 @@
 
 ### Objective
 
-Search multiple documentation sources from a single, public entrypoint.
+Run our own instance of [Algolia's DocSearch](https://community.algolia.com/docsearch/what-is-docsearch.html) on a custom landing page.
 
 ### Background
 
-The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, handbooks, etc). There currently is not a way for VFS/VSP users to search all of the documentation sources with a single query.
+The documentation we have is spread across many different locations (public repos, private repos, GitHub pages, handbooks, etc). There currently isn't a way for VFS/VSP users to search multiple documentation sources with a single query.
 
 ### High Level Design
 
-We are adding a public landing page that will contain a form where users can search multiple, public documentation sources with a single query.
+We are adding a public landing page that will contain a search input where users can search multiple sources of documentation with one query.
 
 ## Specifics
 
 ### Detailed Design
 
-We are adding a public landing page (on a custom domain, if possible) that will contain a search input. That search input will query multiple, public documentation sources with one query.
+We are adding a public landing page that will contain the [DocSearch frontend library](https://github.com/algolia/docsearch), and running our own instance of the [`docsearch-scraper`](https://github.com/algolia/docsearch-scraper) to extract content from our documentation sources and push it to an Algolia index.
 
 A successful implementation will have these components.
 
@@ -34,13 +34,9 @@ A successful implementation will have these components.
 1. Index/Database - We need a place to store the records that will be returned to the user.
 1. Crawler/Scraper - We need a crawler to frequently scan our documentation sources for additions/deletions/modifications.
 
-We do not currently have an index of our target documentation sources. And we do not currently have infrastructure to crawl our target documentation sources to build said index.
-
-Algolia appears to be the leader when it comes to searching documentation.
-
 ### Code Location
 
-_The path of the source code in the repository._
+The code will live in a new repo (tentatively titled something like `docs-landing-page`).
 
 ### Testing Plan
 
@@ -52,7 +48,7 @@ _How you will verify the behavior of your system. Once the system is written, th
 
 ### Logging
 
-By logging the term(s) that users are querying, we could theoretically identify trends to help increase the quality of our search results.
+Algolia includes analytics, such as ["Most popular searches and results most often returned by the search engine."](https://www.algolia.com/products/analytics/?tab=popular)
 
 ### Debugging
 
@@ -63,8 +59,6 @@ _How users can debug interactions with your system. When designing a system it's
 - Access Control: By making the documentation landing page public, it becomes difficult, if not impossible, to allow an unauthenticated user to search documentation from private sources (like a private Github repo). One suggestion is that search results lead to public documentation sources, and we include links to private documentation in the public sources. That way, we can rely on existing access control solutions, while still providing a decent solution. One of the major downsides of that approach is auditing, adding, updating, and maintaining links to/from the public and private sources.
 
 ### Security Concerns
-
-The search input would need to be sanitized.
 
 If the search input dispatched a request directly to the Algolia API, then there'd be minimal risk of the documentation search negatively affecting other systems. If the request was proxied through our API, then we should be able to rely on any existing DOS protections.
 
@@ -93,24 +87,28 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - I estimate one week because I suspect we'll either need to get approval to use Algolia's hosted API or get approval to provision a custom data store.
 
 1. Configure crawler to seed the initial data store. - 2 days
-1. Run the crawler to populate the data store. - 1 day
-1. Build a landing page that will contain a search input that submits requests to the Search API. - 1 day
-1. Deploy the landing page to a publicly available location. - 1 day
+1. Run the crawler to populate the data store. - 2 day
+1. Build a landing page that will contain a search input that submits requests to the Search API. - 2 day
+1. Deploy the landing page to a publicly available location. - 2 day
 
-- I estimate this may take longer if we need to need to coordinate with DevOps.
+- I estimate this may take longer if we need to need to coordinate with other teams.
 
 ### Alternatives
 
-#### Ready-made solutions
+#### Ready-made alternatives
 
 - [Slab](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#slab) supports multi-repo search, but was considered too expensive (about \$24k/year for the current number of users in the #general channel of the DSVA Slack workspace).
 - [GitBook](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#gitbook) includes a decent search feature, but it unfortunately only searches a single repo at a time. It doesn't support multi-repo/organization search, and didn't appear to be customizable.
 
-#### Open source solutions
+#### Open source alternatives
 
-#### Custom solutions
+- Open source crawler: https://github.com/internetarchive/heritrix3
+- Open source document search engine with automated crawling, OCR, tagging and instant full-text search: https://ambar.cloud/
+- Open source search engine: Elasticsearch
 
-- Continue iterating on existing Gatsby site.
+#### Custom alternatives
+
+- Continue iterating on existing [Gatsby site](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/).
 
 ### Future Work
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,7 +2,7 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-02-11
+**Last Updated:** 2020-02-13
 
 **Status:** **Draft**
 
@@ -26,7 +26,7 @@ We are adding a public landing page that will contain a search input where users
 
 ### Detailed Design
 
-For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/). This will use [Algolia's Search API](https://www.algolia.com/products/search/) to query Algolia's Hosted database (link needed), which will be populated by [Algolia's scraper](https://github.com/algolia/docsearch-scraper) using a configuration we supply (link needed).
+For a multi-repo search MVP, we are adding an HTML text input and [Algolia's DocSearch JS snippet](https://github.com/algolia/docsearch) to the [`va.gov-team` GitHub Pages site](https://department-of-veterans-affairs.github.io/va.gov-team/). This will use [Algolia's Search API](https://www.algolia.com/products/search/) to query Algolia's hosted database (https://www.algolia.com/pricing/), which will be populated by [Algolia's scraper](https://github.com/algolia/docsearch-scraper) using a configuration we supply (link needed).
 
 In general, this kind of system requires the following components:
 
@@ -46,7 +46,7 @@ By leveraging the following existing technologies, we should only need to add th
 
 #### Where/when to run the scraper
 
-For the MVP, we will run the crawler in a scheduled job once every 24 hours in Circle CI.
+For the MVP, we will run the crawler in a scheduled job once every 24 hours in a Circle CI pipeline for the `va.gov-team` repo.
 
 #### Private repos
 
@@ -54,7 +54,9 @@ For the MVP, we will run the crawler in a scheduled job once every 24 hours in C
 
 ### Code Location
 
-The code will live in a new repo (tentatively titled something like `docs-landing-page`).
+The search input and DocSearch JS snippet will live in the `docs/index.html` file inside the `va.gov-team` repo.
+
+The config file for the crawler (`config.json`) will also live inside inside the `va.gov-team` repo.
 
 ### Testing Plan
 
@@ -171,8 +173,10 @@ The recommendation from the discovery sprint is to build a custom documentation 
 
 ### Revision History
 
-| Date         | Revisions Made         | Author        | Reviewed By |
-| ------------ | ---------------------- | ------------- | ----------- |
-| Jan 27, 2020 | Initial Draft          | Bill Fienberg |             |
-| Feb 10, 2020 | Update Detailed Design | Bill Fienberg |             |
-| Feb 11, 2020 | Answer open questions  | Bill Fienberg |             |
+| Date         | Revisions Made                      | Author        | Reviewed By |
+| ------------ | ----------------------------------- | ------------- | ----------- |
+| Jan 27, 2020 | Initial Draft                       | Bill Fienberg |             |
+| Feb 10, 2020 | Update Detailed Design              | Bill Fienberg |             |
+| Feb 11, 2020 | Answer open questions               | Bill Fienberg |             |
+| Feb 12, 2020 | Expand on where/when to run crawler | Bill Fienberg |             |
+| Feb 13, 2020 | Update Code Location section        | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -72,7 +72,7 @@ If the search input dispatched a request directly to the Algolia API, then there
 
 Since the initial implementation will be an unauthenticated landing page, we will have little, if any, data about the user.
 
-While there shouldn't be any PII in our public documentation sources, it is possible it exists, and hasn't been discovered yet. Therefore, it is possible that our search results could lead public users to sources that contain PII.
+While there shouldn't be any PII in our public documentation sources, it is possible it exists, and hasn't been discovered yet. Therefore, it is possible that our search results could lead public users to sources that contain PII. If PII is discovered in a repo, we have a [checklist](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/removing-sensitive-data-from-a-repository.md#checklist-for-removing-pii-in-md-file-from-a-documentation-repo) for how to remove it.
 
 ### Open Questions and Risks
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -131,6 +131,8 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 
 #### Ready-made alternatives
 
+The recommendation from the discovery sprint is to build a custom documentation landing page that includes multi-repo search functionality, as well as a table of contents for critical documentation. This design doc is focused specifically on the search component. The following alternatives are more robust documentation solutions that include search functionality as part of a larger product.
+
 - [Slab](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#slab) is a full-featured documentation solution that includes search (powered by Algolia). Slab's search feature is able to search across multiple repos. However, there are concerns about requiring users to sign in to a Slab account to browse documentation, which is something that is not part of their current workflow. Additionally, Slab's pricing is non-trivial. Using the number of users in the #general channel of the DSVA Slack workspace, we estimate Slab would cost approximately \$24k per year. And since this design doc is focused on an MVP for documentation searching, Slab is far more than an MVP. Slab is currently being viewed as a post-MVP solution, if the MVP doesn't meet expectations.
 - [GitBook](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#gitbook) includes a decent search feature, but it unfortunately only searches a single repo at a time. It doesn't support multi-repo/organization search, and didn't appear to be customizable.
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -113,6 +113,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - What is the inexperience risk? Have any of the team members involved ever built/deployed/maintained this type of system before?
 - It's possible that work estimates are materially inaccurate.
 - What is the documentation debt risk? At least one person interviewed during the discovery sprint said that we need a solution ASAP. Currently, the default documentation location is the [`va.gov-team` repo](https://github.com/department-of-veterans-affairs/va.gov-team). Is there a risk that people are deferring documentation in the present until the custom documentation solution is shipped, and/or adding/referencing/changing in the wrong place because they don't know where to find the correct documentation?
+- [Algolia's pricing](https://www.algolia.com/pricing/) includes a free tier called the Community plan. The Community plan includes 50k operations and 10k records, and doesn't include analytics (like recent search patterns). We currently have ~3k `*.md` files in the `va.gov-team` repo. If we exceeded those usage limits and/or wanted analytics, we would need a paid account.
 
 ### Work Estimates
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -78,11 +78,16 @@ _Split the work into milestones that can be delivered, put them in the order tha
 
 ### Alternatives
 
-- Continue iterating on existing Gatsby site
+#### Ready-made solutions
+
 - Slab
 - GitBook
 
-_This section contains alternative solutions to the stated objective, as well as explanations for why they weren't used. In the planning stage, this section is useful for understanding the value added by the proposed solution and why particular solutions were discarded. Once the system has been implemented, this section will inform readers of alternative solutions so they can find the best system to address their needs._
+#### Open source solutions
+
+#### Custom solutions
+
+- Continue iterating on existing Gatsby site
 
 ### Future Work
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -112,7 +112,7 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - What is the Not-Invented-Here risk? How likely is that we're reinventing the wheel?
 - What is the inexperience risk? Have any of the team members involved ever built/deployed/maintained this type of system before?
 - It's possible that work estimates are materially inaccurate.
-- What is the documentation debt risk? At least one person interviewed during the discovery sprint said that we need a solution ASAP. Is there a risk that people are deferring documentation in the present until the custom documentation solution is shipped?
+- What is the documentation debt risk? At least one person interviewed during the discovery sprint said that we need a solution ASAP. Currently, the default documentation location is the [`va.gov-team` repo](https://github.com/department-of-veterans-affairs/va.gov-team). Is there a risk that people are deferring documentation in the present until the custom documentation solution is shipped, and/or adding/referencing/changing in the wrong place because they don't know where to find the correct documentation?
 
 ### Work Estimates
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -44,9 +44,31 @@ By leveraging the following existing technologies, we should only need to add th
 - Algolia's open source JavaScript snippet will display search results to the user.
 - Algolia's open source scraper will crawl and scrape our public documentation sources to push records into our index.
 
+#### Usage limits
+
+[Algolia's pricing page](https://www.algolia.com/pricing/) shows three different tiers, in addition to an enterprise plan. The primary differentiator between the tiers is the number of records and the number of operations (read/write/edit/delete) included with each plan.
+
+##### The Community Plan
+
+The free tier, the Community plan, includes up to 10K records and 50K operations (read/write/edit/delete). After hitting the limit, we'd have to upgrade to a paid plan.
+
+##### The Starter Plan
+
+The middle tier, the Starter plan, includes up to 50K records and 250k operations. It costs an extra $10/month to get 100K additional operations, and it costs an extra $10/month to get an extra 20K records.
+
+##### The Pro Plan
+
+And the upper tier, the Pro plan, includes up to 1M records and 5M operations. It costs an extra $5/month to get 100K additional operations, and it costs an extra $5/month to get an extra 20K records.
+
+---
+
+Essentially, every line of text (`<p>`, `<li>`, `<h1-6>`, etc) in a markdown file ends up as a separate record in the Algolia index. We have approximately 3K `.md` files in the `va.gov-team` repo. We ran a test crawler to estimate how many elements would match our selectors, and it found almost 150K matching elements, which would translate to 150K records.
+
 #### Where/when to run the scraper
 
-For the MVP, we will run the crawler in a scheduled job once every 24 hours in a Circle CI pipeline for the `va.gov-team` repo.
+Subject to review, we will run the crawler in a scheduled job once every 24 hours in a Circle CI pipeline for the `va.gov-team` repo.
+
+It's possible that running the scraper once per day would consume a significant number of operations.
 
 #### Private repos
 
@@ -173,10 +195,10 @@ The recommendation from the discovery sprint is to build a custom documentation 
 
 ### Revision History
 
-| Date         | Revisions Made                      | Author        | Reviewed By |
-| ------------ | ----------------------------------- | ------------- | ----------- |
-| Jan 27, 2020 | Initial Draft                       | Bill Fienberg |             |
-| Feb 10, 2020 | Update Detailed Design              | Bill Fienberg |             |
-| Feb 11, 2020 | Answer open questions               | Bill Fienberg |             |
-| Feb 12, 2020 | Expand on where/when to run crawler | Bill Fienberg |             |
-| Feb 13, 2020 | Update Code Location section        | Bill Fienberg |             |
+| Date         | Revisions Made                                            | Author        | Reviewed By |
+| ------------ | --------------------------------------------------------- | ------------- | ----------- |
+| Jan 27, 2020 | Initial Draft                                             | Bill Fienberg |             |
+| Feb 10, 2020 | Update Detailed Design                                    | Bill Fienberg |             |
+| Feb 11, 2020 | Answer open questions                                     | Bill Fienberg |             |
+| Feb 12, 2020 | Expand on where/when to run crawler                       | Bill Fienberg |             |
+| Feb 13, 2020 | Add Usage Limits section and update Code Location section | Bill Fienberg |             |

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -85,17 +85,27 @@ While there shouldn't be any PII in our public documentation sources, it is poss
 - What is the key person risk? How disruptive would it be if the author(s) of the custom solution were temporarily/permanently unavailable?
 - What is the Not-Invented-Here risk? How likely is that we're reinventing the wheel?
 - What is the inexperience risk? Have any of the team members involved ever built/deployed/maintained this type of system before?
+- It's possible that work estimates are materially inaccurate.
 
 ### Work Estimates
 
-_Split the work into milestones that can be delivered, put them in the order that you think they should be done, and estimate roughly how much time you expect it each milestone to take. Ideally each milestone will take one week or less._
+1. Provision and configure data store to house records that will be returned from the Search API. - 1 week
+
+- I estimate one week because I suspect we'll either need to get approval to use Algolia's hosted API or get approval to provision a custom data store.
+
+1. Configure crawler to seed the initial data store. - 2 days
+1. Run the crawler to populate the data store. - 1 day
+1. Build a landing page that will contain a search input that submits requests to the Search API. - 1 day
+1. Deploy the landing page to a publicly available location. - 1 day
+
+- I estimate this may take longer if we need to need to coordinate with DevOps.
 
 ### Alternatives
 
 #### Ready-made solutions
 
-- Slab
-- GitBook
+- [Slab](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#slab) supports multi-repo search, but was considered too expensive (about \$24k/year for the current number of users in the #general channel of the DSVA Slack workspace).
+- [GitBook](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/research/discovery-sprint-12-2019/technology-discovery.md#gitbook) includes a decent search feature, but it unfortunately only searches a single repo at a time. It doesn't support multi-repo/organization search, and didn't appear to be customizable.
 
 #### Open source solutions
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -1,8 +1,11 @@
 # Global Documentation Search
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
+
 **Last Updated:** 2020-01-23
+
 **Status:** **Draft**
+
 **Approvers:** Andrew G., Megan K.
 
 ## Overview
@@ -73,6 +76,10 @@ _For each question you should include any relevant information you know. For ris
 _Split the work into milestones that can be delivered, put them in the order that you think they should be done, and estimate roughly how much time you expect it each milestone to take. Ideally each milestone will take one week or less._
 
 ### Alternatives
+
+- Continue iterating on existing Gatsby site
+- Slab
+- GitBook
 
 _This section contains alternative solutions to the stated objective, as well as explanations for why they weren't used. In the planning stage, this section is useful for understanding the value added by the proposed solution and why particular solutions were discarded. Once the system has been implemented, this section will inform readers of alternative solutions so they can find the best system to address their needs._
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -9,7 +9,7 @@
 
 ### Objective
 
-We want to implement a public landing page where VFS/VSP team members can search multiple documentation sources from a single entrypoint.
+We want to implement a landing page where VFS/VSP team members can search multiple documentation sources from a single entrypoint.
 
 ### Background
 
@@ -17,7 +17,7 @@ The documentation we have is spread across many different locations (public repo
 
 ### High Level Design
 
-We are adding a public landing page that will contain a form where users can search all of our public documentation in one location.
+We are adding a landing page that will contain a form where users can search multiple documentation sources in one location.
 
 ## Specifics
 
@@ -41,7 +41,7 @@ _How you will verify the behavior of your system. Once the system is written, th
 
 ### Logging
 
-_What your system will record and how._
+By logging the term(s) that users are querying, we could theoretically identify trends to help increase the quality of our search results.
 
 ### Debugging
 
@@ -49,11 +49,7 @@ _How users can debug interactions with your system. When designing a system it's
 
 ### Caveats
 
-_Gotchas, differences between the design and implementation, other potential stumbling blocks for users or maintainers, and their implications and workarounds. Unless something is known to be tricky ahead of time, this section will probably start out empty._
-
-_Rather than deleting it, it's recommended that you keep this section with a simple place holder, since caveats will almost certainly appear down the road._
-
-_To be determined._
+- Access Control: By making the documentation landing page public, it becomes difficult to impossible to allow an unauthenticated user to search documentation from private sources (like a private Github repo). One suggestion is that search results lead to public documentation sources, and we include links to private documentation in the public sources. That way, we can rely on existing access control solutions, while still providing a decent solution. One of the major downsides of that approach is auditing, adding, updating, and maintaining links to/from the public and private sources.
 
 ### Security Concerns
 
@@ -65,9 +61,10 @@ _This section should describe any risks related to user data, PII that are added
 
 ### Open Questions and Risks
 
-_This section should describe design questions that have not been decided yet, research that needs to be done and potential risks that could make make this system less effective or more difficult to implement._
-
-_Some examples are: Should we communicate using TCP or UDP? How often do we expect our users to interrupt running jobs? This relies on an undocumented third-party API which may be turned off at any point._
+- Should we index private documentation sources? If so, what private documentation sources can we expose to public users, if any?
+- Should the landing page be public only, or should it also support authenticated users?
+- How often should we reindex our documentation sources? For perspective, Algolia's open source crawler runs every 24 hours.
+- What should the URL of the documentation landing page be? Since we have `design.va.gov`, does something like `docs.va.gov` make sense?
 
 _For each question you should include any relevant information you know. For risks you should include estimates of likelihood, cost if they occur and ideas for possible workarounds._
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -2,11 +2,11 @@
 
 **Author(s):** Bill Fienberg <bill.fienberg@oddball.io>
 
-**Last Updated:** 2020-02-04
+**Last Updated:** 2020-02-10
 
 **Status:** **Draft**
 
-**Approvers:** Andrew G., Megan K., Rian F., VSP Ops
+**Approvers:** Andrew G., Megan K., Rian F., Wyatt W.
 
 ## Overview
 

--- a/products/platform/documentation-site/research/search-design-doc.md
+++ b/products/platform/documentation-site/research/search-design-doc.md
@@ -140,9 +140,11 @@ For the MVP, we will not be indexing private documentation sources.
 
 ### Code Location
 
-The search input and DocSearch JS snippet will live in the `docs/index.html` file inside the `va.gov-team` repo.
+The search input, JS snippet, and scraper config file will all live in the `va.gov-team` repo.
 
-The config file for the crawler (`config.json`) will also live inside inside the `va.gov-team` repo.
+The search input and DocSearch JS snippet will live in the `docs/index.html` file.
+
+The config file for the scraper will live in the `docs/docsearch-scraper-config.json`) file.
 
 ### Testing Plan
 
@@ -189,9 +191,19 @@ Algolia includes analytics, such as ["Most popular searches and results most oft
 
 ### Debugging
 
-The Docker image for the scraper is available on [Docker Hub](https://hub.docker.com/r/algolia/docsearch-scraper). Once we have a config file, we can [run the scraper locally](https://community.algolia.com/docsearch/run-your-own.html#run-the-crawl-from-the-docker-image).
-
 #### Debugging the scraper
+
+The Docker image for the scraper is available on [Docker Hub](https://hub.docker.com/r/algolia/docsearch-scraper). We can [run the scraper locally](https://community.algolia.com/docsearch/run-your-own.html#run-the-crawl-from-the-docker-image) with the config file, and a `.env` file containing the `APPLICATION_ID` and `API_KEY`.
+
+I've added a [sample `.env` file](.env.sample).
+
+If you don't have an `.env` file, you'll need to create one. If you do have an `.env` file, then you'll need to add/edit the `APPLICATION_ID` and `API_KEY` keys to include the corresponding values from the Algolia website.
+
+##### Dependencies to run `docsearch-scraper` locally
+
+- [Docker](https://docs.docker.com/install/).
+- [`docsearch-scraper` Docker image](https://hub.docker.com/r/algolia/docsearch-scraper)
+- [`jq`](https://github.com/stedolan/jq/wiki/Installation)
 
 #### Debugging the search functionality
 


### PR DESCRIPTION
**Status**: On Hold while we seek approval for Algolia

In December 2019, members of the Product Support, Content & IA, and Leadership team conducted a [discovery sprint about documentation](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/platform/documentation-site/research/discovery-sprint-12-2019). 

Here is the [product outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/platform/documentation-site/product-outline.md) and the [recommendation](https://docs.google.com/presentation/d/14eD-GJ5mBQXh1L9k5Lr83zbVV1iehp0a67qZz0Fn_94/edit#slide=id.p1) that came out of the discovery sprint.

This PR follows our [Design Doc template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/design-docs/design-doc-template.md) to seek feedback and approval for a solution to search multiple, public documentation sources with a single query from a single entry point. 