### PR TITLE
move GIDS PR guidelines to ongoing-support-developer doc

### DIFF
--- a/teams/vsp/teams/tools/backend/README.md
+++ b/teams/vsp/teams/tools/backend/README.md
@@ -1,16 +1,1 @@
 # BE Tools Team
-
-## Utility Developer Support Rotation
-
-### GIDS/BAH PR Reviews
-
-The GIDS/BAH team needs a bit more autonomy, and so their PR review process differs from the [standard process](../../../../../platform/engineering/code_review_guidelines.md) as follows:
-
-- VSP review for major problems with syntax or rubyisms.
-- VSP review changes to `db/migrate/*`.
-- VSP review changes to `Gemfile`.
-- VSP review changes to `spec/factories`.
-- VSP will not request large PRs (> 250 SLoC) be broken up, and GIDS will not expect VSP to perform thorough review of large PRs.
-- VSP do not critique code organization.
-- VSP do not review SQL strings for safety. GIDS are solely responsible for the safety and security of their SQL code.
-- VSP do not perform security reviews. GIDS are solely responsible for the security of their code.

--- a/teams/vsp/teams/tools/backend/triage/ongoing-support-developer.md
+++ b/teams/vsp/teams/tools/backend/triage/ongoing-support-developer.md
@@ -96,6 +96,19 @@ For quick reference these are also pinned in the [#vsp-backend-utility-dev] chan
 
 - add pull request to the [Code Review Epic][Super Epics] for the current sprint
 
+#### GIDS/BAH PR Reviews
+
+The GIDS/BAH team needs a bit more autonomy, and so their PR review process differs from the [standard process](../../../../../../platform/engineering/code_review_guidelines.md) as follows:
+
+- VSP review for major problems with syntax or rubyisms.
+- VSP review changes to `db/migrate/*`.
+- VSP review changes to `Gemfile`.
+- VSP review changes to `spec/factories`.
+- VSP will not request large PRs (> 250 SLoC) be broken up, and GIDS will not expect VSP to perform thorough review of large PRs.
+- VSP do not critique code organization.
+- VSP do not review SQL strings for safety. GIDS are solely responsible for the safety and security of their SQL code.
+- VSP do not perform security reviews. GIDS are solely responsible for the security of their code.
+
 #### Overriding Jumbo Pull Requests
 
 When a pull request is large enough, the `Danger-bot` status check will fail. 


### PR DESCRIPTION
I realized this morning that there was a better place for these guidelines. So I moved them.