### PR TITLE
Replace HTML image with markdown image

### DIFF
--- a/platform/working-with-vsp/orientation/zenhub.md
+++ b/platform/working-with-vsp/orientation/zenhub.md
@@ -15,7 +15,7 @@ To start using Zenhub, you can follow the onboarding process described here:
 
 If after following the onboarding instructions above, you see a screen like the below stating "You have not been assigned a license; Contact an admin to request access", 
 
-<img src="zenhub-license-request.png" width="400" alt="zenhub license request"></img>
+![zenhub license request](zenhub-license-request.png)
 
 try to click the button to request a license, then wait 1 business day for access to be granted.
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Technical_summary), an `image` tag must not have an end tag.

>Must have a start tag and must not have an end tag.

Invalid HTML in a markdown file breaks the build of the [`veteran-facing-services-tools` repo](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/).

![image](https://user-images.githubusercontent.com/6130520/83894488-f9c86380-a716-11ea-8620-b17fa17542af.png)

This PR fixes that invalid HTML, which should prevent the `veteran-facing-services-tools` build from failing in the future. 