### PR TITLE
Create staging review processes file

### DIFF
--- a/platform/accessibility/guidance/post-launch-audit-processes.md
+++ b/platform/accessibility/guidance/post-launch-audit-processes.md
@@ -1,9 +1,9 @@
-# Accessibility Post-Launch Audit Processes
+# Accessibility Post-launch Audit Processes
 Post-launch audit processes are designed to evaluate applications and static content using a wider set of devices than the [accessibility staging review](./staging-review-processes.md). The accessibility specialist(s) will also schedule your application or content for a VA 508 office quick test.
 
-You can [request a full audit](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=1Copenut%2C+jenstrickland&labels=508%2FAccessibility%2C+product+support&template=full-accessibility-and-508-office-audit.md&title=Full+Accessibility+%26+508+Office+Audit+%5BFeature-Name%5D) when your application is relatively code-stable in production. Ideally all issues identified during the staging review have been fixed, but your accessibility specialist will communicate known issues to the VA 508 office.
+You should [request a full audit](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=1Copenut%2C+jenstrickland&labels=508%2FAccessibility%2C+product+support&template=full-accessibility-and-508-office-audit.md&title=Full+Accessibility+%26+508+Office+Audit+%5BFeature-Name%5D) when your application is relatively code-stable in production. Ideally all issues identified during the staging review have been fixed, but your accessibility specialist will communicate known issues to the VA 508 office.
 
-## How The Audit is Different from a Staging Review
+## How The VSP/VSA Post-launch Audit is Different from a Staging Review
 The post-launch audit will focus on manual testing with mobile and assistive technology:
 
 * Windows 7/10 IE11 + JAWS
@@ -11,9 +11,10 @@ The post-launch audit will focus on manual testing with mobile and assistive tec
 * Windows 7/10 NVDA + Firefox
 * MacOS Safari + VoiceOver
 * iOS and Android mobile devices as available
-* Browsers such as AVG or Waterfox. Additional browsers will be tested as time allows, and may change depending on analytics data.
+* Browsers such as Edge Chromium, AVG, or Waterfox. Additional software may be tested as time allows. Preferered pairings may change depending on analytics data.
 
 ## Issue Gathering and Triage
 * Issues will be collected as issues in a new ZenHub epic. The accessibility specialist will assign this epic to the person who requested the staging review.
-* Issues will be triaged according to their severity. Teams should review the [accessibility defect severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md) if they have questions about issue severity or impact.
+* Issues will be triaged according to their severity. Some issues will be launch blockers. Others can be fixed post-launch. Teams should review the [accessibility defect severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md) if they have questions about issue severity or impact.
 * The accessibility specialist will communciate the application or content's readiness for review to the VA 508 office. The specialist will list known issues and serve as a liaison between the requesting team and the VA 508 representative.
+* Accessibility specialists will work with stakeholders as issues are ready to be re-tested. When an issue has been resolved, the specialist or project manager should close it with a brief comment like _"Issue has been tested, and success criteria met. Moving to close."_

--- a/platform/accessibility/guidance/post-launch-audit-processes.md
+++ b/platform/accessibility/guidance/post-launch-audit-processes.md
@@ -1,0 +1,19 @@
+# Accessibility Post-Launch Audit Processes
+Post-launch audit processes are designed to evaluate applications and static content using a wider set of devices than the [accessibility staging review](./staging-review-processes.md). The accessibility specialist(s) will also schedule your application or content for a VA 508 office quick test.
+
+You can [request a full audit](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=1Copenut%2C+jenstrickland&labels=508%2FAccessibility%2C+product+support&template=full-accessibility-and-508-office-audit.md&title=Full+Accessibility+%26+508+Office+Audit+%5BFeature-Name%5D) when your application is relatively code-stable in production. Ideally all issues identified during the staging review have been fixed, but your accessibility specialist will communicate known issues to the VA 508 office.
+
+## How The Audit is Different from a Staging Review
+The post-launch audit will focus on manual testing with mobile and assistive technology:
+
+* Windows 7/10 IE11 + JAWS
+* Windows 7/10 Chrome + JAWS
+* Windows 7/10 NVDA + Firefox
+* MacOS Safari + VoiceOver
+* iOS and Android mobile devices as available
+* Browsers such as AVG or Waterfox. Additional browsers will be tested as time allows, and may change depending on analytics data.
+
+## Issue Gathering and Triage
+* Issues will be collected as issues in a new ZenHub epic. The accessibility specialist will assign this epic to the person who requested the staging review.
+* Issues will be triaged according to their severity. Teams should review the [accessibility defect severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md) if they have questions about issue severity or impact.
+* The accessibility specialist will communciate the application or content's readiness for review to the VA 508 office. The specialist will list known issues and serve as a liaison between the requesting team and the VA 508 representative.

