### PR TITLE
Update broken links from `call-center` to `contact-center`

### DIFF
--- a/platform/README.md
+++ b/platform/README.md
@@ -1,22 +1,25 @@
 # Veteran-facing Services Platform (VSP)
+
 This `platform` directory contains everything you need to know about Platform as a VFS Team building something on VA.gov. It includes details on the tools and services Platform offers, and . administrative content such as orientation documents, policies, work norms, processes and how to work with the VSP teams.
 
 - If you are looking for documentation on VA.gov user-facing applications and content, please see [/products](../products/README.md).
-- If you are looking for information on the teams currently building on VSP, please see [/teams](../teams/README.md). 
-
+- If you are looking for information on the teams currently building on VSP, please see [/teams](../teams/README.md).
 
 ### About VSP
+
 - [Learn about VSP](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/about-vsp)
 
 ### Working with VSP
+
 - [Getting Started with VSP](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/working-with-vsp)
 - [Orientation](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/working-with-vsp/orientation)
 - [Policies and Work Norms](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/working-with-vsp/policies-work-norms)
 
 ### Practice Areas
+
 - [Accessibility and 508 Compliance](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/accessibility)
 - [Analytics and Insights](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/analytics)
-- [Contact Center](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/call-center)
+- [Contact Center](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/contact-center)
 - [Content](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/content)
 - [Design](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/design)
 - [Engineering](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/engineering)
@@ -26,4 +29,3 @@ This `platform` directory contains everything you need to know about Platform as
 - [Quality Assurance](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/quality-assurance)
 - [Triage](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/triage)
 - [User Research](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/research)
-

--- a/platform/contact-center/README.md
+++ b/platform/contact-center/README.md
@@ -5,13 +5,13 @@ Welcome to the Platform Contact Center Folder!
 - VSP POC: Kimberley Daniels (kimberley.daniels@adhocteam.us) (kimberley.daniels@va.gov)
 
 ## Process Documents
-- [Contact Center Review Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/request-contact-center-review.md) 
+- [Contact Center Review Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md) 
   * This document outlines the process for requesting a contact center team review for any new or significantly updated tool/feature. This process allows the contact center team to update contact centers on changes to VA.gov so that contact center agents can get trained to answer user issues and questions.  
-- [VFS App Bugs Escalation Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/tier-3-escalation-process.md)
+- [VFS App Bugs Escalation Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/tier-3-escalation-process.md)
   * The contact center team is responsible for triaging and escalating bugs to the correct VFS team. This document outlines the process for notifying VFS team of a bug and the process and timelines for responding to a reported issue. 
 
 ## Key Documents
-- [VFS Monthly Contact Center Report](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/vsp/teams/insights-analytics/call-center/call-center-data)
+- [VFS Monthly Contact Center Report](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/vsp/teams/insights-analytics/contact-center/call-center-data)
   * These reports compile contact center data across multiple VA contact centers and sysytems. 
 
 

--- a/platform/engineering/frontend/readme.md
+++ b/platform/engineering/frontend/readme.md
@@ -7,4 +7,4 @@
 
 # Request DSVA to review your team's work
 
-- [Request Contact Center Review](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/request-contact-center-review.md)
+- [Request Contact Center Review](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md)

--- a/platform/working-with-vsp/vsp-collaboration-cycle/vsp-collaboration-cycle.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/vsp-collaboration-cycle.md
@@ -276,10 +276,10 @@ Ensure that VA contact center representatives are prepared to help Veterans trou
 ## Collaboration format: asynchronous
 
 ### Request process
-**VFS Product Manager** follows instructions on the [Contact Center Review page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/request-contact-center-review.md) to request a Contact Center review.
+**VFS Product Manager** follows instructions on the [Contact Center Review page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md) to request a Contact Center review.
 
 ### Artifact inputs
-You bring (refer to [Contact Center Review page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/request-contact-center-review.md) for further instruction): 
+You bring (refer to [Contact Center Review page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md) for further instruction): 
 - Product Guide
 - Product Video
 

--- a/products/disability/rated-disabilities/contact-center/README.md
+++ b/products/disability/rated-disabilities/contact-center/README.md
@@ -1,14 +1,14 @@
 # Contact Center Product Guide: "Your VA disability ratings"
 
 ### Table of Contents 
