### PR TITLE
Update the design system edge cases doc

### DIFF
--- a/platform/design/design-system/governance-process/edge-cases.md
+++ b/platform/design/design-system/governance-process/edge-cases.md
@@ -26,15 +26,15 @@ Edge cases arise when, in step 3 of the happy path, **teams can't isolate the re
 
 #### If the change impacts multiple features/teams:
 The VFS team can't launch until this gets reviewed by the design system council.
-- Example: forms library changes, buttons, error messaging
+- **Example:** forms library changes, buttons, error messaging
 
 #### If the change does not impact multiple features/teams:
 The VFS team can submit a PR for VSP to review the code change. The PR is subject to the [platform code review guidelines](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md). [Submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column with the `code new` label and the design system council will review the request when it is prioritized.
-- Example: global elements like the header
+- **Example:** global elements like the header
 
 ### For changes that are not launch-blocking
 The VFS team can't change the code, but should [submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column w/the appropriate label. The design system council will review the request when it is prioritized.
-- Example: minor visual bugs
+- **Example:** minor visual bugs
 
 ### Escalation path for decision-making
 For assistance in deciding on the best solution, escalate to any VSP DEPO lead.

--- a/platform/design/design-system/governance-process/edge-cases.md
+++ b/platform/design/design-system/governance-process/edge-cases.md
@@ -3,7 +3,7 @@
 The Design System Governance Process is based on a happy path flow for VFS teams to request a new pattern or adjust an existing pattern. This happy path does not always accomodate certain VFS team edge case scenarios. We're not currently prioritizing Design System and Forms Library improvements that would prevent these edge cases. This document explains how we handle edge cases based on whether the required changes are launch-blocking and their impact to other teams or features.
 
 ## Overview of happy path to submit new/adjust an existing pattern
-This is the happy path flow for a VFS team that wants to create a new pattern or adjust an existing pattern for their solution to better meet the needs of their users:
+**This is the happy path flow** for a VFS team that wants to create a new pattern or adjust an existing pattern for their solution to better meet the needs of their users:
 1. Draft new/adjusted pattern
 1. Get new/adjusted pattern approved through design reviews in the Collaboration Cycle
 1. Use that new/adjusted pattern in the isolated code for the feature
@@ -13,20 +13,20 @@ That's it! VSP works through the backlog and transforms proposed new/adjusted pa
 
 ## Edge cases not accounted for in the happy path
 
-Edge cases arise when, in step 3 of the happy path, teams can't isolate the required changes in their code.
+Edge cases arise when, in step 3 of the happy path, **teams can't isolate the required changes in their code.**
 
-- Example 1: code changes that must made directly in the forms library for it to render for that feature
-- Example 2: the feature is a global element stored only in the design system
+- **Example 1:** code changes that must be made **directly in the forms library** for it to render for that feature
+- **Example 2:** the feature is a **global element** stored only in the design system
 
 
 ## Edge case governance process
 
 ### For changes that are launch-blocking
-**If the change impacts multiple features/teams:** \
+#### If the change impacts multiple features/teams:
 The VFS team can't launch until this gets reviewed by the design system council.
 - Example: forms library changes, buttons, error messaging
 
-**If the change does not impact multiple features/teams:** \
+#### If the change does not impact multiple features/teams:
 The VFS team can change the code. [Submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column with the `code new` label and the design system council will review the request when it is prioritized.
 - Example: global elements like the header
 
@@ -36,3 +36,4 @@ The VFS team can't change the code, but should [submit a ticket](https://github.
 
 ### Escalation path for decision-making
 For assistance in deciding on the best solution, escalate to any VSP DEPO lead.
+

--- a/platform/design/design-system/governance-process/edge-cases.md
+++ b/platform/design/design-system/governance-process/edge-cases.md
@@ -22,12 +22,14 @@ Edge cases arise when, in step 3 of the happy path, **teams can't isolate the re
 ## Edge case governance process
 
 ### For changes that are launch-blocking
+"Launch-blocking" is defined here by the VFS team.
+
 #### If the change impacts multiple features/teams:
 The VFS team can't launch until this gets reviewed by the design system council.
 - Example: forms library changes, buttons, error messaging
 
 #### If the change does not impact multiple features/teams:
-The VFS team can change the code. [Submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column with the `code new` label and the design system council will review the request when it is prioritized.
+The VFS team can submit a PR for VSP to review the code change. The PR is subject to the [platform code review guidelines](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md). [Submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column with the `code new` label and the design system council will review the request when it is prioritized.
 - Example: global elements like the header
 
 ### For changes that are not launch-blocking

--- a/platform/design/design-system/governance-process/edge-cases.md
+++ b/platform/design/design-system/governance-process/edge-cases.md
@@ -21,21 +21,27 @@ Edge cases arise when, in step 3 of the happy path, **teams can't isolate the re
 
 ## Edge case governance process
 
-### For changes that are launch-blocking
-"Launch-blocking" is defined here by the VFS team.
+### For application changes that are launch-blocking
 
-#### If the change impacts multiple features/teams:
-The VFS team can't launch until this gets reviewed by the design system council.
+When a VFS team needs application changes that diverge from existing design system patterns to launch, the following guidance summarizes their options:
+
+#### If the application change _can_ be made without impacting multiple features/teams:
+
+If the VFS team is able to make the change within their own application code, they should do so.
+
+VSP will evaluate if this application change should **also** be made to the design system in the future, but without launch-blocking the VFS team in the meantime. To track this, the VFS team should [submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column with the `code new` label. The VSP design system council will review the request at a later date.
+
+- **Example:** global elements like the header, new components for a specific application
+
+#### If the application change _cannot_ be made without impact to other features/teams:
+
+For application changes where the implementation affects additional features/teams, this should be treated as a design system change. Therefore, the VFS team can't launch until this gets reviewed by the design system council.
+
 - **Example:** forms library changes, buttons, error messaging
 
-#### If the change does not impact multiple features/teams:
-The VFS team can submit a PR for VSP to review the code change. The PR is subject to the [platform code review guidelines](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/code_review_guidelines.md). [Submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column with the `code new` label and the design system council will review the request when it is prioritized.
-- **Example:** global elements like the header
-
 ### For changes that are not launch-blocking
-The VFS team can't change the code, but should [submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column w/the appropriate label. The design system council will review the request when it is prioritized.
+The VFS team can't change the code, but should [submit a ticket](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/projects/3) in the Proposals column w/the appropriate label. The design system council will review the request at a later date.
 - **Example:** minor visual bugs
 
 ### Escalation path for decision-making
 For assistance in deciding on the best solution, escalate to any VSP DEPO lead.
-


### PR DESCRIPTION
The updates here
- Add a little more clarity on what "VFS teams can change the code" means
- Explicitly state what "launch-blocking" means
- Encourage VFS teams to use existing design system patterns and components