### PR TITLE
change to vagov for updated naming convention

### DIFF
--- a/scripts/socks/README.md
+++ b/scripts/socks/README.md
@@ -19,7 +19,7 @@ Make sure to comment out any `IdentitiesOnly yes` directives set at the top leve
 Once this is saved, try the following commands:
 
 ```
-$ ssh-add -K ~/.ssh/vetsgov_id_rsa
+$ ssh-add -K ~/.ssh/*gov*
 $ ssh socks -D 2001 -N
 ```
 
@@ -31,7 +31,7 @@ $ ./socks.sh     # check status
 $ ./socks.sh off # turn off socks proxy
 ```
 
-The script assumes you have stored your key at `~/.ssh/vetsgov_id_rsa` - if you put it elsewhere you can set the VA_SOCKS_KEYFILE variable before invoking it. The script also sets up a proxy for the "Wi-Fi" network by default; if you are using a different network, you can override the SOCKS_NETWORK environment variable - for example:
+The script assumes you have stored your key using "gov" somewhere within name (`~/.ssh/*gov*`). If you put it elsewhere or name it otherwise, you can set the VA_SOCKS_KEYFILE variable before invoking it. The script also sets up a proxy for the "Wi-Fi" network by default; if you are using a different network, you can override the SOCKS_NETWORK environment variable - for example:
 
 ```
 $ SOCKS_NETWORK="USB 10/100/1000 LAN" ./socks.sh on

--- a/scripts/socks/socks.sh
+++ b/scripts/socks/socks.sh
@@ -18,8 +18,8 @@ AUTOCONFIG_PORT=9500
 # from https://stackoverflow.com/a/246128/4907881
 PROXY_PAC_LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/vetsgov_id_rsa}"
-socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/vetsgov_id_rsa}"
+socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/vagov_id_rsa}"
+socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/vagov_id_rsa}"
 socks_start_cmd="ssh socks -D ${WEB_PORT} -N";
 socks_kill_cmd="pkill -f \"$socks_start_cmd\"";
 webserver_start_cmd="ruby -run -e httpd ${PROXY_PAC_LOCATION} -p ${AUTOCONFIG_PORT} --bind-address 127.0.0.1"

--- a/scripts/socks/socks.sh
+++ b/scripts/socks/socks.sh
@@ -18,8 +18,8 @@ AUTOCONFIG_PORT=9500
 # from https://stackoverflow.com/a/246128/4907881
 PROXY_PAC_LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/*v*gov*}"
-socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/*v*gov*}"
+socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/*gov*}"
+socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/*gov*}"
 socks_start_cmd="ssh socks -D ${WEB_PORT} -N";
 socks_kill_cmd="pkill -f \"$socks_start_cmd\"";
 webserver_start_cmd="ruby -run -e httpd ${PROXY_PAC_LOCATION} -p ${AUTOCONFIG_PORT} --bind-address 127.0.0.1"

--- a/scripts/socks/socks.sh
+++ b/scripts/socks/socks.sh
@@ -18,8 +18,8 @@ AUTOCONFIG_PORT=9500
 # from https://stackoverflow.com/a/246128/4907881
 PROXY_PAC_LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/vagov_id_rsa}"
-socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/vagov_id_rsa}"
+socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/id_rsa_v*gov*}"
+socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/id_rsa_v*gov*}"
 socks_start_cmd="ssh socks -D ${WEB_PORT} -N";
 socks_kill_cmd="pkill -f \"$socks_start_cmd\"";
 webserver_start_cmd="ruby -run -e httpd ${PROXY_PAC_LOCATION} -p ${AUTOCONFIG_PORT} --bind-address 127.0.0.1"

--- a/scripts/socks/socks.sh
+++ b/scripts/socks/socks.sh
@@ -18,8 +18,8 @@ AUTOCONFIG_PORT=9500
 # from https://stackoverflow.com/a/246128/4907881
 PROXY_PAC_LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/id_rsa_v*gov*}"
-socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/id_rsa_v*gov*}"
+socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/*v*gov*}"
+socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/*v*gov*}"
 socks_start_cmd="ssh socks -D ${WEB_PORT} -N";
 socks_kill_cmd="pkill -f \"$socks_start_cmd\"";
 webserver_start_cmd="ruby -run -e httpd ${PROXY_PAC_LOCATION} -p ${AUTOCONFIG_PORT} --bind-address 127.0.0.1"


### PR DESCRIPTION
Working on updating the docs in https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/internal-tools.md and phasing out references to the old `vetsgov` naming convention. This PR updates key naming to newer version / matches to changes being made to the internal-tools doc.

Additional reference for transparency: https://github.com/department-of-veterans-affairs/va.gov-team/pull/11950