- - [What is it?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#what-is-it)
- - [User Access](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#user-access)
-   - [Who can access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#who-can-access-this)
-   - [How can users access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#how-can-users-access-this)
- - [Navigation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#navigation)
- - [FAQs](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#faqs)
- - [Functionality](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#functionality)
- - [Error Handling & Notifications](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#error-handling-and-notifications)
+ - [What is it?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#what-is-it)
+ - [User Access](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#user-access)
+   - [Who can access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#who-can-access-this)
+   - [How can users access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#how-can-users-access-this)
+ - [Navigation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#navigation)
+ - [FAQs](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#faqs)
+ - [Functionality](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#functionality)
+ - [Error Handling & Notifications](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#error-handling-and-notifications)
  - [Video Demo Link (YouTube)](#)
 
 ## What is it?
@@ -18,15 +18,15 @@ The **Your VA disability ratings** page is where Veterans can view their combine
 - **Compensation 101: How did I get this rating?** video on YouTube; this explains how disability claims are determined, and how ratings are calculated. `(C)`
 - The VA phone number: 800-827-1000 `(D)`
 
-![Your-VA-disability rating](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-1_clean.png)
+![Your-VA-disability rating](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-1_clean.png)
 
 The **Your VA disability ratings** screen will show disability ratings that are known to the VA. If a Veteran does not have a disability rating, an informational alert box will appear:
 
-![RD 400 error](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-2_clean.png)
+![RD 400 error](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-2_clean.png)
 
 If there is an error getting the Veteran's disability rating, an error alert will appear. It is possible that either the total combined VA disability rating, or the individual disability ratings, or both, could show error alerts.
 
-![RD 500 error](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-3_clean.png)
+![RD 500 error](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-3_clean.png)
 
 Target launch date is end of November 2019, early December 2020.
 
@@ -40,9 +40,9 @@ The **Your VA disability ratings** page is accessible for testing within the **V
 ## Navigation
 If a Veteran searches or browses **VA.gov**, several links will connect to the **View your VA disability rating** landing page (https://va.gov/disability/view-disability-rating). If the Veteran is already logged-in, they can proceed to the **Your VA disability rating** page by clicking the blue **View your VA disability rating >** button. Veterans who are not logged-in will see the same page, but with the green **Sign in or create an account** button. The **View your VA disability rating** landing page has information about some basic access questions. It also has a link to **Learn how VA disability ratings are assigned**, which can help explain the VA disability rating calculation. The usual navigations links are in the left sidebar.
 
-![RD  authenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD_Landing_1A.png)
+![RD  authenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD_Landing_1A.png)
 
-![RD  unauthenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-4_clean.png)
+![RD  unauthenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-4_clean.png)
 
 After authentication, the Veteran is brought to the **Your VA disability ratings** page.  
 

--- a/products/health-care/appointments/va-online-scheduling/product/Product Dev Checklist - VAOS MVP.md
+++ b/products/health-care/appointments/va-online-scheduling/product/Product Dev Checklist - VAOS MVP.md
@@ -56,7 +56,7 @@ _Note: as always, use the **#vfs-platform-support** Slack channel whenever you h
 - [ ] Dashboards and alerts are set up for finding and investigating issues
 - [ ] Point of contact are documented for the app itself and any new backend dependencies `*`
 - [ ] There's a [Product Outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/34add7c7b3d558158ccf3f599e79c2380076481c/platform/product-management/product-outline-template.md)
-- [ ] [Contact centers know how to help users who call in about the feature](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/request-contact-center-review.md)
+- [ ] [Contact centers know how to help users who call in about the feature](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md)
 
 ### ...marketable?
 - [ ] Product brief (with visuals), outlining the value and functionality of your product is in github

--- a/products/platform/documentation-site/research/research-round-2/research-plan.md
+++ b/products/platform/documentation-site/research/research-round-2/research-plan.md
@@ -46,7 +46,7 @@
       - [Information Architecture](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/README.md)
       - [Insights](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/readme.md)
           - [Analytics](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/analytics/google-analytics/readme.md)
-          - [Contact Center](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/README.md)
+          - [Contact Center](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/README.md)
       - [Product](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/product-management/README.md)
       - [QA](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/README.md)
       - [Research](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/research/README.md)

--- a/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md
+++ b/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md
@@ -1,14 +1,14 @@
 # Contact Center Product Guide: "Your VA disability ratings"
 
 ### Table of Contents 
- - [What is it?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#what-is-it)
- - [User Access](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#user-access)
-   - [Who can access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#who-can-access-this)
-   - [How can users access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#how-can-users-access-this)
- - [Navigation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#navigation)
- - [FAQs](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#faqs)
- - [Functionality](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#functionality)
- - [Error Handling & Notifications](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/call-center/product-guide.md#error-handling-and-notifications)
+ - [What is it?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#what-is-it)
+ - [User Access](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#user-access)
+   - [Who can access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#who-can-access-this)
+   - [How can users access this?](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#how-can-users-access-this)
+ - [Navigation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#navigation)
+ - [FAQs](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#faqs)
+ - [Functionality](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#functionality)
+ - [Error Handling & Notifications](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-rated-disabilities/contact-center/product-guide.md#error-handling-and-notifications)
  - [Video Demo Link (YouTube)](#)
 
 ## What is it?
@@ -18,11 +18,11 @@ The **Your VA disability ratings** page is where Veterans can view their combine
 - **Compensation 101: How did I get this rating?** video on YouTube; this explains how disability claims are determined, and how ratings are calculated. `C`
 - The VA phone number: 800-827-1000 `D`
 
-![Your-VA-disability rating](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-1_clean.png)
+![Your-VA-disability rating](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-1_clean.png)
 
 The **Your VA disability ratings** screen will show disability ratings that are known to the VA. If a Veteran does not have a disability rating, an informational alert box will appear:
 
-![RD 400 error](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-2_clean.png)
+![RD 400 error](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-2_clean.png)
 
 If there is an error getting the Veteran's disability rating, an error alert will appear. It is possible that either the total combined VA disability rating, or the individual disability ratings, or both, could show error alerts.
 
@@ -40,9 +40,9 @@ The **Your VA disability ratings** page is accessible for testing within the **V
 ## Navigation
 If a Veteran searches or browses **VA.gov**, several links will connect to the **View your VA disability rating** landing page (https://va.gov/disability/view-disability-rating). If the Veteran is already logged-in, they can proceed to the **Your VA disability rating** page by clicking the blue **View your VA disability rating >** button. Veterans who are not logged-in will see the same page, but with the green **Sign in or create an account** button. The **View your VA disability rating** landing page has information about some basic access questions. It also has a link to **Learn how VA disability ratings are assigned**, which can help explain the VA disability rating calculation. The usual navigations links are in the left sidebar.
 
-![RD  authenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD_Landing_1A.png)
+![RD  authenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD_Landing_1A.png)
 
-![RD  unauthenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/call-center/images/RD-4_clean.png)
+![RD  unauthenticated landing page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/rated-disabilities/contact-center/images/RD-4_clean.png)
 
 After authentication, the Veteran is brought to the **Your VA disability ratings** page.  
 

--- a/teams/vsp/teams/insights-analytics/contact-center/README.md
+++ b/teams/vsp/teams/insights-analytics/contact-center/README.md
@@ -1,6 +1,6 @@
 Welcome to the Contact Center lead Folder.
 
-Responsiblities for the Contact Center Lead can be found [HERE](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/triage/call-center/call-center-lead-responsibilities.md)
+Responsibilities for the Contact Center Lead can be found [HERE](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/insights-analytics/contact-center/call-center-lead-responsibilities.md)
 
 ## Process Documents
 - WHVAH Escalation Process

--- a/teams/vsp/teams/insights-analytics/contact-center/upload-demo-video-process.md
+++ b/teams/vsp/teams/insights-analytics/contact-center/upload-demo-video-process.md
@@ -4,6 +4,6 @@ Product teams are required to notify the contact center team before a new featur
 process, the product team must provide a demo video and associated transcript. It is the responsibility of the contact center team to review the 
 demo video and transcript and then request the Office of Public and Intergovernmental Affairs (OPIA). This is done by by emailing the video file 
 along with the written transcript to both Tass Mimikos [tass.mimikos@va.gov](tass.mimikos@va.gov) and Ben Pekkanen [Ben Pekkanen](Ben.Pekkanen@va.gov). 
-To read more about requirements for uploading videos to the official VA.gov Youtube channel, review the [VA Office of Public Affairs Youtube Requirements document](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/call-center/VA%20Office%20of%20Public%20Affairs%20YouTube%20Requirements.docx). 
+To read more about requirements for uploading videos to the official VA.gov Youtube channel, review the [VA Office of Public Affairs Youtube Requirements document](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/VA%20Office%20of%20Public%20Affairs%20YouTube%20Requirements.docx). 
 
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/6200#issuecomment-600596076