### PR TITLE
Cypress Migration Guide

### DIFF
--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -21,10 +21,10 @@ The purpose of this guide is to help with converting Nightwatch tests to Cypress
 
 ## Initial Setup <a name="initial-setup"></a>
 
-The location of tests remains the same as it is in nightwatch. All cypress tests must be in the `tests` directory of the application.
+Cypress tests are written in the same location as Nightwatch tests. Cypress tests need to be in the `tests` directory of the application.
 Cypress tests need to have the file extension `.cypress.spec.js`. E.g. `my-test-name.cypress.spec.js`.
 
-The overall folder structure for cypress in the `vets-website` repo is as follows:
+The overall folder structure for Cypress in the `vets-website` repo is as follows:
 
 ```
 vets-website
@@ -39,19 +39,25 @@ vets-website
 │       │   index.js
 ```
 
-- `cypress.json` holds the [configuration](https://docs.cypress.io/guides/references/configuration.html) for cypress tests. You can set things like the `baseUrl`, `defaultCommandTimeout`, etc.
-- `plugins` contains custom tasks, which allow you to [tap into the node environment](https://docs.cypress.io/guides/tooling/plugins-guide.html). This is valuable because all cypress test code is executed in the browser, so plugins allow us to execute code in the node process running outside of the browser.
-- `support` holds [custom cypress commands](https://docs.cypress.io/api/cypress-api/custom-commands.html#Syntax), specifically in the `commands.js` file. These commands can be run in cypress tests, similar to the built in commands. This is similar to [Nightwatch's custom commands](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/common-tasks/new-end-to-end-test/#custom-nightwatch-commands). This is also where cypress plugins are imported, as shown in `index.js`.
+`cypress.json` is the [configuration file](https://docs.cypress.io/guides/references/configuration.html) for Cypress tests. You can set the `baseUrl`, `defaultCommandTimeout`, etc.
+- `plugins` contains custom tasks, which allow you to [tap into the Node environment](https://docs.cypress.io/guides/tooling/plugins-guide.html). This is valuable because all Cypress test code is executed in the browser, so plugins allow us to execute code in the Node process running outside of the browser.
+- `support` contains [custom Cypress commands](https://docs.cypress.io/api/cypress-api/custom-commands.html#Syntax). By default, the custom commands imported in `commands/index.js` are available to all of our Cypress tests. These commands can be invoked similarly to the built in commands. This feature is similar to [Nightwatch's custom commands](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/common-tasks/new-end-to-end-test/#custom-nightwatch-commands). This is also where custom commands from Cypress plugins are imported, as can be seen in `index.js`.
 
 ### Test Dependencies
-You do not need to import any modules for helpers and timeouts, etc as before with nightwatch. You can start writing your tests without anything needed to be imported.
+You generally do not need to import any modules for helpers, timeouts, etc. as with Nightwatch.
 
 ## Writing Tests <a name="writing-tests"></a>
 ### Test Structure <a name="test-structure"></a>
-The test structure of Cypress should feel familiar. Cypress uses mocha's bdd syntax which is what we use for our unit tests. Note that because `it()` blocks are their own tests, each `it()` block should be independent of others in the same testing suite. Everything executed in the browser needs to be inside of an `it()` block. Visit [here](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Test-Structure) for more context.
+The test structure of Cypress should feel familiar. Cypress uses Mocha's BDD syntax, which is what we use for our unit tests.
+
+Each spec file starts a new browser instance and runs the suite of tests according to the `describe()` and `it()` blocks.
+
+Note that `it()` blocks are individual tests, so each `it()` block should be independent of others in the same test suite. Everything executed in the browser needs to be inside of an `it()` block.
+
+Visit [the Cypress docs](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Test-Structure) for more context.
 
 ### Visiting a Page <a name="visiting-a-page"></a>
-When [visiting a page](https://docs.cypress.io/api/commands/visit.html#Syntax), you do not need to be concerned about the `baseUrl`. Cypress's configuration file takes care of this. So rather than grabbing the `baseUrl` from the helpers in nightwatch:
+When [visiting a page](https://docs.cypress.io/api/commands/visit.html#Syntax), you do not need to be concerned about the `baseUrl`. Cypress's configuration file takes care of this. So rather than grabbing the `baseUrl` from the helpers in Nightwatch:
 
 ```javascript
 client.openUrl(`${E2eHelpers.baseUrl}/health-care/apply/application`)
@@ -64,7 +70,7 @@ cy.visit('health-care/apply/application')
 ```
 
 ### Interacting with Page Elements <a name="interacting-with-page-elements"></a>
-Cypress has a large api that allows for easy interacting with elements. The most common tasks you will probably need to convert from nightwatch tests are clicking, selecting elements from dropdowns, and entering input. Shown below is an overview of how to perform these tasks in cypress.
+Cypress has a [comprehensive API](https://docs.cypress.io/api/api/table-of-contents.html) that allows for easy interaction with elements. The most common interactions you will probably need to convert from Nightwatch tests are clicking, selecting elements from dropdowns, and entering text inputs. Below are examples of these interactions in Cypress.
 
 #### Clicking
 Nightwatch:
@@ -96,33 +102,41 @@ Cypress:
 cy.get('#root_firstName').type(testData.veteranFullName.first)
 ```
 
-Please visit [here](https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Actionability) for more information about interacting with elements. For additional ways to interact with the DOM we have also included the [cypress testing library](https://testing-library.com/docs/cypress-testing-library/intro) in the repo.
+For more information about how Cypress interactions behave, visit [the Cypress guide for interacting with elements](https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Actionability).
+
+For additional ways to interact with the DOM, we have also included the [Cypress Testing Library](https://testing-library.com/docs/cypress-testing-library/intro) as a dependency.
 
 ### Custom Commands <a name="custom-commands"></a>
 
-Some custom nightwatch commands located in `src/platform/testing/e2e/nightwatch-commands` were converted to cypress commands, and can be found in `src/platform/testing/e2e-cypress/support`. Many of them did not need to be converted because cypress supports their functionality natively. These custom commands can be used directly on `cy`. For example:
+Some custom Nightwatch commands located in `src/platform/testing/e2e/nightwatch-commands` were converted to custom Cypress commands, and can be found in `src/platform/testing/e2e/cypress/support/commands`.
+
+Many of them did not need to be converted, either because Cypress supports their functionality natively or the functionality was [too simple to abstract into a command](https://docs.cypress.io/api/cypress-api/custom-commands.html#2-Don%E2%80%99t-overcomplicate-things).
+
+These custom commands can be called from the `cy` object. For example:
 
 ```javascript
-cy.fillDate('root_dob', testData.veteranDateOfBirth);
+cy.axeCheck();
 ```
 
 ### Test Data (Fixtures) <a name="test-data"></a>
 
 In Cypress, because everything in a test is executed inside of the browser, [fixtures](https://docs.cypress.io/api/commands/fixture.html#Syntax) are used to get access to data in tests.
 
-By default Cypress doesn't support fixtures in seperate directories, so we have a custom command used for accessing fixtures stored in your app's directory. 
+By default, Cypress doesn't support fixtures in separate directories, so we have a custom command for accessing fixtures stored in your app's directory.
 
-For example, `src/applications/hca/tests/schema` contains test data for the `hca` application. You can grab the files like so:
+For example, `src/applications/hca/tests/schema` contains test data for the `hca` application. You can load the file as a fixture like so:
 
 ```javascript
 cy.syncFixtures({
-  'maximal-test.json': 'src/applications/hca/tests/schema/maximal-test.json', 
+  'data': 'srce/applications/hca/tests/schema',
+  'minimal-test.json': 'src/applications/hca/tests/schema/maximal-test.json', 
+  'maximal-test': 'src/applications/hca/tests/schema/maximal-test.json',
 });
 
 cy.fixture('maximal-test.json').as('testData');
 ```
 
-To get access to the fixture, you can use `.get()`:
+To access the contents of the file, you can use a combination of `cy.get()` and `cy.then()`:
 
 ```javascript
 cy.get('@testData').then(testData => {
@@ -132,7 +146,7 @@ cy.get('@testData').then(testData => {
 
 ### Mocking Data <a name="mocking-data"></a>
 
-Cypress allows you to [stub responses](https://docs.cypress.io/guides/guides/network-requests.html#Stubbing), which can avoid the need to use the mock api helpers.
+Cypress allows you to [stub responses](https://docs.cypress.io/guides/guides/network-requests.html#Stubbing), avoiding the need for mock API helpers.
 
 ```javascript
 // Start a server to begin routing responses
@@ -166,12 +180,14 @@ cy.on('window:before:load', window => {
   delete window.fetch;
 });
 ```
-Based on the above stubs, whenever the browser makes a `GET` request to `/v0/health_care_applications/enrollment_status*` or a `POST` request to `/v0/health_care_applications`, cypress will automatically stub the given response.
+Based on the above stubs, whenever the browser makes a `GET /v0/health_care_applications/enrollment_status*` or a `POST /v0/health_care_applications` request, Cypress will automatically handle the request with the stubbed response.
 
-All of your mock api calls using `mockData()` can be replaced with `cy.route()`. Note, be sure to always start the server with `cy.server()` before stubbing requests.
+All of your mock API calls using `mockData()` can be replaced with `cy.route()`.
+
+Be sure to always start the server with `cy.server()` before stubbing requests.
 
 ### File Uploads <a name="file-uploads"></a>
-File uploads are not yet natively supported in Cypress. We have a custom command for uploading files that is based off [this](https://github.com/cypress-io/cypress/issues/170#issuecomment-619758213) workaround.
+File uploads are not yet natively supported in Cypress. We have a custom command for uploading files that is based off of [this workaround](https://github.com/cypress-io/cypress/issues/170#issuecomment-619758213). 
 
 ```javascript
 cy.get('[name="root_attachments_0_attachmentName"]')
@@ -179,9 +195,9 @@ cy.get('[name="root_attachments_0_attachmentName"]')
 ```
 
 ### Accessibility <a name="accessibility"></a>
-Just like most e2e tools, cypress has its own [axe-core plugin](https://github.com/avanslaars/cypress-axe) to test accessibility.
+Like most E2E tools, Cypress has its own [axe-core plugin](https://github.com/avanslaars/cypress-axe) to test accessibility.
 
-To add axe checks to your tests use the custom `axeCheck()` command based off the `checkA11y` [command](https://github.com/avanslaars/cypress-axe#cychecka11y).
+To add aXe checks to your tests use the custom `axeCheck()` command based off the `checkA11y` [command](https://github.com/avanslaars/cypress-axe#cychecka11y).
 
 #### Nightwatch:
 ```javascript
@@ -219,15 +235,15 @@ cy.get('button').should('be.disabled')
 
 ## Running Tests <a name="running-tests"></a>
 
-As of now, cypress supports Chrome, Edge, Firefox(beta) and a few [others](https://docs.cypress.io/guides/guides/launching-browsers.html#Browsers). You can run tests in headless mode or via the test runner.
+Cypress supports Chrome, Edge, Firefox, and a few [others](https://docs.cypress.io/guides/guides/launching-browsers.html#Browsers). You can run tests in headless mode or via the test runner.
 
 ### Headless mode <a name="headless-mode"></a>
-To run tests headless, run `yarn test:cypress:run`
+To run tests headless, run `yarn cypress run --headless`
 
 ### Test Runner <a name="test-runner"></a>
-To run tests using the cypress [test runner](https://docs.cypress.io/guides/core-concepts/test-runner.html#Overview), run `yarn test:cypress:open`.
+To run tests using the Cypress [test runner](https://docs.cypress.io/guides/core-concepts/test-runner.html#Overview), run `yarn cypress open`.
 
-With the Test Runner, you are able to use cypress's `Open Selector Playground'. This allows you to click on elements in the DOM and copy the selector for that item for your test. This means there's usually no need to inspect an element manually.
+With the test runner, you are able to use Cypress's "Open Selector Playground". This allows you to click on elements in the DOM and copy that element's selector to use in your test. This means there's usually no need to manually inspect an element and copy the selector.
 
 The test runner provides the ability to pause tests, and [time travel](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#Time-travel), which allows you to see snapshots of your tests.
 

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -1,0 +1,243 @@
+# Cypress Migration Guide
+
+The purpose of this guide is to help with converting Nightwatch tests to Cypress.
+
+# Table of Contents
+1. [Initial Setup](#initial-setup)
+2. [Writing Tests](#writing-tests)
+    1. [Test Structure](#test-structure)
+    2. [Visiting a page](#visiting-a-page)
+    3. [Interacting With Page Elements](#interacting-with-page-elements)
+    4. [Custom Commands](#custom-commands)
+    5. [Test Data](#test-data)
+    6. [Mocking Data](#mocking-data)
+    7. [File Uploads](#file-uploads)
+    8. [Accessibility](#accessibility)
+    9. [Assertions](#assertions)
+3. [Running Tests](#running-tests)
+    1. [Headless Mode](#headless-mode)
+    1. [Test Runner](#test-runner)
+4. [Things to Note](#things-to-note)
+
+## Initial Setup <a name="initial-setup"></a>
+
+The location of tests remains the same as it is in nightwatch. All cypress tests must be in the `tests` directory of the application.
+Cypress tests need to have the file extension `.cypress.spec.js`. E.g. `my-test-name.cypress.spec.js`.
+
+The overall folder structure for cypress in the `vets-website` repo is as follows:
+
+```
+vets-website
+|
+└───src/platform/testing/e2e-cypress
+|   |
+│   └───fixtures
+│   |   │   hca/maximal-test.json
+│   |   │   
+│   └───plugins
+│   |   │   index.js
+│   |   │   
+│   └───support
+│       │   commands.js
+│       │   index.js
+```
+
+- `cypress.json` holds the [configuration](https://docs.cypress.io/guides/references/configuration.html) for cypress tests. You can set things like the `baseUrl`, `defaultCommandTimeout`, etc.
+- `fixtures` holds the [test data](https://docs.cypress.io/api/commands/fixture.html) that can be accessed inside of cypress tests.
+- `plugins` contains custom tasks, which allow you to [tap into the node environment](https://docs.cypress.io/guides/tooling/plugins-guide.html). This is valuable because all cypress test code is executed in the browser, so plugins allow us to execute code in the node process running outside of the browser.
+- `support` holds [custom cypress commands](https://docs.cypress.io/api/cypress-api/custom-commands.html#Syntax), specifically in the `commands.js` file. These commands can be run in cypress tests, similar to the built in commands. This is similar to [Nightwatch's custom commands](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/common-tasks/new-end-to-end-test/#custom-nightwatch-commands). This is also where cypress plugins are imported, as shown in `index.js`.
+
+### Test Dependencies
+You do not need to import any modules for helpers and timeouts, etc as before with nightwatch. You can start writing your tests without anything needed to be imported.
+
+## Writing Tests <a name="writing-tests"></a>
+### Test Structure <a name="test-structure"></a>
+The test structure of Cypress should feel familiar. Cypress uses mocha's bdd syntax which is what we use for our unit tests. Note that because `it()` blocks are their own tests, each `it()` block should be independent of others in the same testing suite. Everything executed in the browser needs to be inside of an `it()` block. Visit [here](https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Test-Structure) for more context.
+
+### Visiting a Page <a name="visiting-a-page"></a>
+When [visiting a page](https://docs.cypress.io/api/commands/visit.html#Syntax), you do not need to be concerned about the `baseUrl`. Cypress's configuration file takes care of this. So rather than grabbing the `baseUrl` from the helpers in nightwatch:
+
+```javascript
+client.openUrl(`${E2eHelpers.baseUrl}/health-care/apply/application`)
+```
+
+You can instead enter the page directly:
+
+```javascript
+cy.visit('health-care/apply/application')
+```
+
+### Interacting with Page Elements <a name="interacting-with-page-elements"></a>
+Cypress has a large api that allows for easy interacting with elements. The most common tasks you will probably need to convert from nightwatch tests are clicking, selecting elements from dropdowns, and entering input. Shown below is an overview of how to perform these tasks in cypress.
+
+#### Clicking
+Nightwatch:
+```javascript
+client.click('.form-panel .usa-button-primary');
+```
+Cypress:
+```javascript
+cy.get('.form-panel .usa-button-primary').click();
+```
+
+#### Selecting From Dropdown
+Nightwatch:
+```javascript
+client.selectDropdown('root_veteranAddress_country', data.veteranAddress.country)
+```
+Cypress:
+```javascript
+cy.get('#root_veteranAddress_state').select(testData.veteranAddress.state)
+```
+
+#### Entering Data
+Nightwatch:
+```javascript
+client.fill('input[name="root_firstName"]', data.veteranFullName.first)
+```
+Cypress:
+```javascript
+cy.get('#root_firstName').type(testData.veteranFullName.first)
+```
+
+Please visit [here](https://docs.cypress.io/guides/core-concepts/interacting-with-elements.html#Actionability) for more information about interacting with elements. For additional ways to interact with the DOM we have also included the [cypress testing library](https://testing-library.com/docs/cypress-testing-library/intro) in the repo.
+
+### Custom Commands <a name="custom-commands"></a>
+
+Some custom nightwatch commands located in `src/platform/testing/e2e/nightwatch-commands` were converted to cypress commands, and can be found in `src/platform/testing/e2e-cypress/support`. Many of them did not need to be converted because cypress supports their functionality natively. These custom commands can be used directly on `cy`. For example:
+
+```javascript
+cy.fillDate('root_dob', testData.veteranDateOfBirth);
+```
+
+### Test Data <a name="test-data"></a>
+
+In Cypress, because everything in a test is executed inside of the browser, [fixtures](https://docs.cypress.io/api/commands/fixture.html#Syntax) are used to get access to data in tests.
+
+Fixtures should be stored in the app specific folder inside of `src/platform/testing/e2e-cypress/fixtures`. If the app specific folder does not exist feel free to create it.
+
+For example: `src/platform/testing/e2e-cypress/fixtures/hca` contains all the fixtures for the `hca` application. You can copy all the schema files used in current tests to the proper fixtures folder.
+
+You can inject the fixture into your test by doing:
+```javascript
+cy.fixture('hca/maximal-test.json').as('testData');
+```
+Cypress already knows to look in the `fixtures` folder, so you can use the application specific directory for the path to the fixture.
+
+To get access to the fixture, you can use `.get()`:
+
+```javascript
+cy.get('@testData').then(testData => {
+  cy.get('#root_firstName').type(testData.veteranFullName.first);
+});
+```
+
+### Mocking Data <a name="mocking-data"></a>
+
+Cypress allows you to [stub responses](https://docs.cypress.io/guides/guides/network-requests.html#Stubbing), which can avoid the need to use the mock api helpers.
+
+```javascript
+// Start a server to begin routing responses
+cy.server();
+
+// Stub request to get enrollment status
+cy.route({
+  method: 'GET',
+  url: '/v0/health_care_applications/enrollment_status*',
+  status: 404,
+  response: {
+    errors: [
+      {
+        title: 'Record not found',
+        detail: 'The record identified by  could not be found',
+        code: '404',
+        status: '404',
+      },
+    ],
+  },
+}).as('getApplication');
+
+// Stub request to submit application
+cy.route('POST', '/v0/health_care_applications', {
+  formSubmissionId: '123fake-submission-id-567',
+  timestamp: '2016-05-16',
+}).as('submitApplication');
+
+// Workaround to intercept requests made with fetch API.
+cy.on('window:before:load', window => {
+  delete window.fetch;
+});
+```
+Based on the above stubs, whenever the browser makes a `GET` request to `/v0/health_care_applications/enrollment_status*` or a `POST` request to `/v0/health_care_applications`, cypress will automatically stub the given response.
+
+All of your mock api calls using `mockData()` can be replaced with `cy.route()`. Note, be sure to always start the server with `cy.server()` before stubbing requests.
+
+### File Uploads <a name="file-uploads"></a>
+File uploads can be done using the [cypress file upload](https://github.com/abramenal/cypress-file-upload/tree/v3.5.3) plugin. For instructions on usage please visit [here](https://github.com/abramenal/cypress-file-upload/tree/v3.5.3#usage).
+
+**Note:** Version 4 is unstable to please follow instructions for v3.5.3.
+
+### Accessibility <a name="accessibility"></a>
+Just like most e2e tools, cypress has its own [axe-core plugin](https://github.com/avanslaars/cypress-axe) to test accessibility.
+
+To add axe checks to your tests use the [`checkA11y` command](https://github.com/avanslaars/cypress-axe#cychecka11y).
+
+#### Nightwatch:
+```javascript
+client.axeCheck('.main')
+```
+
+#### Cypress:
+```javascript
+cy.checkA11y('.main', null, terminalLog);
+```
+
+Notice that the last argument in the `checkA11y` command is a [custom function](https://github.com/avanslaars/cypress-axe#in-your-spec-file) that outputs the accessibility errors to the console in a table. You can `import` this function from `platform/testing/e2e-cypress/helpers.js`.
+
+### Assertions <a name="assertions"></a>
+
+Cypress uses `chai` to [handle assertions](https://docs.cypress.io/guides/references/assertions.html#BDD-Assertions). Currently in the `nightwatch-assertions` folder, we have 4 custom assertions, which can all be replaced:
+
+#### hasFocusableCount / hasTabbableCount
+Checks the count of focusable and tabbable elements.
+
+These can be converted by making [custom chai assertions](https://docs.cypress.io/guides/references/assertions.html#Adding-New-Assertions).
+
+#### isActiveElement
+Checks if the given element is focused on the page.
+
+```javascript
+// Bdd assertion
+cy.get('input').should('have.focus')
+```
+#### isDisabledElement 
+Checks if the given element is disabled on the page.
+
+```javascript
+// Bdd assertion
+cy.get('button').should('be.disabled')
+```
+
+## Running Tests <a name="running-tests"></a>
+
+As of now, cypress supports Chrome, Edge, Firefox(beta) and a few [others](https://docs.cypress.io/guides/guides/launching-browsers.html#Browsers). You can run tests in headless mode or via the test runner.
+
+### Headless mode <a name="headless-mode"></a>
+To run tests headless, run `yarn test:cypress:run`
+
+### Test Runner <a name="test-runner"></a>
+To run tests using the cypress [test runner](https://docs.cypress.io/guides/core-concepts/test-runner.html#Overview), run `yarn test:cypress:open`.
+
+With the Test Runner, you are able to use cypress's `Open Selector Playground'. This allows you to click on elements in the DOM and copy the selector for that item for your test. This means there's usually no need to inspect an element manually.
+
+The test runner provides the ability to pause tests, and [time travel](https://docs.cypress.io/guides/getting-started/writing-your-first-test.html#Time-travel), which allows you to see snapshots of your tests.
+
+You can add any of the [run options](https://docs.cypress.io/guides/guides/command-line.html#Commands) to the commands above.
+
+## Things to Note <a name="things-to-note"></a>
+
+### Automatic Waiting
+Cypress automatically waits for commands to execute before moving on to the next. This eliminates needing to use the timeout consts in `platform/testing/e2e/timeouts.js`
+
+### Third Party Plugins
+Cypress has many third party [plugins](https://docs.cypress.io/plugins/) available. If you find yourself needing to do something that isn't natively supported, there may be a plugin for it.

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -180,7 +180,7 @@ File uploads can be done using the [cypress file upload](https://github.com/abra
 ### Accessibility <a name="accessibility"></a>
 Just like most e2e tools, cypress has its own [axe-core plugin](https://github.com/avanslaars/cypress-axe) to test accessibility.
 
-To add axe checks to your tests use the [`checkA11y` command](https://github.com/avanslaars/cypress-axe#cychecka11y).
+To add axe checks to your tests use the custom `axeCheck()` command based off the `checkA11y` [command](https://github.com/avanslaars/cypress-axe#cychecka11y).
 
 #### Nightwatch:
 ```javascript
@@ -189,10 +189,8 @@ client.axeCheck('.main')
 
 #### Cypress:
 ```javascript
-cy.checkA11y('.main', null, terminalLog);
+cy.axeCheck();
 ```
-
-Notice that the last argument in the `checkA11y` command is a [custom function](https://github.com/avanslaars/cypress-axe#in-your-spec-file) that outputs the accessibility errors to the console in a table. You can `import` this function from `platform/testing/e2e-cypress/helpers.js`.
 
 ### Assertions <a name="assertions"></a>
 

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -175,9 +175,12 @@ Based on the above stubs, whenever the browser makes a `GET` request to `/v0/hea
 All of your mock api calls using `mockData()` can be replaced with `cy.route()`. Note, be sure to always start the server with `cy.server()` before stubbing requests.
 
 ### File Uploads <a name="file-uploads"></a>
-File uploads can be done using the [cypress file upload](https://github.com/abramenal/cypress-file-upload/tree/v3.5.3) plugin. For instructions on usage please visit [here](https://github.com/abramenal/cypress-file-upload/tree/v3.5.3#usage).
+File uploads are not yet natively supported in Cypress. We have a custom command for uploading files that is based off [this](https://github.com/cypress-io/cypress/issues/170#issuecomment-619758213) workaround.
 
-**Note:** Version 4 is unstable to please follow instructions for v3.5.3.
+```javascript
+cy.get('[name="root_attachments_0_attachmentName"]')
+  .upload('src/platform/testing/example-upload.png', 'image/jpg')
+```
 
 ### Accessibility <a name="accessibility"></a>
 Just like most e2e tools, cypress has its own [axe-core plugin](https://github.com/avanslaars/cypress-axe) to test accessibility.

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -133,7 +133,7 @@ cy.syncFixtures({
   'maximal-test': 'src/applications/hca/tests/schema/maximal-test.json',
 });
 
-cy.fixture('maximal-test.json').as('testData');
+cy.fixture('maximal-test').as('testData');
 ```
 
 To access the contents of the file, you can use a combination of `cy.get()` and `cy.then()`:
@@ -174,11 +174,6 @@ cy.route('POST', '/v0/health_care_applications', {
   formSubmissionId: '123fake-submission-id-567',
   timestamp: '2016-05-16',
 }).as('submitApplication');
-
-// Workaround to intercept requests made with fetch API.
-cy.on('window:before:load', window => {
-  delete window.fetch;
-});
 ```
 Based on the above stubs, whenever the browser makes a `GET /v0/health_care_applications/enrollment_status*` or a `POST /v0/health_care_applications` request, Cypress will automatically handle the request with the stubbed response.
 
@@ -252,7 +247,9 @@ You can add any of the [run options](https://docs.cypress.io/guides/guides/comma
 ## Things to Note <a name="things-to-note"></a>
 
 ### Automatic Waiting
-Cypress automatically waits for commands to execute before moving on to the next. This eliminates needing to use the timeout consts in `platform/testing/e2e/timeouts.js`. Cypress queues it's commands instead of running them synchronously, so doing something like [this](https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values) will not work.
+Cypress automatically waits for commands to execute before moving on to the next one. This eliminates the need to use the timeout constants in `platform/testing/e2e/timeouts.js`.
+
+Cypress queues its commands instead of running them synchronously, so doing something like [this](https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values) will not work.
 
 ### Third Party Plugins
 Cypress has many third party [plugins](https://docs.cypress.io/plugins/) available. If you find yourself needing to do something that isn't natively supported, there may be a plugin for it.

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -252,7 +252,7 @@ You can add any of the [run options](https://docs.cypress.io/guides/guides/comma
 ## Things to Note <a name="things-to-note"></a>
 
 ### Automatic Waiting
-Cypress automatically waits for commands to execute before moving on to the next. This eliminates needing to use the timeout consts in `platform/testing/e2e/timeouts.js`
+Cypress automatically waits for commands to execute before moving on to the next. This eliminates needing to use the timeout consts in `platform/testing/e2e/timeouts.js`. Cypress queues it's commands instead of running them synchronously, so doing something like [this](https://docs.cypress.io/guides/references/best-practices.html#Assigning-Return-Values) will not work.
 
 ### Third Party Plugins
 Cypress has many third party [plugins](https://docs.cypress.io/plugins/) available. If you find yourself needing to do something that isn't natively supported, there may be a plugin for it.

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -29,21 +29,17 @@ The overall folder structure for cypress in the `vets-website` repo is as follow
 ```
 vets-website
 |
-└───src/platform/testing/e2e-cypress
-|   |
-│   └───fixtures
-│   |   │   hca/maximal-test.json
+└───src/platform/testing/e2e/cypress
 │   |   │   
 │   └───plugins
 │   |   │   index.js
 │   |   │   
 │   └───support
-│       │   commands.js
+│       │   commands
 │       │   index.js
 ```
 
 - `cypress.json` holds the [configuration](https://docs.cypress.io/guides/references/configuration.html) for cypress tests. You can set things like the `baseUrl`, `defaultCommandTimeout`, etc.
-- `fixtures` holds the [test data](https://docs.cypress.io/api/commands/fixture.html) that can be accessed inside of cypress tests.
 - `plugins` contains custom tasks, which allow you to [tap into the node environment](https://docs.cypress.io/guides/tooling/plugins-guide.html). This is valuable because all cypress test code is executed in the browser, so plugins allow us to execute code in the node process running outside of the browser.
 - `support` holds [custom cypress commands](https://docs.cypress.io/api/cypress-api/custom-commands.html#Syntax), specifically in the `commands.js` file. These commands can be run in cypress tests, similar to the built in commands. This is similar to [Nightwatch's custom commands](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/getting-started/common-tasks/new-end-to-end-test/#custom-nightwatch-commands). This is also where cypress plugins are imported, as shown in `index.js`.
 

--- a/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
+++ b/teams/vsp/teams/tools/frontend/cypress-migration-guide.md
@@ -9,7 +9,7 @@ The purpose of this guide is to help with converting Nightwatch tests to Cypress
     2. [Visiting a page](#visiting-a-page)
     3. [Interacting With Page Elements](#interacting-with-page-elements)
     4. [Custom Commands](#custom-commands)
-    5. [Test Data](#test-data)
+    5. [Test Data (Fixtures)](#test-data)
     6. [Mocking Data](#mocking-data)
     7. [File Uploads](#file-uploads)
     8. [Accessibility](#accessibility)
@@ -110,19 +110,21 @@ Some custom nightwatch commands located in `src/platform/testing/e2e/nightwatch-
 cy.fillDate('root_dob', testData.veteranDateOfBirth);
 ```
 
-### Test Data <a name="test-data"></a>
+### Test Data (Fixtures) <a name="test-data"></a>
 
 In Cypress, because everything in a test is executed inside of the browser, [fixtures](https://docs.cypress.io/api/commands/fixture.html#Syntax) are used to get access to data in tests.
 
-Fixtures should be stored in the app specific folder inside of `src/platform/testing/e2e-cypress/fixtures`. If the app specific folder does not exist feel free to create it.
+By default Cypress doesn't support fixtures in seperate directories, so we have a custom command used for accessing fixtures stored in your app's directory. 
 
-For example: `src/platform/testing/e2e-cypress/fixtures/hca` contains all the fixtures for the `hca` application. You can copy all the schema files used in current tests to the proper fixtures folder.
+For example, `src/applications/hca/tests/schema` contains test data for the `hca` application. You can grab the files like so:
 
-You can inject the fixture into your test by doing:
 ```javascript
-cy.fixture('hca/maximal-test.json').as('testData');
+cy.syncFixtures({
+  'maximal-test.json': 'src/applications/hca/tests/schema/maximal-test.json', 
+});
+
+cy.fixture('maximal-test.json').as('testData');
 ```
-Cypress already knows to look in the `fixtures` folder, so you can use the application specific directory for the path to the fixture.
 
 To get access to the fixture, you can use `.get()`:
 


### PR DESCRIPTION
This is the migration guide that will be used to help teams convert their nightwatch tests. All feedback is welcome and appreciated!