### PR TITLE
Clarifies "out-of-band deployment" process

### DIFF
--- a/platform/working-with-vsp/policies-work-norms/deployment-policy.md
+++ b/platform/working-with-vsp/policies-work-norms/deployment-policy.md
@@ -27,11 +27,32 @@ Automated deploys will not occur on the following days, due to holidays:
 
 # Requesting out-of-band deploys
 
-If there is a critical issue that needs to be resolved outside the automated deployment schedule (i.e. a bug affecting a large group of users that must be fixed right away), permission must be granted for a manual deploy.
+If there is a _critical issue_ that needs to be resolved outside the automated deployment schedule, explicit permission must be granted for an out-of-band deploy.
 
-Extra releases to “just get something out sooner” will not be approved.
+For every out-of-band deploy requested, VSP team will expect a follow-up [postmortem](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/tree/master/Postmortems) from the requesting team, explaining the context that led to the problem and proposing follow-up actions to prevent similar future problems.
 
-1. You must reach out to Kevin Hoffman who will escalate this request to Chris Johnston for approval.
+## Is my issue critical?
+
+Examples of _critical issues_ include:
+* A bug that’s preventing a significant number of Veterans from accessing a feature
+* A bug creating a non-trivial deviation from expected functionality
+* A 508/accessibility failure of severity level **0** (_Showstopper_) or **1** (_Critical_) ([severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md))
+
+Examples of _non-critical issues_ include:
+* Incorrect text or visual formatting that does not impede the feature from working
+* Any code for features not yet released to Veterans
+* Just wanting to get code out sooner
+
+When in doubt on whether an issue is _critical_ enough for out-of-band deployment, DEPO leadership for VSP will make the deciding call.
+
+## Step-by-step process for out-of-band deployment approval
+
+1. You must reach out to VSP DEPO leadership (currently, Kevin Hoffman or Dror Matalon) who will escalate this request to Chris Johnston for approval.
+1. Once approved, contact the [VSP DevOps oncall](https://dsva.pagerduty.com/schedules#PGIEA8Q) through the [#oncall channel](https://dsva.slack.com/archives/C30LCU8S3) to coordinate the release.
+1. Within two business days of this incident, send a PR with a [postmortem](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/tree/master/Postmortems), including any relevant stakeholders, VSP DEPO leadership, and any VSP team members involved in resolving the incident as reviewers.
+
+## Step-by-step process for deployment
+
 1. To deploy this change to production, the release job is run with the git SHA for the commit to deploy.
 1. The auto-deploy boolean flag must be set to `FALSE` on the job.
 1. The release tag is captured and then used as input for the matching deploy job.


### PR DESCRIPTION
Adds a few clarifications to the process for requesting out-of-band deployments, whether those are extra deployments in addition to the scheduled daily deployment or for releases during holiday freezes.

* Adds some examples of what we do/don't consider issues worth extra deployments, but with DEPO leadership explicitly as arbiter
* Adds expectation for requesting teams to provide a postmortem after emergency deployment