### PR TITLE
Add cms export documentation

### DIFF
--- a/products/cms-integration/best-practices.md
+++ b/products/cms-integration/best-practices.md
@@ -1,20 +1,16 @@
 
 # Table of Contents
 
-1.  [Best Practices](#orgffadb84)
-    1.  [Schema naming](#org3c7669a)
+1.  [Best Practices](#best-practices)
+    1.  [Schema naming](#schema-naming)
 
 
-
-<a id="orgffadb84"></a>
 
 # Best Practices
 
 Things tend to be a little easier with some established norms. This document
 attempts to gather those into one place.
 
-
-<a id="org3c7669a"></a>
 
 ## Schema naming
 

--- a/products/cms-integration/best-practices.md
+++ b/products/cms-integration/best-practices.md
@@ -1,0 +1,24 @@
+
+# Table of Contents
+
+1.  [Best Practices](#orgffadb84)
+    1.  [Schema naming](#org3c7669a)
+
+
+
+<a id="orgffadb84"></a>
+
+# Best Practices
+
+Things tend to be a little easier with some established norms. This document
+attempts to gather those into one place.
+
+
+<a id="org3c7669a"></a>
+
+## Schema naming
+
+For raw and transformed schemas, the `$id` is [added automatically](transformation-process.md), but for
+common schemas, it&rsquo;s best to add them manually. When doing so, **capitalize the
+schema name**.
+

--- a/products/cms-integration/best-practices.md
+++ b/products/cms-integration/best-practices.md
@@ -14,7 +14,7 @@ attempts to gather those into one place.
 
 ## Schema naming
 
-For raw and transformed schemas, the `$id` is [added automatically](transformation-process.md), but for
+For raw and transformed schemas, the `$id` is [added automatically](transformation-process.md#automatic-id), but for
 common schemas, it&rsquo;s best to add them manually. When doing so, **capitalize the
 schema name**.
 

--- a/products/cms-integration/best-practices.md
+++ b/products/cms-integration/best-practices.md
@@ -15,6 +15,6 @@ attempts to gather those into one place.
 ## Schema naming
 
 For raw and transformed schemas, the `$id` is [added automatically](transformation-process.md#automatic-id), but for
-common schemas, it&rsquo;s best to add them manually. When doing so, **capitalize the
+common schemas, it's best to add them manually. When doing so, **capitalize the
 schema name**.
 

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -1,25 +1,26 @@
 
 # Table of Contents
 
-1.  [Debugging Field Guide](#orgabae1eb)
-    1.  [JSON schema validation errors](#org10ab85f)
-        1.  [Solution](#orgf97a4c8)
-    2.  [Object doesn&rsquo;t deep equal object??](#org830b381)
-        1.  [Solution](#orgb85397c)
-    3.  [Transformer trouble](#org4eae7ce)
-    4.  [Handling circular references](#orge68be39)
-        1.  [Solution](#org924393b)
+1.  [Debugging Field Guide](#org2e3cfb5)
+    1.  [JSON schema validation errors](#orgae0b4b9)
+        1.  [Solution](#org322866b)
+    2.  [Object doesn&rsquo;t deep equal object??](#org9a505f1)
+        1.  [Solution](#org75ee4dd)
+    3.  [Handling circular references](#org3dd19b5)
+        1.  [Solution](#orgd30f084)
+    4.  [My transformer isn&rsquo;t receiving a property that exists in the raw content](#org65ea096)
+        1.  [Solution](#orgc5c9c05)
 
 
 
-<a id="orgabae1eb"></a>
+<a id="org2e3cfb5"></a>
 
 # Debugging Field Guide
 
 Oh no. Something broke, didn&rsquo;t it? Here, take this guide. I hope it helps.
 
 
-<a id="org10ab85f"></a>
+<a id="orgae0b4b9"></a>
 
 ## JSON schema validation errors
 
@@ -69,7 +70,7 @@ From this message we can see the following:
         sense
 
 
-<a id="orgf97a4c8"></a>
+<a id="org322866b"></a>
 
 ### Solution
 
@@ -81,17 +82,17 @@ to scroll up quite a ways to see the actual validation error output. Just look
 for the yellow / gold writing.
 
 
-<a id="org830b381"></a>
+<a id="org9a505f1"></a>
 
 ## Object doesn&rsquo;t deep equal object??
 
 Ideally, we&rsquo;d catch all the validation errors locally, but that won&rsquo;t always be
 the case. Unfortunately, the error output from Mocha is sometimes limited in
-Jenkins. As such, when the unit test encounters an error, it logs the entire test
-file and the output of the transformation for manual comparison.
+Jenkins. As such, when the unit test encounters an error, it logs the entire
+test file and the output of the transformation for manual comparison.
 
 
-<a id="orgb85397c"></a>
+<a id="org75ee4dd"></a>
 
 ### Solution
 
@@ -100,12 +101,7 @@ Open the full logs in Jenkins to find the error output. Search for
     Transformed entity in the test JSON file:
 
 
-<a id="org4eae7ce"></a>
-
-## TODO Transformer trouble
-
-
-<a id="orge68be39"></a>
+<a id="org3dd19b5"></a>
 
 ## Handling circular references
 
@@ -128,16 +124,35 @@ but sometimes this causes a circular reference. For example:
         }
     }
 
-If this happens, [AJV](https://github.com/epoberezkin/ajv), the underlying JSON schema validator, will fail with the
+If this happens, AJV, the underlying JSON schema validator, will fail with the
 following error:
 
     TypeError: Converting circular structure to JSON
 
 
-<a id="org924393b"></a>
+<a id="orgd30f084"></a>
 
 ### Solution
 
 Return only part of a content model. See [`node-vamc_operating_status_and_alerts`](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js#L18-L25)
 for an example. Once this is done, the [schema will need to be updated](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/schemas/transformed/node-vamc_operating_status_and_alerts.js#L23-L28) so it
 doesn&rsquo;t expect the missing pieces.
+
+
+<a id="org65ea096"></a>
+
+## My transformer isn&rsquo;t receiving a property that exists in the raw content
+
+You&rsquo;ve verified that the property *does* exist in the content model and it&rsquo;s
+present in the actual entity on file, but when you try to use it in the
+transformer, it just plain isn&rsquo;t there? Sounds like it needs to be added to the
+content model&rsquo;s `filter`.
+
+
+<a id="orgc5c9c05"></a>
+
+### Solution
+
+Make sure the content model&rsquo;s [`filter`](transformation-process.md) includes the property you want to use in
+the transformer.
+

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -137,6 +137,6 @@ content model's `filter`.
 
 ### Solution
 
-Make sure the content model's [`filter`](transformation-process.md) includes the property you want to use in
+Make sure the content model's [`filter`](transformation-process.md#filter) includes the property you want to use in
 the transformer.
 

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -87,7 +87,7 @@ for the yellow / gold writing.
 
 Ideally, we&rsquo;d catch all the validation errors locally, but that won&rsquo;t always be
 the case. Unfortunately, the error output from Mocha is sometimes limitted in
-Jenkins. As such, when the unit test encounter an error, it logs the entire test
+Jenkins. As such, when the unit test encounters an error, it logs the entire test
 file and the output of the transformation for manual comparison.
 
 
@@ -141,4 +141,3 @@ following error:
 Return only part of a content model. See [`node-vamc_operating_status_and_alerts`](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js#L18-L25)
 for an example. Once this is done, the [schema will need to be updated](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/schemas/transformed/node-vamc_operating_status_and_alerts.js#L23-L28) so it
 doesn&rsquo;t expect the missing pieces.
-

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -1,26 +1,21 @@
 
 # Table of Contents
 
-1.  [Debugging Field Guide](#org2e3cfb5)
-    1.  [JSON schema validation errors](#orgae0b4b9)
-        1.  [Solution](#org322866b)
-    2.  [Object doesn&rsquo;t deep equal object??](#org9a505f1)
-        1.  [Solution](#org75ee4dd)
-    3.  [Handling circular references](#org3dd19b5)
-        1.  [Solution](#orgd30f084)
-    4.  [My transformer isn&rsquo;t receiving a property that exists in the raw content](#org65ea096)
-        1.  [Solution](#orgc5c9c05)
+1.  [Debugging Field Guide](#debugging-field-guide)
+    1.  [JSON schema validation errors](#json-schema-validation-errors)
+        1.  [Solution](#solution)
+    2.  [Object doesn&rsquo;t deep equal object??](#object-doesnt-deep-equal-object)
+        1.  [Solution](#solution-1)
+    3.  [Handling circular references](#handling-circular-references)
+        1.  [Solution](#solution-2)
+    4.  [My transformer isn&rsquo;t receiving a property that exists in the raw content](#my-transformer-isnt-receiving-a-property-that-exists-in-the-raw-content)
+        1.  [Solution](#solution-3)
 
-
-
-<a id="org2e3cfb5"></a>
 
 # Debugging Field Guide
 
 Oh no. Something broke, didn&rsquo;t it? Here, take this guide. I hope it helps.
 
-
-<a id="orgae0b4b9"></a>
 
 ## JSON schema validation errors
 
@@ -70,8 +65,6 @@ From this message we can see the following:
         sense
 
 
-<a id="org322866b"></a>
-
 ### Solution
 
 Armed with this information, we can crack open the transformer and see what&rsquo;s
@@ -82,8 +75,6 @@ to scroll up quite a ways to see the actual validation error output. Just look
 for the yellow / gold writing.
 
 
-<a id="org9a505f1"></a>
-
 ## Object doesn&rsquo;t deep equal object??
 
 Ideally, we&rsquo;d catch all the validation errors locally, but that won&rsquo;t always be
@@ -92,16 +83,12 @@ Jenkins. As such, when the unit test encounters an error, it logs the entire
 test file and the output of the transformation for manual comparison.
 
 
-<a id="org75ee4dd"></a>
-
 ### Solution
 
 Open the full logs in Jenkins to find the error output. Search for
 
     Transformed entity in the test JSON file:
 
-
-<a id="org3dd19b5"></a>
 
 ## Handling circular references
 
@@ -130,8 +117,6 @@ following error:
     TypeError: Converting circular structure to JSON
 
 
-<a id="orgd30f084"></a>
-
 ### Solution
 
 Return only part of a content model. See [`node-vamc_operating_status_and_alerts`](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js#L18-L25)
@@ -139,7 +124,6 @@ for an example. Once this is done, the [schema will need to be updated](https://
 doesn&rsquo;t expect the missing pieces.
 
 
-<a id="org65ea096"></a>
 
 ## My transformer isn&rsquo;t receiving a property that exists in the raw content
 
@@ -148,8 +132,6 @@ present in the actual entity on file, but when you try to use it in the
 transformer, it just plain isn&rsquo;t there? Sounds like it needs to be added to the
 content model&rsquo;s `filter`.
 
-
-<a id="orgc5c9c05"></a>
 
 ### Solution
 

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -42,9 +42,9 @@ From this message we can see the following:
 -   Which content model it was
     -   `node-health_care_region_page`
 -   Which schema failed
-    -   &ldquo;invalid after transformation&rdquo; means the schema in question can be found in
+    -   "invalid after transformation" means the schema in question can be found in
         `schemas/transformed/node-health_care_region_page.js`
-    -   &ldquo;invalid before transformation&rdquo; would mean the schema could be found in
+    -   "invalid before transformation" would mean the schema could be found in
         `schemas/raw/node-health_care_region_page.js`
 -   The field that failed validation
     -   Look in the `dataPath`

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -86,7 +86,7 @@ for the yellow / gold writing.
 ## Object doesn&rsquo;t deep equal object??
 
 Ideally, we&rsquo;d catch all the validation errors locally, but that won&rsquo;t always be
-the case. Unfortunately, the error output from Mocha is sometimes limitted in
+the case. Unfortunately, the error output from Mocha is sometimes limited in
 Jenkins. As such, when the unit test encounters an error, it logs the entire test
 file and the output of the transformation for manual comparison.
 

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -4,17 +4,17 @@
 1.  [Debugging Field Guide](#debugging-field-guide)
     1.  [JSON schema validation errors](#json-schema-validation-errors)
         1.  [Solution](#solution)
-    2.  [Object doesn&rsquo;t deep equal object??](#object-doesnt-deep-equal-object)
+    2.  [Object doesn't deep equal object??](#object-doesnt-deep-equal-object)
         1.  [Solution](#solution-1)
     3.  [Handling circular references](#handling-circular-references)
         1.  [Solution](#solution-2)
-    4.  [My transformer isn&rsquo;t receiving a property that exists in the raw content](#my-transformer-isnt-receiving-a-property-that-exists-in-the-raw-content)
+    4.  [My transformer isn't receiving a property that exists in the raw content](#my-transformer-isnt-receiving-a-property-that-exists-in-the-raw-content)
         1.  [Solution](#solution-3)
 
 
 # Debugging Field Guide
 
-Oh no. Something broke, didn&rsquo;t it? Here, take this guide. I hope it helps.
+Oh no. Something broke, didn't it? Here, take this guide. I hope it helps.
 
 
 ## JSON schema validation errors
@@ -52,11 +52,11 @@ From this message we can see the following:
     -   `schemapath` tells us what rule it was, `params` tells us what the valid
         options were
         -   Technically, it tells us what the parameters were for that particular rule
-    -   In this case, we can see it was the `fieldLinkFacilityEmergList`&rsquo;s `type`
+    -   In this case, we can see it was the `fieldLinkFacilityEmergList`'s `type`
         which was supposed to be either an object or null
 -   The exact error message returned from [AJV](https://github.com/epoberezkin/ajv)
     -   Look in `message`
-    -   This is the easy way to figure out what the error was, but it&rsquo;s sometimes
+    -   This is the easy way to figure out what the error was, but it's sometimes
         still mystifying
 -   What the actual data was that failed the validation
     -   In this case, we can see `.entity.fieldLinkFacilityEmergList` was an empty
@@ -67,7 +67,7 @@ From this message we can see the following:
 
 ### Solution
 
-Armed with this information, we can crack open the transformer and see what&rsquo;s
+Armed with this information, we can crack open the transformer and see what's
 going on.
 
 **Note:** If a validation error occurs while running the unit tests, you may have
@@ -75,9 +75,9 @@ to scroll up quite a ways to see the actual validation error output. Just look
 for the yellow / gold writing.
 
 
-## Object doesn&rsquo;t deep equal object??
+## Object doesn't deep equal object??
 
-Ideally, we&rsquo;d catch all the validation errors locally, but that won&rsquo;t always be
+Ideally, we'd catch all the validation errors locally, but that won't always be
 the case. Unfortunately, the error output from Mocha is sometimes limited in
 Jenkins. As such, when the unit test encounters an error, it logs the entire
 test file and the output of the transformation for manual comparison.
@@ -92,7 +92,7 @@ Open the full logs in Jenkins to find the error output. Search for
 
 ## Handling circular references
 
-Typically, it&rsquo;s best to leave child entities alone in the parent transformer,
+Typically, it's best to leave child entities alone in the parent transformer,
 but sometimes this causes a circular reference. For example:
 
     {
@@ -121,20 +121,20 @@ following error:
 
 Return only part of a content model. See [`node-vamc_operating_status_and_alerts`](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js#L18-L25)
 for an example. Once this is done, the [schema will need to be updated](https://github.com/department-of-veterans-affairs/vets-website/blob/5015d231a1391c542b2bd4637500afd6296cc649/src/site/stages/build/process-cms-exports/schemas/transformed/node-vamc_operating_status_and_alerts.js#L23-L28) so it
-doesn&rsquo;t expect the missing pieces.
+doesn't expect the missing pieces.
 
 
 
-## My transformer isn&rsquo;t receiving a property that exists in the raw content
+## My transformer isn't receiving a property that exists in the raw content
 
-You&rsquo;ve verified that the property *does* exist in the content model and it&rsquo;s
+You've verified that the property *does* exist in the content model and it's
 present in the actual entity on file, but when you try to use it in the
-transformer, it just plain isn&rsquo;t there? Sounds like it needs to be added to the
-content model&rsquo;s `filter`.
+transformer, it just plain isn't there? Sounds like it needs to be added to the
+content model's `filter`.
 
 
 ### Solution
 
-Make sure the content model&rsquo;s [`filter`](transformation-process.md) includes the property you want to use in
+Make sure the content model's [`filter`](transformation-process.md) includes the property you want to use in
 the transformer.
 

--- a/products/cms-integration/debugging-field-guide.md
+++ b/products/cms-integration/debugging-field-guide.md
@@ -95,6 +95,7 @@ Open the full logs in Jenkins to find the error output. Search for
 Typically, it's best to leave child entities alone in the parent transformer,
 but sometimes this causes a circular reference. For example:
 
+```json
     {
         "$id": "Foo",
         "type": "object",
@@ -110,6 +111,7 @@ but sometimes this causes a circular reference. For example:
             "fooChild": { "$ref": "Foo" }
         }
     }
+```
 
 If this happens, AJV, the underlying JSON schema validator, will fail with the
 following error:

--- a/products/cms-integration/overview.md
+++ b/products/cms-integration/overview.md
@@ -1,0 +1,95 @@
+
+# Table of Contents
+
+1.  [CMS Export Content Model Transformation Overview](#org452f1e3)
+    1.  [Purpose](#orga07c918)
+    2.  [10,000ft view](#orgaf4354e)
+    3.  [Adding a new content model](#org77f88f4)
+    4.  [Zooming in](#orgacd6399)
+    5.  [Debugging](#org68c9208)
+    6.  [Best practices](#orgc3b70c7)
+
+
+
+<a id="org452f1e3"></a>
+
+# CMS Export Content Model Transformation Overview
+
+That&rsquo;s a mouthful, isn&rsquo;t it?
+
+
+<a id="orga07c918"></a>
+
+## Purpose
+
+To outline how content gets from the CMS to static HTML files.
+
+
+<a id="orgaf4354e"></a>
+
+## 10,000ft view
+
+New content begins its life in the CMS. When it grows up, it gets published.
+That process is out of scope for this document. We start our story after content
+is published.
+
+The Drupal CMS will bundle the CMS export into a tarball and make it available to
+the build script for processing.
+
+When the content build is run, it does a lot of things. The steps that are
+pertinent to this document are:
+
+1.  Pulling the CMS export tarball
+2.  Transforming the content from the CMS export content models to the template
+    content models
+3.  Applying the content models to the templates to generate static HTML
+
+
+<a id="org77f88f4"></a>
+
+## Adding a new content model
+
+When adding a new content model, you&rsquo;ll need to add a handful of new files to
+`src/site/stages/build/process-cms-exports/`:
+
+-   Pre-transformation (raw) schema
+    -   Found in `schemas/raw/`
+-   Post-transformation schema
+    -   Found in `schemas/transformed/`
+-   Transformer
+    -   Found in `transformers/`
+-   Pre-transformation test entity
+    -   And all child entities
+    -   These go in `tests/entities/`
+    -   A new entry will have to be added to `tests/entities/index.js` to associate
+        this new test file with the new content model
+-   Post-transformation test entity
+    -   These go in `tests/transformed-entities/`
+
+The transformer is the workhorse. Everything else is there to ensure it all
+works together as expected. For more information on what each of these pieces
+are, see [Transformation Process](transformation-process.md).
+
+
+<a id="orgacd6399"></a>
+
+## Zooming in
+
+To dig deeper into how content is transformed from the CMS export content models
+to the template content models (and what that even means), see [Transformation Process](transformation-process.md).
+
+
+<a id="org68c9208"></a>
+
+## Debugging
+
+See the [Debugging Field Guide](debugging-field-guide.md) for a reference manual on how to debug transformer
+issues in the wild.
+
+
+<a id="orgc3b70c7"></a>
+
+## Best practices
+
+See [Best Practices](best-practices.md).
+

--- a/products/cms-integration/overview.md
+++ b/products/cms-integration/overview.md
@@ -1,31 +1,30 @@
 
 # Table of Contents
 
-1.  [CMS Export Content Model Transformation Overview](#org452f1e3)
-    1.  [Purpose](#orga07c918)
-    2.  [10,000ft view](#orgaf4354e)
-    3.  [Adding a new content model](#org77f88f4)
-    4.  [Zooming in](#orgacd6399)
-    5.  [Debugging](#org68c9208)
-    6.  [Best practices](#orgc3b70c7)
+1.  [CMS Export Content Model Transformation Overview](#org295a7ae)
+    1.  [Purpose](#orgb35279e)
+    2.  [10,000ft view](#org6b062b2)
+    3.  [Adding a new content model](#orgab7f362)
+    4.  [Debugging](#org6571ded)
+    5.  [Best practices](#org8861206)
 
 
 
-<a id="org452f1e3"></a>
+<a id="org295a7ae"></a>
 
 # CMS Export Content Model Transformation Overview
 
 That&rsquo;s a mouthful, isn&rsquo;t it?
 
 
-<a id="orga07c918"></a>
+<a id="orgb35279e"></a>
 
 ## Purpose
 
 To outline how content gets from the CMS to static HTML files.
 
 
-<a id="orgaf4354e"></a>
+<a id="org6b062b2"></a>
 
 ## 10,000ft view
 
@@ -40,24 +39,34 @@ When the content build is run, it does a lot of things. The steps that are
 pertinent to this document are:
 
 1.  Pulling the CMS export tarball
-2.  Transforming the CMS export content models to the template
-    content models
+2.  Transforming the CMS export content models to the template content models
 3.  Applying the content models to the templates to generate static HTML
 
 
-<a id="org77f88f4"></a>
+<a id="orgab7f362"></a>
 
 ## Adding a new content model
 
-When adding a new content model, you&rsquo;ll need to add a handful of new files to
+The transformer is the workhorse. Everything else is there to ensure it all
+works together as expected. For more information on what each of these pieces
+are, see [Transformation Process](transformation-process.md).
+
+When adding a new content model, you&rsquo;ll need to add the following files to
 `src/site/stages/build/process-cms-exports/`:
 
--   Pre-transformation (raw) schema
+-   [Pre-transformation (raw) schema](transformation-process.md)
     -   Found in `schemas/raw/`
--   Post-transformation schema
-    -   Found in `schemas/transformed/`
--   Transformer
+    -   Validates the [content from the CMS](transformation-process.md)
+-   [Filters](transformation-process.md)
+    -   Found in `transformers/` with the transformers
+    -   Ensures [entity expansion](transformation-process.md) doesn&rsquo;t read a bunch of entities that won&rsquo;t end up
+        in the transformed content
+-   [Transformer](transformation-process.md)
     -   Found in `transformers/`
+    -   Takes the content from the CMS and transforms it into the shape expected in
+        the [Liquid templates](transformation-process.md)
+-   [Post-transformation schema](transformation-process.md)
+    -   Found in `schemas/transformed/`
 -   Pre-transformation test entity
     -   And all child entities
     -   These go in `tests/entities/`
@@ -66,20 +75,13 @@ When adding a new content model, you&rsquo;ll need to add a handful of new files
 -   Post-transformation test entity
     -   These go in `tests/transformed-entities/`
 
-The transformer is the workhorse. Everything else is there to ensure it all
-works together as expected. For more information on what each of these pieces
-are, see [Transformation Process](transformation-process.md).
+Once you&rsquo;ve added all those files and wrote your transformer to do what you want
+it to, be sure to run the tests to catch any unexpected failures:
+
+    yarn test:unit src/site/stages/build/process-cms-exports/tests/
 
 
-<a id="orgacd6399"></a>
-
-## Zooming in
-
-To dig deeper into how content is transformed from the CMS export content models
-to the template content models (and what that even means), see [Transformation Process](transformation-process.md).
-
-
-<a id="org68c9208"></a>
+<a id="org6571ded"></a>
 
 ## Debugging
 
@@ -87,8 +89,9 @@ See the [Debugging Field Guide](debugging-field-guide.md) for a reference manual
 issues in the wild.
 
 
-<a id="orgc3b70c7"></a>
+<a id="org8861206"></a>
 
 ## Best practices
 
 See [Best Practices](best-practices.md).
+

--- a/products/cms-integration/overview.md
+++ b/products/cms-integration/overview.md
@@ -11,7 +11,7 @@
 
 # CMS Export Content Model Transformation Overview
 
-That&rsquo;s a mouthful, isn&rsquo;t it?
+That's a mouthful, isn't it?
 
 
 ## Purpose
@@ -42,7 +42,7 @@ The transformer is the workhorse. Everything else is there to ensure it all
 works together as expected. For more information on what each of these pieces
 are, see [Transformation Process](transformation-process.md).
 
-When adding a new content model, you&rsquo;ll need to add the following files to
+When adding a new content model, you'll need to add the following files to
 `src/site/stages/build/process-cms-exports/`:
 
 -   [Pre-transformation (raw) schema](transformation-process.md)
@@ -50,7 +50,7 @@ When adding a new content model, you&rsquo;ll need to add the following files to
     -   Validates the [content from the CMS](transformation-process.md)
 -   [Filters](transformation-process.md)
     -   Found in `transformers/` with the transformers
-    -   Ensures [entity expansion](transformation-process.md) doesn&rsquo;t read a bunch of entities that won&rsquo;t end up
+    -   Ensures [entity expansion](transformation-process.md) doesn't read a bunch of entities that won't end up
         in the transformed content
 -   [Transformer](transformation-process.md)
     -   Found in `transformers/`
@@ -66,7 +66,7 @@ When adding a new content model, you&rsquo;ll need to add the following files to
 -   Post-transformation test entity
     -   These go in `tests/transformed-entities/`
 
-Once you&rsquo;ve added all those files and wrote your transformer to do what you want
+Once you've added all those files and wrote your transformer to do what you want
 it to, be sure to run the tests to catch any unexpected failures:
 
     yarn test:unit src/site/stages/build/process-cms-exports/tests/

--- a/products/cms-integration/overview.md
+++ b/products/cms-integration/overview.md
@@ -40,7 +40,7 @@ When the content build is run, it does a lot of things. The steps that are
 pertinent to this document are:
 
 1.  Pulling the CMS export tarball
-2.  Transforming the content from the CMS export content models to the template
+2.  Transforming the CMS export content models to the template
     content models
 3.  Applying the content models to the templates to generate static HTML
 
@@ -92,4 +92,3 @@ issues in the wild.
 ## Best practices
 
 See [Best Practices](best-practices.md).
-

--- a/products/cms-integration/overview.md
+++ b/products/cms-integration/overview.md
@@ -45,18 +45,18 @@ are, see [Transformation Process](transformation-process.md).
 When adding a new content model, you'll need to add the following files to
 `src/site/stages/build/process-cms-exports/`:
 
--   [Pre-transformation (raw) schema](transformation-process.md)
+-   [Pre-transformation (raw) schema](transformation-process.md#pre-transformation-json-schema)
     -   Found in `schemas/raw/`
-    -   Validates the [content from the CMS](transformation-process.md)
--   [Filters](transformation-process.md)
+    -   Validates the [content from the CMS](transformation-process.md#cms-export-tarball)
+-   [Filters](transformation-process.md#filter)
     -   Found in `transformers/` with the transformers
-    -   Ensures [entity expansion](transformation-process.md) doesn't read a bunch of entities that won't end up
+    -   Ensures [entity expansion](transformation-process.md#entity-expansion) doesn't read a bunch of entities that won't end up
         in the transformed content
--   [Transformer](transformation-process.md)
+-   [Transformer](transformation-process.md#transformer)
     -   Found in `transformers/`
     -   Takes the content from the CMS and transforms it into the shape expected in
-        the [Liquid templates](transformation-process.md)
--   [Post-transformation schema](transformation-process.md)
+        the [Liquid templates](transformation-process.md#liquid-templates)
+-   [Post-transformation schema](transformation-process.md#pre-transformation-json-schema)
     -   Found in `schemas/transformed/`
 -   Pre-transformation test entity
     -   And all child entities

--- a/products/cms-integration/overview.md
+++ b/products/cms-integration/overview.md
@@ -1,30 +1,23 @@
 
 # Table of Contents
 
-1.  [CMS Export Content Model Transformation Overview](#org295a7ae)
-    1.  [Purpose](#orgb35279e)
-    2.  [10,000ft view](#org6b062b2)
-    3.  [Adding a new content model](#orgab7f362)
-    4.  [Debugging](#org6571ded)
-    5.  [Best practices](#org8861206)
+1.  [CMS Export Content Model Transformation Overview](#cms-export-content-model-transformation-overview)
+    1.  [Purpose](#purpose)
+    2.  [10,000ft view](#10000ft-view)
+    3.  [Adding a new content model](#adding-a-new-content-model)
+    4.  [Debugging](#debugging)
+    5.  [Best practices](#best-practices)
 
-
-
-<a id="org295a7ae"></a>
 
 # CMS Export Content Model Transformation Overview
 
 That&rsquo;s a mouthful, isn&rsquo;t it?
 
 
-<a id="orgb35279e"></a>
-
 ## Purpose
 
 To outline how content gets from the CMS to static HTML files.
 
-
-<a id="org6b062b2"></a>
 
 ## 10,000ft view
 
@@ -42,8 +35,6 @@ pertinent to this document are:
 2.  Transforming the CMS export content models to the template content models
 3.  Applying the content models to the templates to generate static HTML
 
-
-<a id="orgab7f362"></a>
 
 ## Adding a new content model
 
@@ -81,15 +72,11 @@ it to, be sure to run the tests to catch any unexpected failures:
     yarn test:unit src/site/stages/build/process-cms-exports/tests/
 
 
-<a id="org6571ded"></a>
-
 ## Debugging
 
 See the [Debugging Field Guide](debugging-field-guide.md) for a reference manual on how to debug transformer
 issues in the wild.
 
-
-<a id="org8861206"></a>
 
 ## Best practices
 

--- a/products/cms-integration/transformation-process.md
+++ b/products/cms-integration/transformation-process.md
@@ -27,17 +27,17 @@
 
 # Transformation Process
 
-So you want to take a peek under the hood, eh? Please, step inside. I&rsquo;ll show
+So you want to take a peek under the hood, eh? Please, step inside. I'll show
 you how it works.
 
 
 ## The actors
 
 The goal of the whole transformer system is to change all the content models
-from one shape to another. In the end, it&rsquo;s just inputs (raw content), process
+from one shape to another. In the end, it's just inputs (raw content), process
 (the transformers), and outputs (transformed content).
 
-Before we talk about how it all works, let&rsquo;s get some shared terminology first.
+Before we talk about how it all works, let's get some shared terminology first.
 
 
 ### Content model name
@@ -87,9 +87,9 @@ The JSON objects in of each of these files should match exactly one [pre-transfo
 
 ### Filter
 
-Filters are found in as a named export in a content model&rsquo;s [`transformer` file](#content-model-transformers).
-They&rsquo;re used to filter out properties in the [raw content](#raw-content) before [entity expansion](#entity-expansion)
-so it doesn&rsquo;t read more files than necessary.
+Filters are found in as a named export in a content model's [`transformer` file](#content-model-transformers).
+They're used to filter out properties in the [raw content](#raw-content) before [entity expansion](#entity-expansion)
+so it doesn't read more files than necessary.
 
 
 ### Transformer
@@ -102,7 +102,7 @@ using the content in the [templates](#liquid-templates).
 ### Transformed content
 
 The [transformer](#transformer), converts raw content into transformed content. The resulting
-data structure must match the content model&rsquo;s [post-transformation JSON schema](#post-transformation-json-schema)
+data structure must match the content model's [post-transformation JSON schema](#post-transformation-json-schema)
 and is what will be used in the [templates](#liquid-templates).
 
 
@@ -112,7 +112,7 @@ The final step before content is translated from an abstract content model to
 full-fledged HTML files, the liquid templates are used to couch the content in
 the necessary trappings of HTML.
 
-For more information on the Liquid template language, see [Shopify&rsquo;s
+For more information on the Liquid template language, see [Shopify's
 documentation](https://shopify.github.io/liquid/).
 
 
@@ -129,7 +129,7 @@ the pipeline. A high-level overview looks something like this:
     -   Certain properties will be kept based on the [filters](#filter) provided for the
         content model type
     -   The remaining properties will be scoured for references to other entities
-        -   If found, it&rsquo;ll recurse with those new entities, [expanding](#entity-expansion) the child
+        -   If found, it'll recurse with those new entities, [expanding](#entity-expansion) the child
             references
     -   The [transformer](#content-model-transformers) for the content model is run on the data
     -   The newly-transformed data is validated against the [post-transformation JSON
@@ -218,8 +218,8 @@ it against a post-transformation JSON schema found in
 `src/site/stages/build/process-cms-exports/schemas/transformed/` to ensure
 nothing unexpected happened during transformation.
 
-These schemas are also **useful for debugging** what&rsquo;s going on in the templates
-(see below). If you know what content model you&rsquo;re working with in a given
+These schemas are also **useful for debugging** what's going on in the templates
+(see below). If you know what content model you're working with in a given
 template, you can look at the schema to see what data you have access to and
 what shape it takes.
 
@@ -250,7 +250,7 @@ The unit test will:
 
 ## Digging deep
 
-There&rsquo;s some magic hidden behind the scenes to make adding new content models as
+There's some magic hidden behind the scenes to make adding new content models as
 easy as possible.
 
 

--- a/products/cms-integration/transformation-process.md
+++ b/products/cms-integration/transformation-process.md
@@ -228,7 +228,7 @@ easy as possible.
 ### Automatic schema imports
 
 Files in the three schemas directories are imported and used intelligently in
-[schema-validator.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/schema-validation.js).
+[schema-validation.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/schema-validation.js).
 
 
 <a id="orga2b24c5"></a>
@@ -252,4 +252,3 @@ See [Structuring a complex schema](https://json-schema.org/understanding-json-sc
 
 See the [Debugging Field Guide](debugging-field-guide.md) for a reference manual on how to debug transformer
 issues in the wild.
-

--- a/products/cms-integration/transformation-process.md
+++ b/products/cms-integration/transformation-process.md
@@ -1,37 +1,40 @@
 
 # Table of Contents
 
-1.  [Transformation Process](#org6b499b3)
-    1.  [The actors](#org70bbb4e)
-        1.  [Content models](#orgd9cac48)
-        2.  [Raw content](#orgb12cb7b)
-        3.  [Transformed content](#org07d25fc)
-        4.  [Transformer](#org3a44eb7)
-        5.  [Liquid templates](#org187853e)
-    2.  [The process](#org48df923)
-        1.  [Metalsmith pipeline](#org0b02218)
-        2.  [CMS export tarball](#org458259d)
-        3.  [Pre-transformation JSON schema](#org187b1ae)
-        4.  [Content model transformers](#orgf314d86)
-        5.  [Post-transformation JSON](#org0fada70)
-        6.  [Liquid templates](#orgf5df85e)
-    3.  [Testing](#org3becc44)
-    4.  [Digging deep](#orgc84a542)
-        1.  [Automatic schema imports](#orgd8989fc)
-        2.  [Automatic `$id`](#orga2b24c5)
-    5.  [Debugging](#orgc67539d)
+1.  [Transformation Process](#org3d51180)
+    1.  [The actors](#org742210c)
+        1.  [Content model name](#org5d30ede)
+        2.  [Content model](#org0c2b21d)
+        3.  [Raw content](#org28b6201)
+        4.  [Filter](#orga60e353)
+        5.  [Transformer](#org2c9bdf4)
+        6.  [Transformed content](#orgb2e5ea4)
+        7.  [Liquid templates](#org6f052af)
+    2.  [The process](#orga5401ec)
+        1.  [Metalsmith pipeline](#orgf0c5512)
+        2.  [CMS export tarball](#orgffc87ba)
+        3.  [Pre-transformation JSON schema](#orgd4903ba)
+        4.  [Entity expansion](#orgf48d43f)
+        5.  [Content model transformers](#org0b354f8)
+        6.  [Post-transformation JSON schema](#org2a89c43)
+        7.  [Liquid templates](#org5a3177e)
+    3.  [Testing](#org43964c1)
+    4.  [Digging deep](#org6a46c23)
+        1.  [Automatic schema imports](#org8ff8e44)
+        2.  [Automatic `$id`](#orgfdcff70)
+    5.  [Debugging](#orgd20bc34)
 
 
 
-<a id="org6b499b3"></a>
+<a id="org3d51180"></a>
 
 # Transformation Process
 
-So you want to learn some black magic, eh? Please, step inside. I&rsquo;ll show you
-how the sausage is made.
+So you want to take a peek under the hood, eh? Please, step inside. I&rsquo;ll show
+you how it works.
 
 
-<a id="org70bbb4e"></a>
+<a id="org742210c"></a>
 
 ## The actors
 
@@ -42,9 +45,9 @@ from one shape to another. In the end, it&rsquo;s just inputs (raw content), pro
 Before we talk about how it all works, let&rsquo;s get some shared terminology first.
 
 
-<a id="orgd9cac48"></a>
+<a id="org5d30ede"></a>
 
-### Content models
+### Content model name
 
 A content model has a two-part name, for the purposes of this integration:
 
@@ -53,7 +56,7 @@ A content model has a two-part name, for the purposes of this integration:
 
 The **base type** is found in the first part of the name of the file in the CMS
 export content directory. For a `node.<UUID>.json` file, its base type is
-`node`. See the section [Raw content](#orgb12cb7b) below for context.
+`node`. See the section [Raw content](#org28b6201) below for context.
 
 The **sub type** is found *inside* the entity, usually in its `type[0].target_id`
 property.
@@ -62,7 +65,22 @@ To get the full name, simply separate them with a hyphen. Examples include
 `node-page` and `paragraph-q_a_section`.
 
 
-<a id="orgb12cb7b"></a>
+<a id="org0c2b21d"></a>
+
+### Content model
+
+Each content model name applies to two separate content models (shapes for the
+data):
+
+-   Raw content model
+    -   The shape of the entity fresh from the [CMS export tarball](#orgffc87ba)
+    -   The [pre-transformation JSON schema](#orgd4903ba) says what this model actually is
+-   Transformed content model
+    -   The shape of the entity after it passes through the [transformer](#org2c9bdf4)
+    -   The [post-transformation JSON schema](#org2a89c43) says what this model actually is
+
+
+<a id="org28b6201"></a>
 
 ### Raw content
 
@@ -74,25 +92,38 @@ one for now.
 Each file is named like `node.<UUID>.json` where `<UUID>` is the UUID of the
 entity.
 
-
-<a id="org07d25fc"></a>
-
-### Transformed content
-
-After content has run through a [transformer](#org3a44eb7), we call it `transformed content`.
-The resulting data structure is what will be used in the [templates](#org187853e).
+The JSON objects in of each of these files should match exactly one [pre-transformation JSON schema](#orgd4903ba) which determines which raw content model it is
+(and subsequently which transformer should be used on it).
 
 
-<a id="org3a44eb7"></a>
+<a id="orga60e353"></a>
+
+### Filter
+
+Filters are found in as a named export in a content model&rsquo;s [`transformer` file](#org0b354f8).
+They&rsquo;re used to filter out properties in the [raw content](#org28b6201) before [entity expansion](#orgf48d43f)
+so it doesn&rsquo;t read more files than necessary.
+
+
+<a id="org2c9bdf4"></a>
 
 ### Transformer
 
 When you boil down a transformer, all you find is a function that takes an
 object and returns an object. The purpose behind the transformer is to simplify
-using the content in the [templates](#org187853e).
+using the content in the [templates](#org6f052af).
 
 
-<a id="org187853e"></a>
+<a id="orgb2e5ea4"></a>
+
+### Transformed content
+
+The [transformer](#org2c9bdf4), converts raw content into transformed content. The resulting
+data structure must match the content model&rsquo;s [post-transformation JSON schema](#org2a89c43)
+and is what will be used in the [templates](#org6f052af).
+
+
+<a id="org6f052af"></a>
 
 ### Liquid templates
 
@@ -104,26 +135,38 @@ For more information on the Liquid template language, see [Shopify&rsquo;s
 documentation](https://shopify.github.io/liquid/).
 
 
-<a id="org48df923"></a>
+<a id="orga5401ec"></a>
 
 ## The process
 
-Our content&rsquo;s story begins in the gritty metropolis of Metalsmith Pipes, travels
-over the stern Validation Mountains, down into the Vale of the Transformers for
-a life-altering experience, and through the exacting JSON Schema Forest before
-passing through the murky waters of the Liquid Template Lake to come out the
-other side no more a mere collection of abstract content models, but concrete
-HTML files.
+Building the content is a step-by-step process which uses Metalsmith to manage
+the pipeline. A high-level overview looks something like this:
+
+-   CMS export is fetched and untarred
+-   All `node` entities are fed into the entity tree assembler function
+-   The following will be performed on each `node`
+    -   The content model type (name) will be determined
+    -   The entity will be validated against [pre-transformation JSON schema](#orgd4903ba)
+    -   Certain properties will be kept based on the [filters](#orga60e353) provided for the
+        content model type
+    -   The remaining properties will be scoured for references to other entities
+        -   If found, it&rsquo;ll recurse with those new entities, [expanding](#orgf48d43f) the child
+            references
+    -   The [transformer](#org0b354f8) for the content model is run on the data
+    -   The newly-transformed data is validated against the [post-transformation JSON
+        schema](#org2a89c43)
+    -   Finally, the transformed content will be applied to a [liquid template](#org6f052af) to be
+        transmogrified into HTML
 
 
-<a id="org0b02218"></a>
+<a id="orgf0c5512"></a>
 
 ### Metalsmith pipeline
 
 A content build is kicked off by a node script: `yarn build --pull-drupal`
 
-This script is responsible for a lot of things, but for now, the important parts
-are:
+This script is responsible for a lot of things, but for now, **the important
+parts** are:
 
 1.  Pulling the CMS export tarball
 2.  Running the content through the validation and transformation process
@@ -131,26 +174,29 @@ are:
     static HTML
 
 
-<a id="org458259d"></a>
+<a id="orgffc87ba"></a>
 
 ### CMS export tarball
 
 Before we can *do* anything with the content, we need to actually fetch the
 latest.
 
+TODO: Once we know where the tarball will live after the CMS bundles the export
+up, this section should say where the build fetches that tarball from.
 
-<a id="org187b1ae"></a>
+
+<a id="orgd4903ba"></a>
 
 ### Pre-transformation JSON schema
 
-To ensure the content model from the CMS matches what the transformer expects in
-the next step, we check every untransformed (raw) entity we get from the CMS
+To ensure the **content model from the CMS** matches what the transformer expects in
+the next step, we **check every untransformed (raw) entity** we get from the CMS
 against a JSON schema. This is the first line of defense when content models get
 updated.
 
 Pre-transformation (raw) schemas can be found in
-`src/site/stages/build/process-cms-exports/schemas/raw/`. Each file in this
-directory is named after the content model it validates (e.g. `node-page.js`).
+`src/site/stages/build/process-cms-exports/schemas/raw/`. **Each file in this
+directory is named after the content model it validates** (e.g. `node-page.js`).
 Schemas from the `/process-cms-exports/schemas/common/` directory are used
 heavily in these schemas for readability.
 
@@ -158,50 +204,74 @@ See [json-schema.org](https://json-schema.org/understanding-json-schema/) for a 
 schema.
 
 
-<a id="orgf314d86"></a>
+<a id="orgf48d43f"></a>
+
+### Entity expansion
+
+When the raw content for an entity contains a **reference to another entity**, the
+entity tree assembler will **read the entity file and recurse**.
+
+An entity reference is a property that looks like the following:
+
+    "this_field_contains_a_child_entity": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "<UUID>"
+        }
+    ]
+
+The assembler will know to read the CMS export file with the name
+`paragraph.<UUID>.json`.
+
+**Note:** Because entity expansion happens recursively **before the transformer**,
+all child entities will be fully expanded and transformed by the time the data
+is passed to the transformer.
+
+
+<a id="org0b354f8"></a>
 
 ### Content model transformers
 
-By performing some basic data transformations, we can take the raw data and mold
-it into a shape that the templates expect.
+By performing some basic data transformations, we can take the raw data and **mold
+it into a shape that the [templates](#org6f052af) expect**.
 
 Transformers can be found in
-`src/site/stages/build/process-cms-exports/transformers/`. Each file in this
-directory is named after the content model it transforms (e.g. `node-page.js`).
+`src/site/stages/build/process-cms-exports/transformers/`. **Each file in this
+directory is named after the content model it transforms** (e.g. `node-page.js`).
 Common functions from `transformers/helpers.js` are used heavily in these
 transformers for readability and consistency.
 
 
-<a id="org0fada70"></a>
+<a id="org2a89c43"></a>
 
-### Post-transformation JSON
+### Post-transformation JSON schema
 
-After the content has been transformed, we&rsquo;ll validate it against a
-post-transformation JSON schema found in
+After the content has been transformed, the entity tree assembler will validate
+it against a post-transformation JSON schema found in
 `src/site/stages/build/process-cms-exports/schemas/transformed/` to ensure
 nothing unexpected happened during transformation.
 
-These schemas are also useful for debugging what&rsquo;s going on in the templates
+These schemas are also **useful for debugging** what&rsquo;s going on in the templates
 (see below). If you know what content model you&rsquo;re working with in a given
 template, you can look at the schema to see what data you have access to and
 what shape it takes.
 
 
-<a id="orgf5df85e"></a>
+<a id="org5a3177e"></a>
 
 ### Liquid templates
 
 This is where the magic happens. In the end, the content models are applied to
-various templates to generate the static HTML. This happens after the content
+various templates to **generate the static HTML**. This happens after the content
 model transformation in a separate Metalsmith step.
 
 
-<a id="org3becc44"></a>
+<a id="org43964c1"></a>
 
 ## Testing
 
 Testing the transformers is designed to be as straightforward as possible by
-automatically ensuring that each new transformer is tested without any extra
+**automatically ensuring that each new transformer is tested** without any extra
 wiring needed.
 
 The unit test will:
@@ -215,7 +285,7 @@ The unit test will:
     matches the entry in `tests/transformed-entitites/`
 
 
-<a id="orgc84a542"></a>
+<a id="org6a46c23"></a>
 
 ## Digging deep
 
@@ -223,20 +293,20 @@ There&rsquo;s some magic hidden behind the scenes to make adding new content mod
 easy as possible.
 
 
-<a id="orgd8989fc"></a>
+<a id="org8ff8e44"></a>
 
 ### Automatic schema imports
 
-Files in the three schemas directories are imported and used intelligently in
+Files in the **three schemas directories** are imported and used intelligently in
 [schema-validation.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/schema-validation.js).
 
 
-<a id="orga2b24c5"></a>
+<a id="orgfdcff70"></a>
 
 ### Automatic `$id`
 
 Schemas can be referenced in other schemas by their `$id`. For schemas which
-have no explicit `$id`, [validator.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/validator.js) automatically adds one, prefixed with the
+have no explicit `$id`, **[validator.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/validator.js) automatically adds one**, prefixed with the
 directory name. This allows us to re-use the schema for children of an entity
 with `$ref`.
 
@@ -246,9 +316,10 @@ See [Structuring a complex schema](https://json-schema.org/understanding-json-sc
 `$ref`.
 
 
-<a id="orgc67539d"></a>
+<a id="orgd20bc34"></a>
 
 ## Debugging
 
 See the [Debugging Field Guide](debugging-field-guide.md) for a reference manual on how to debug transformer
 issues in the wild.
+

--- a/products/cms-integration/transformation-process.md
+++ b/products/cms-integration/transformation-process.md
@@ -1,0 +1,255 @@
+
+# Table of Contents
+
+1.  [Transformation Process](#org6b499b3)
+    1.  [The actors](#org70bbb4e)
+        1.  [Content models](#orgd9cac48)
+        2.  [Raw content](#orgb12cb7b)
+        3.  [Transformed content](#org07d25fc)
+        4.  [Transformer](#org3a44eb7)
+        5.  [Liquid templates](#org187853e)
+    2.  [The process](#org48df923)
+        1.  [Metalsmith pipeline](#org0b02218)
+        2.  [CMS export tarball](#org458259d)
+        3.  [Pre-transformation JSON schema](#org187b1ae)
+        4.  [Content model transformers](#orgf314d86)
+        5.  [Post-transformation JSON](#org0fada70)
+        6.  [Liquid templates](#orgf5df85e)
+    3.  [Testing](#org3becc44)
+    4.  [Digging deep](#orgc84a542)
+        1.  [Automatic schema imports](#orgd8989fc)
+        2.  [Automatic `$id`](#orga2b24c5)
+    5.  [Debugging](#orgc67539d)
+
+
+
+<a id="org6b499b3"></a>
+
+# Transformation Process
+
+So you want to learn some black magic, eh? Please, step inside. I&rsquo;ll show you
+how the sausage is made.
+
+
+<a id="org70bbb4e"></a>
+
+## The actors
+
+The goal of the whole transformer system is to change all the content models
+from one shape to another. In the end, it&rsquo;s just inputs (raw content), process
+(the transformers), and outputs (transformed content).
+
+Before we talk about how it all works, let&rsquo;s get some shared terminology first.
+
+
+<a id="orgd9cac48"></a>
+
+### Content models
+
+A content model has a two-part name, for the purposes of this integration:
+
+1.  A base type
+2.  A sub type
+
+The **base type** is found in the first part of the name of the file in the CMS
+export content directory. For a `node.<UUID>.json` file, its base type is
+`node`. See the section [Raw content](#orgb12cb7b) below for context.
+
+The **sub type** is found *inside* the entity, usually in its `type[0].target_id`
+property.
+
+To get the full name, simply separate them with a hyphen. Examples include
+`node-page` and `paragraph-q_a_section`.
+
+
+<a id="orgb12cb7b"></a>
+
+### Raw content
+
+We start with the raw content as found in the CMS export tarball. When
+extracted, this tarball creates a directory with a child `content/`. In *there*
+are thousands of flat JSON files and a `meta/index.json`, but we can ignore that
+one for now.
+
+Each file is named like `node.<UUID>.json` where `<UUID>` is the UUID of the
+entity.
+
+
+<a id="org07d25fc"></a>
+
+### Transformed content
+
+After content has run through a [transformer](#org3a44eb7), we call it `transformed content`.
+The resulting data structure is what will be used in the [templates](#org187853e).
+
+
+<a id="org3a44eb7"></a>
+
+### Transformer
+
+When you boil down a transformer, all you find is a function that takes an
+object and returns an object. The purpose behind the transformer is to simplify
+using the content in the [templates](#org187853e).
+
+
+<a id="org187853e"></a>
+
+### Liquid templates
+
+The final step before content is translated from an abstract content model to
+full-fledged HTML files, the liquid templates are used to couch the content in
+the necessary trappings of HTML.
+
+For more information on the Liquid template language, see [Shopify&rsquo;s
+documentation](https://shopify.github.io/liquid/).
+
+
+<a id="org48df923"></a>
+
+## The process
+
+Our content&rsquo;s story begins in the gritty metropolis of Metalsmith Pipes, travels
+over the stern Validation Mountains, down into the Vale of the Transformers for
+a life-altering experience, and through the exacting JSON Schema Forest before
+passing through the murky waters of the Liquid Template Lake to come out the
+other side no more a mere collection of abstract content models, but concrete
+HTML files.
+
+
+<a id="org0b02218"></a>
+
+### Metalsmith pipeline
+
+A content build is kicked off by a node script: `yarn build --pull-drupal`
+
+This script is responsible for a lot of things, but for now, the important parts
+are:
+
+1.  Pulling the CMS export tarball
+2.  Running the content through the validation and transformation process
+3.  Applying the transformed content models to the Liquid templates to generate
+    static HTML
+
+
+<a id="org458259d"></a>
+
+### CMS export tarball
+
+Before we can *do* anything with the content, we need to actually fetch the
+latest.
+
+
+<a id="org187b1ae"></a>
+
+### Pre-transformation JSON schema
+
+To ensure the content model from the CMS matches what the transformer expects in
+the next step, we check every untransformed (raw) entity we get from the CMS
+against a JSON schema. This is the first line of defense when content models get
+updated.
+
+Pre-transformation (raw) schemas can be found in
+`src/site/stages/build/process-cms-exports/schemas/raw/`. Each file in this
+directory is named after the content model it validates (e.g. `node-page.js`).
+Schemas from the `/process-cms-exports/schemas/common/` directory are used
+heavily in these schemas for readability.
+
+See [json-schema.org](https://json-schema.org/understanding-json-schema/) for a great introduction and reference for all things JSON
+schema.
+
+
+<a id="orgf314d86"></a>
+
+### Content model transformers
+
+By performing some basic data transformations, we can take the raw data and mold
+it into a shape that the templates expect.
+
+Transformers can be found in
+`src/site/stages/build/process-cms-exports/transformers/`. Each file in this
+directory is named after the content model it transforms (e.g. `node-page.js`).
+Common functions from `transformers/helpers.js` are used heavily in these
+transformers for readability and consistency.
+
+
+<a id="org0fada70"></a>
+
+### Post-transformation JSON
+
+After the content has been transformed, we&rsquo;ll validate it against a
+post-transformation JSON schema found in
+`src/site/stages/build/process-cms-exports/schemas/transformed/` to ensure
+nothing unexpected happened during transformation.
+
+These schemas are also useful for debugging what&rsquo;s going on in the templates
+(see below). If you know what content model you&rsquo;re working with in a given
+template, you can look at the schema to see what data you have access to and
+what shape it takes.
+
+
+<a id="orgf5df85e"></a>
+
+### Liquid templates
+
+This is where the magic happens. In the end, the content models are applied to
+various templates to generate the static HTML. This happens after the content
+model transformation in a separate Metalsmith step.
+
+
+<a id="org3becc44"></a>
+
+## Testing
+
+Testing the transformers is designed to be as straightforward as possible by
+automatically ensuring that each new transformer is tested without any extra
+wiring needed.
+
+The unit test will:
+
+-   Look in `transformers/` for all transformers
+-   Ensure each transformer has a matching file in `tests/transformed-entities/`
+-   Ensure each transformer has a matching entry in `tests/entities/index.js`
+    -   This file acts as a sort of map, pointing to an example of each content
+        model
+-   Run each above entry through its transformer and validate that it exactly
+    matches the entry in `tests/transformed-entitites/`
+
+
+<a id="orgc84a542"></a>
+
+## Digging deep
+
+There&rsquo;s some magic hidden behind the scenes to make adding new content models as
+easy as possible.
+
+
+<a id="orgd8989fc"></a>
+
+### Automatic schema imports
+
+Files in the three schemas directories are imported and used intelligently in
+[schema-validator.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/schema-validation.js).
+
+
+<a id="orga2b24c5"></a>
+
+### Automatic `$id`
+
+Schemas can be referenced in other schemas by their `$id`. For schemas which
+have no explicit `$id`, [validator.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/validator.js) automatically adds one, prefixed with the
+directory name. This allows us to re-use the schema for children of an entity
+with `$ref`.
+
+Example: `$ref: 'transformed/page-node'`
+
+See [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for more information on how to use `$id` and
+`$ref`.
+
+
+<a id="orgc67539d"></a>
+
+## Debugging
+
+See the [Debugging Field Guide](debugging-field-guide.md) for a reference manual on how to debug transformer
+issues in the wild.
+

--- a/products/cms-integration/transformation-process.md
+++ b/products/cms-integration/transformation-process.md
@@ -1,40 +1,35 @@
 
 # Table of Contents
 
-1.  [Transformation Process](#org3d51180)
-    1.  [The actors](#org742210c)
-        1.  [Content model name](#org5d30ede)
-        2.  [Content model](#org0c2b21d)
-        3.  [Raw content](#org28b6201)
-        4.  [Filter](#orga60e353)
-        5.  [Transformer](#org2c9bdf4)
-        6.  [Transformed content](#orgb2e5ea4)
-        7.  [Liquid templates](#org6f052af)
-    2.  [The process](#orga5401ec)
-        1.  [Metalsmith pipeline](#orgf0c5512)
-        2.  [CMS export tarball](#orgffc87ba)
-        3.  [Pre-transformation JSON schema](#orgd4903ba)
-        4.  [Entity expansion](#orgf48d43f)
-        5.  [Content model transformers](#org0b354f8)
-        6.  [Post-transformation JSON schema](#org2a89c43)
-        7.  [Liquid templates](#org5a3177e)
-    3.  [Testing](#org43964c1)
-    4.  [Digging deep](#org6a46c23)
-        1.  [Automatic schema imports](#org8ff8e44)
-        2.  [Automatic `$id`](#orgfdcff70)
-    5.  [Debugging](#orgd20bc34)
+1.  [Transformation Process](#transformation-process)
+    1.  [The actors](#the-actors)
+        1.  [Content model name](#content-model-name)
+        2.  [Content model](#content-model)
+        3.  [Raw content](#raw-content)
+        4.  [Filter](#filter)
+        5.  [Transformer](#transformer)
+        6.  [Transformed content](#transformed-content)
+        7.  [Liquid templates](#liquid-templates)
+    2.  [The process](#the-process)
+        1.  [Metalsmith pipeline](#metalsmith-pipeline)
+        2.  [CMS export tarball](#cms-export-tarball)
+        3.  [Pre-transformation JSON schema](#pre-transformation-json-schema)
+        4.  [Entity expansion](#entity-expansion)
+        5.  [Content model transformers](#content-model-transformers)
+        6.  [Post-transformation JSON schema](#post-transformation-json-schema)
+        7.  [Liquid templates](#liquid-templates)
+    3.  [Testing](#testing)
+    4.  [Digging deep](#digging-deep)
+        1.  [Automatic schema imports](#automatic-schema-imports)
+        2.  [Automatic `$id`](#automatic-id)
+    5.  [Debugging](#debugging)
 
-
-
-<a id="org3d51180"></a>
 
 # Transformation Process
 
 So you want to take a peek under the hood, eh? Please, step inside. I&rsquo;ll show
 you how it works.
 
-
-<a id="org742210c"></a>
 
 ## The actors
 
@@ -45,8 +40,6 @@ from one shape to another. In the end, it&rsquo;s just inputs (raw content), pro
 Before we talk about how it all works, let&rsquo;s get some shared terminology first.
 
 
-<a id="org5d30ede"></a>
-
 ### Content model name
 
 A content model has a two-part name, for the purposes of this integration:
@@ -56,7 +49,7 @@ A content model has a two-part name, for the purposes of this integration:
 
 The **base type** is found in the first part of the name of the file in the CMS
 export content directory. For a `node.<UUID>.json` file, its base type is
-`node`. See the section [Raw content](#org28b6201) below for context.
+`node`. See the section [Raw content](#raw-content) below for context.
 
 The **sub type** is found *inside* the entity, usually in its `type[0].target_id`
 property.
@@ -65,22 +58,18 @@ To get the full name, simply separate them with a hyphen. Examples include
 `node-page` and `paragraph-q_a_section`.
 
 
-<a id="org0c2b21d"></a>
-
 ### Content model
 
 Each content model name applies to two separate content models (shapes for the
 data):
 
 -   Raw content model
-    -   The shape of the entity fresh from the [CMS export tarball](#orgffc87ba)
-    -   The [pre-transformation JSON schema](#orgd4903ba) says what this model actually is
+    -   The shape of the entity fresh from the [CMS export tarball](#cms-export-tarball)
+    -   The [pre-transformation JSON schema](#pre-transformation-json-schema) says what this model actually is
 -   Transformed content model
-    -   The shape of the entity after it passes through the [transformer](#org2c9bdf4)
-    -   The [post-transformation JSON schema](#org2a89c43) says what this model actually is
+    -   The shape of the entity after it passes through the [transformer](#transformer)
+    -   The [post-transformation JSON schema](#post-transformation-json-schema) says what this model actually is
 
-
-<a id="org28b6201"></a>
 
 ### Raw content
 
@@ -92,38 +81,30 @@ one for now.
 Each file is named like `node.<UUID>.json` where `<UUID>` is the UUID of the
 entity.
 
-The JSON objects in of each of these files should match exactly one [pre-transformation JSON schema](#orgd4903ba) which determines which raw content model it is
+The JSON objects in of each of these files should match exactly one [pre-transformation JSON schema](#pre-transformation-json-schema) which determines which raw content model it is
 (and subsequently which transformer should be used on it).
 
 
-<a id="orga60e353"></a>
-
 ### Filter
 
-Filters are found in as a named export in a content model&rsquo;s [`transformer` file](#org0b354f8).
-They&rsquo;re used to filter out properties in the [raw content](#org28b6201) before [entity expansion](#orgf48d43f)
+Filters are found in as a named export in a content model&rsquo;s [`transformer` file](#content-model-transformers).
+They&rsquo;re used to filter out properties in the [raw content](#raw-content) before [entity expansion](#entity-expansion)
 so it doesn&rsquo;t read more files than necessary.
 
-
-<a id="org2c9bdf4"></a>
 
 ### Transformer
 
 When you boil down a transformer, all you find is a function that takes an
 object and returns an object. The purpose behind the transformer is to simplify
-using the content in the [templates](#org6f052af).
+using the content in the [templates](#liquid-templates).
 
-
-<a id="orgb2e5ea4"></a>
 
 ### Transformed content
 
-The [transformer](#org2c9bdf4), converts raw content into transformed content. The resulting
-data structure must match the content model&rsquo;s [post-transformation JSON schema](#org2a89c43)
-and is what will be used in the [templates](#org6f052af).
+The [transformer](#transformer), converts raw content into transformed content. The resulting
+data structure must match the content model&rsquo;s [post-transformation JSON schema](#post-transformation-json-schema)
+and is what will be used in the [templates](#liquid-templates).
 
-
-<a id="org6f052af"></a>
 
 ### Liquid templates
 
@@ -135,8 +116,6 @@ For more information on the Liquid template language, see [Shopify&rsquo;s
 documentation](https://shopify.github.io/liquid/).
 
 
-<a id="orga5401ec"></a>
-
 ## The process
 
 Building the content is a step-by-step process which uses Metalsmith to manage
@@ -146,20 +125,18 @@ the pipeline. A high-level overview looks something like this:
 -   All `node` entities are fed into the entity tree assembler function
 -   The following will be performed on each `node`
     -   The content model type (name) will be determined
-    -   The entity will be validated against [pre-transformation JSON schema](#orgd4903ba)
-    -   Certain properties will be kept based on the [filters](#orga60e353) provided for the
+    -   The entity will be validated against [pre-transformation JSON schema](#pre-transformation-json-schema)
+    -   Certain properties will be kept based on the [filters](#filter) provided for the
         content model type
     -   The remaining properties will be scoured for references to other entities
-        -   If found, it&rsquo;ll recurse with those new entities, [expanding](#orgf48d43f) the child
+        -   If found, it&rsquo;ll recurse with those new entities, [expanding](#entity-expansion) the child
             references
-    -   The [transformer](#org0b354f8) for the content model is run on the data
+    -   The [transformer](#content-model-transformers) for the content model is run on the data
     -   The newly-transformed data is validated against the [post-transformation JSON
-        schema](#org2a89c43)
-    -   Finally, the transformed content will be applied to a [liquid template](#org6f052af) to be
+        schema](#post-transformation-json-schema)
+    -   Finally, the transformed content will be applied to a [liquid template](#liquid-templates) to be
         transmogrified into HTML
 
-
-<a id="orgf0c5512"></a>
 
 ### Metalsmith pipeline
 
@@ -174,8 +151,6 @@ parts** are:
     static HTML
 
 
-<a id="orgffc87ba"></a>
-
 ### CMS export tarball
 
 Before we can *do* anything with the content, we need to actually fetch the
@@ -184,8 +159,6 @@ latest.
 TODO: Once we know where the tarball will live after the CMS bundles the export
 up, this section should say where the build fetches that tarball from.
 
-
-<a id="orgd4903ba"></a>
 
 ### Pre-transformation JSON schema
 
@@ -203,8 +176,6 @@ heavily in these schemas for readability.
 See [json-schema.org](https://json-schema.org/understanding-json-schema/) for a great introduction and reference for all things JSON
 schema.
 
-
-<a id="orgf48d43f"></a>
 
 ### Entity expansion
 
@@ -228,12 +199,10 @@ all child entities will be fully expanded and transformed by the time the data
 is passed to the transformer.
 
 
-<a id="org0b354f8"></a>
-
 ### Content model transformers
 
 By performing some basic data transformations, we can take the raw data and **mold
-it into a shape that the [templates](#org6f052af) expect**.
+it into a shape that the [templates](#liquid-templates) expect**.
 
 Transformers can be found in
 `src/site/stages/build/process-cms-exports/transformers/`. **Each file in this
@@ -241,8 +210,6 @@ directory is named after the content model it transforms** (e.g. `node-page.js`)
 Common functions from `transformers/helpers.js` are used heavily in these
 transformers for readability and consistency.
 
-
-<a id="org2a89c43"></a>
 
 ### Post-transformation JSON schema
 
@@ -257,16 +224,12 @@ template, you can look at the schema to see what data you have access to and
 what shape it takes.
 
 
-<a id="org5a3177e"></a>
-
 ### Liquid templates
 
 This is where the magic happens. In the end, the content models are applied to
 various templates to **generate the static HTML**. This happens after the content
 model transformation in a separate Metalsmith step.
 
-
-<a id="org43964c1"></a>
 
 ## Testing
 
@@ -285,23 +248,17 @@ The unit test will:
     matches the entry in `tests/transformed-entitites/`
 
 
-<a id="org6a46c23"></a>
-
 ## Digging deep
 
 There&rsquo;s some magic hidden behind the scenes to make adding new content models as
 easy as possible.
 
 
-<a id="org8ff8e44"></a>
-
 ### Automatic schema imports
 
 Files in the **three schemas directories** are imported and used intelligently in
 [schema-validation.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/schema-validation.js).
 
-
-<a id="orgfdcff70"></a>
 
 ### Automatic `$id`
 
@@ -315,8 +272,6 @@ Example: `$ref: 'transformed/page-node'`
 See [Structuring a complex schema](https://json-schema.org/understanding-json-schema/structuring.html) for more information on how to use `$id` and
 `$ref`.
 
-
-<a id="orgd20bc34"></a>
 
 ## Debugging
 


### PR DESCRIPTION
Like it says on the tin, this is the first pass at the CMS export transformation documentation.

Let me know specifically what you think about the tone and overall comprehensiveness. There's a lot more I _could_ write, but I find myself getting distracted and wanted to push out a first pass at this to start with.

**Note:** I used Emacs' Org Mode to write the initial documentation and exported that as markdown from there, so there are odd quirks like the `<a href="#org123abc></a>` tags. I can clean those up before I merge this in along with the `&rsquo;`s.