--- a/platform/accessibility/guidance/post-launch-audit-processes.md
+++ b/platform/accessibility/guidance/post-launch-audit-processes.md
@@ -3,7 +3,7 @@ Post-launch audit processes are designed to evaluate applications and static con
 
 You should [request a full audit](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=1Copenut%2C+jenstrickland&labels=508%2FAccessibility%2C+product+support&template=full-accessibility-and-508-office-audit.md&title=Full+Accessibility+%26+508+Office+Audit+%5BFeature-Name%5D) when your application is relatively code-stable in production. Ideally all issues identified during the staging review have been fixed, but your accessibility specialist will communicate known issues to the VA 508 office.
 
-## How The VSP/VSA Post-launch Audit is Different from a Staging Review
+## How The Post-launch Audit is Different from a Staging Review
 The post-launch audit will focus on manual testing with mobile and assistive technology:
 
 * Windows 7/10 IE11 + JAWS

--- a/platform/accessibility/guidance/staging-review-processes.md
+++ b/platform/accessibility/guidance/staging-review-processes.md
@@ -1,0 +1,35 @@
+# Accessibility Staging Review Processes
+Accessibility staging reviews are part of the wider [VSP staging review](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+meganhkelley&labels=product+support%2C+content-ia-team&template=staging-review.md&title=Staging+Review+%5BFeature-Name%5D) process. The accessibility review is a bit unique because it involves a number of automated and manual tests, and may include a simple code review.
+
+All staging reviews will test the [happy path](https://en.wikipedia.org/wiki/Happy_path) through the application or content page(s). Staging reviews **may not catch all accessibility issues**, but will ensure the basic app functionality is accessible. Accessibility experts will conduct a more thorough audit when your application is relatively code-stable in production.
+
+## Before You Request a Review
+Staging accessibility reviews will be turned around in two days, provided the following items are done ahead of time:
+
+* Provide a 1-2 sprint "heads up" when the review needs to be completed
+* [Provide test user credentials](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-credentials-template.md#accessibility-test-credentials-template)
+* Use the templates to document your accessibility test cases
+  * **TestRail:** [TestRail VSP accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc) **OR**
+  * **Markdown:** [Github accessibility test cases template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-cases-template.md)
+* Log any known issues using the [508 issue template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=508%2FAccessibility&template=508-issue.md&title=)
+
+## Staging Review for Applications
+Accessibility specialist(s) will run through the the following automated and manual tests for rich applications. These include  React applications, forms, and anything else that isn't static HTML.
+
+* Axe browser plugin checks on a handful of pages or app states to ensure coverage
+* Zooming layouts to 400% at 1280px width
+* Once-through keyboard navigation
+* 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). This will most likely be JAWS and NVDA on Windows 7/10, and VoiceOver on MacOS.
+* End-to-end tests will be reviewed to ensure axe checks are run for primary and secondary (hidden) content
+
+## Staging Review for Static Content
+Accessibility specialist(s) will run through the the following automated and manual tests for static content. Static content includes pages generated from the content management system (CMS) or Markdown files.
+
+* Axe browser plugin checks on a handful of pages or app states to ensure coverage
+* Zooming layouts to 400% at 1280px width
+* Once-through keyboard navigation
+* 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). This will most likely be JAWS and NVDA on Windows 7/10, and VoiceOver on MacOS.
+
+## Issue Gathering and Triage
+* Issues will be collected as issues in a new ZenHub epic. The accessibility specialist will assign this epic to the person who requested the staging review.
+* Issues will be triaged according to their severity. Some issues will be launch blockers. Others can be fixed post-launch. Teams should review the [accessibility defect severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md) if they have questions about issue severity or impact.

