### PR TITLE
form-tutorial-basic.md: Update year, and add missing question

### DIFF
--- a/platform/engineering/form-tutorial-basic.md
+++ b/platform/engineering/form-tutorial-basic.md
@@ -24,11 +24,12 @@ You can answer the questions with the [documentation](https://github.com/departm
 - What should be the name of your app's entry bundle? `newForm`
 - What's the root url for this app? `/new-form`
 - Is this a form app? `Y`
+- Where can I find the vagov-content repo? This path can be absolute or relative to vets-website. `./`
 - What's your form number? `XX-230`
 - What's the Google Analytics event prefix you want to use? `new-form-`
 - What's the respondent burden of this form in minutes? `30`
 - What's the OMB control number for this form? `XX3344`
-- What's the OMB expiration date (in M/D/YYYY format) for this form? `5/31/2018`
+- What's the OMB expiration date (in M/D/YYYY format) for this form? `5/31/2020`
 - What's the benefit description for this form? `new form benefits`
 - Which form template would you like to start with? `Choose 'BLANK: A form without any fields'`
 


### PR DESCRIPTION
The following question was missing from the docs:
>Where can I find the vagov-content repo? This path can be absolute or relative to vets-website.

And the example was using a year in the past (`2018`), so I updated it be in the future (`2020`).

![image](https://user-images.githubusercontent.com/6130520/73982892-c4437300-48fa-11ea-8405-faece3628e99.png)
