### PR TITLE
Simplify standard issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/standard-issue.md
+++ b/.github/ISSUE_TEMPLATE/standard-issue.md
@@ -7,18 +7,9 @@ assignees: ''
 
 ---
 
-## User Story or Problem Statement
-As a _____, I need _____ so I can _____.
+## Issue Description
+_What details are necessary for understanding the specific work or request tracked by this issue?_
 
-or
-
-Problem description. How might we _____________ ?
-
-## Goal
-_What outcome(s) do we want to see?_
-
-## Objectives or Key Results this is meant to further
-- _Include references to KPIs we intend to impact_
 ---
 ## Tasks
 - [ ] _What work is necessary for this story to be completed?_


### PR DESCRIPTION
Some of the criteria in the standard issue template is redundant with the [epic template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/epic-issue.md), setting the expectation of lot more overhead for frequent issue-filers on VSP than is actually warranted.

I propose the following changes:
* Removes OKRs/KPIs detail (redundant with Epic template)
* Replaces "user story / problem statement" + "goal" with simpler "Issue Description"