--- a/platform/accessibility/guidance/staging-review-processes.md
+++ b/platform/accessibility/guidance/staging-review-processes.md
@@ -27,7 +27,7 @@ Accessibility specialist(s) will run through the the following automated and man
 * Zooming layouts to 400% on a subset of pages
 * Once-through keyboard navigation
 * 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). The favored browser and screen reader pairings may evolve as Edge Chromium and Chrome assume more market share, but the current pairings include:
-  * JAWS on Windows7/10 using IE11
+  * JAWS on Windows7/10 using IE11 _(This is the VA 508 office's preferred test pairing)_
   * NVDA on Windows 7/10 using Firefox
   * VoiceOver on MacOS
 * End-to-end tests will be reviewed to ensure axe checks are run for primary and secondary (hidden) content
@@ -39,11 +39,13 @@ Accessibility specialist(s) will run through the the following automated and man
 * Zooming layouts to 400% on a subset of pages
 * Once-through keyboard navigation
 * 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). The favored browser and screen reader pairings may evolve as Edge Chromium and Chrome assume more market share, but the current pairings include:
-  * JAWS on Windows7/10 using IE11
+  * JAWS on Windows7/10 using IE11 _(This is the VA 508 office's preferred test pairing)_
   * NVDA on Windows 7/10 using Firefox
   * VoiceOver on MacOS
 
 ## Issue Gathering and Triage
+* Validate code early and often to help identify issues sooner than later
+* Request a spot check 1-2 sprints before your anticipated staging review
 * Issues will be collected as issues in a new ZenHub epic. The accessibility specialist will assign this epic to the person who requested the staging review.
 * Issues will be triaged according to their severity. Some issues will be launch blockers. Others can be fixed post-launch. Teams should review the [accessibility defect severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md) if they have questions about issue severity or impact.
 * Accessibility specialists will work with stakeholders as issues are ready to be re-tested. When an issue has been resolved, the specialist or project manager should close it with a brief comment like _"Issue has been tested, and success criteria met. Moving to close."_

--- a/platform/accessibility/guidance/staging-review-processes.md
+++ b/platform/accessibility/guidance/staging-review-processes.md
@@ -20,7 +20,7 @@ Staging accessibility reviews will be turned around in two days, provided the fo
   * [Github accessibility test cases template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-cases-template.md)
 * Log any known issues using the [508 issue template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=508%2FAccessibility&template=508-issue.md&title=)
 
-## Staging Review for Applications
+## VSP/VSA Staging Review for Applications
 Accessibility specialist(s) will run through the the following automated and manual tests for rich applications. These include  React applications, forms, and anything else that isn't static HTML.
 
 * Axe browser plugin checks on a subset of pages or app states to ensure coverage
@@ -32,7 +32,7 @@ Accessibility specialist(s) will run through the the following automated and man
   * VoiceOver on MacOS
 * End-to-end tests will be reviewed to ensure axe checks are run for primary and secondary (hidden) content
 
-## Staging Review for Static Content
+## VSP/VSA Staging Review for Static Content
 Accessibility specialist(s) will run through the the following automated and manual tests for static content. Static content includes pages generated from the content management system (CMS) or Markdown files.
 
 * Axe browser plugin checks on a subset of pages to ensure coverage

--- a/platform/accessibility/guidance/staging-review-processes.md
+++ b/platform/accessibility/guidance/staging-review-processes.md
@@ -1,35 +1,49 @@
 # Accessibility Staging Review Processes
 Accessibility staging reviews are part of the wider [VSP staging review](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+meganhkelley&labels=product+support%2C+content-ia-team&template=staging-review.md&title=Staging+Review+%5BFeature-Name%5D) process. The accessibility review is a bit unique because it involves a number of automated and manual tests, and may include a simple code review.
 
-All staging reviews will test the [happy path](https://en.wikipedia.org/wiki/Happy_path) through the application or content page(s). Staging reviews **may not catch all accessibility issues**, but will ensure the basic app functionality is accessible. Accessibility experts will conduct a more thorough audit when your application is relatively code-stable in production.
+All staging reviews will test the [happy path](https://en.wikipedia.org/wiki/Happy_path) through the application or content page(s). Staging reviews **may not catch all accessibility issues**, but will ensure basic functionality is accessible. Accessibility specialists will conduct a more thorough audit when your application is relatively code-stable in production.
 
 ## Before You Request a Review
 Staging accessibility reviews will be turned around in two days, provided the following items are done ahead of time:
 
 * Provide a 1-2 sprint "heads up" when the review needs to be completed
 * [Provide test user credentials](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-credentials-template.md#accessibility-test-credentials-template)
-* Use the templates to document your accessibility test cases
-  * **TestRail:** [TestRail VSP accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc) **OR**
-  * **Markdown:** [Github accessibility test cases template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-cases-template.md)
+* Conduct low-level accessibility tests ahead of the VSP staging review:
+  * [Run axe checks using the Chrome or Firefox browser plugin(s)](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#getting-started-with-automation)
+  * [Write end-to-end (e2e) tests with good axe checks, including hidden content](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#build-pipeline-requirements)
+  * [Zoom layouts to 400% at 1280px width](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#zoom-to-400)
+  * [Navigate using the keyboard only](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#keyboard-navigation)
+  * [Test for color contrast and color blindness issues](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#color-tests)
+  * [Test with 1 or 2 screen readers](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#keyboard-navigation) _(VoiceOver or NVDA)_
+* Provide documentation for your test cases using one of the templates:
+  * [TestRail VSP accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc) **OR** 
+  * [Github accessibility test cases template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-cases-template.md)
 * Log any known issues using the [508 issue template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=508%2FAccessibility&template=508-issue.md&title=)
 
 ## Staging Review for Applications
 Accessibility specialist(s) will run through the the following automated and manual tests for rich applications. These include  React applications, forms, and anything else that isn't static HTML.
 
-* Axe browser plugin checks on a handful of pages or app states to ensure coverage
-* Zooming layouts to 400% at 1280px width
+* Axe browser plugin checks on a subset of pages or app states to ensure coverage
+* Zooming layouts to 400% on a subset of pages
 * Once-through keyboard navigation
-* 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). This will most likely be JAWS and NVDA on Windows 7/10, and VoiceOver on MacOS.
+* 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). The favored browser and screen reader pairings may evolve as Edge Chromium and Chrome assume more market share, but the current pairings include:
+  * JAWS on Windows7/10 using IE11
+  * NVDA on Windows 7/10 using Firefox
+  * VoiceOver on MacOS
 * End-to-end tests will be reviewed to ensure axe checks are run for primary and secondary (hidden) content
 
 ## Staging Review for Static Content
 Accessibility specialist(s) will run through the the following automated and manual tests for static content. Static content includes pages generated from the content management system (CMS) or Markdown files.
 
-* Axe browser plugin checks on a handful of pages or app states to ensure coverage
-* Zooming layouts to 400% at 1280px width
+* Axe browser plugin checks on a subset of pages to ensure coverage
+* Zooming layouts to 400% on a subset of pages
 * Once-through keyboard navigation
-* 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). This will most likely be JAWS and NVDA on Windows 7/10, and VoiceOver on MacOS.
+* 3 preferred screen reader and browser pairings. Pairings will be determined by analytics data and WebAIM’s [most recent screen reader survey](https://webaim.org/projects/screenreadersurvey8/#primary). The favored browser and screen reader pairings may evolve as Edge Chromium and Chrome assume more market share, but the current pairings include:
+  * JAWS on Windows7/10 using IE11
+  * NVDA on Windows 7/10 using Firefox
+  * VoiceOver on MacOS
 
 ## Issue Gathering and Triage
 * Issues will be collected as issues in a new ZenHub epic. The accessibility specialist will assign this epic to the person who requested the staging review.
 * Issues will be triaged according to their severity. Some issues will be launch blockers. Others can be fixed post-launch. Teams should review the [accessibility defect severity rubric](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md) if they have questions about issue severity or impact.
+* Accessibility specialists will work with stakeholders as issues are ready to be re-tested. When an issue has been resolved, the specialist or project manager should close it with a brief comment like _"Issue has been tested, and success criteria met. Moving to close."_

--- a/platform/accessibility/guidance/staging-review-processes.md
+++ b/platform/accessibility/guidance/staging-review-processes.md
@@ -6,9 +6,9 @@ All staging reviews will test the [happy path](https://en.wikipedia.org/wiki/Hap
 ## Before You Request a Review
 Staging accessibility reviews will be turned around in two days, provided the following items are done ahead of time:
 
-* Provide a 1-2 sprint "heads up" when the review needs to be completed
+* 1-2 sprints before the review needs to be completed, provide a "heads up" in Slack to the accessibility specialists that the staging review request will be coming soon
 * [Provide test user credentials](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-credentials-template.md#accessibility-test-credentials-template)
-* Conduct low-level accessibility tests ahead of the VSP staging review:
+* Conduct low-level accessibility tests ahead of the staging review:
   * [Run axe checks using the Chrome or Firefox browser plugin(s)](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#getting-started-with-automation)
   * [Write end-to-end (e2e) tests with good axe checks, including hidden content](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#build-pipeline-requirements)
   * [Zoom layouts to 400% at 1280px width](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#zoom-to-400)
@@ -16,11 +16,11 @@ Staging accessibility reviews will be turned around in two days, provided the fo
   * [Test for color contrast and color blindness issues](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#color-tests)
   * [Test with 1 or 2 screen readers](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/508-accessibility-best-practices.md#keyboard-navigation) _(VoiceOver or NVDA)_
 * Provide documentation for your test cases using one of the templates:
-  * [TestRail VSP accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc) **OR** 
+  * [TestRail accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc) **OR** 
   * [Github accessibility test cases template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/accessibility-test-cases-template.md)
 * Log any known issues using the [508 issue template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=508%2FAccessibility&template=508-issue.md&title=)
 
-## VSP/VSA Staging Review for Applications
+## Staging Review for Applications
 Accessibility specialist(s) will run through the the following automated and manual tests for rich applications. These include  React applications, forms, and anything else that isn't static HTML.
 
 * Axe browser plugin checks on a subset of pages or app states to ensure coverage
@@ -32,7 +32,7 @@ Accessibility specialist(s) will run through the the following automated and man
   * VoiceOver on MacOS
 * End-to-end tests will be reviewed to ensure axe checks are run for primary and secondary (hidden) content
 
-## VSP/VSA Staging Review for Static Content
+## Staging Review for Static Content
 Accessibility specialist(s) will run through the the following automated and manual tests for static content. Static content includes pages generated from the content management system (CMS) or Markdown files.
 
 * Axe browser plugin checks on a subset of pages to ensure coverage


### PR DESCRIPTION
This file was created to formalize the staging accessibility review. It makes clear that these are fast tests, and **may not** capture all issues. We are putting the onus on teams to run a lot of the low level tests, so we can get through the happy path quickly and identify any launch blockers.

I am writing a second document that extends this one, and outlines the additional testing I'd like to do in the post-launch audits.