### PR TITLE
add GIDS PR review guidelines

### DIFF
--- a/teams/vsp/teams/tools/backend/README.md
+++ b/teams/vsp/teams/tools/backend/README.md
@@ -1,1 +1,16 @@
-BE Tools Team Readme
+# BE Tools Team
+
+## Utility Developer Support Rotation
+
+### GIDS/BAH PR Reviews
+
+The GIDS/BAH team needs a bit more autonomy, and so their PR review process differs from the [standard process](../../../../../platform/engineering/code_review_guidelines.md) as follows:
+
+- VSP review for major problems with syntax or rubyisms.
+- VSP review changes to `db/migrate/*`.
+- VSP review changes to `Gemfile`.
+- VSP review changes to `spec/factories`.
+- VSP will not request large PRs (> 250 SLoC) be broken up, and GIDS will not expect VSP to perform thorough review of large PRs.
+- VSP do not critique code organization.
+- VSP do not review SQL strings for safety. GIDS are solely responsible for the safety and security of their SQL code.
+- VSP do not perform security reviews. GIDS are solely responsible for the security of their code.


### PR DESCRIPTION
Per https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/12452, we want to publish the guidelines for GIDS reviews.

This PR is *not* intended to introduce new guidelines for interacting with GIDS. Its sole purpose is to codify the guidelines that currently live only in folks' minds.