### PR TITLE
Updates to socks.sh script and associated instructions

### DIFF
--- a/platform/engineering/internal-tools.md
+++ b/platform/engineering/internal-tools.md
@@ -187,11 +187,12 @@ These steps assume your SSH keys have been authorized and that you're running on
 > The next steps are going to create a `~/.ssh/config` file. If you already have a `~/.ssh/config` file and would like to keep it intact, you can save the file to a different name `~/.ssh/config_va` and edit `~/.ssh/config` to add this line at the top: `Include ~/.ssh/config_va`. Alternatively, you can use the following command within the terminal to automate this process: `grep -qxF 'Include ~/.ssh/config_va' ~/.ssh/config || echo -e "Include ~/.ssh/config_va\n$(cat ~/.ssh/config)" > ~/.ssh/config`.
 
 1. Save the SSH configuration that you'll need locally to access the remote SSH servers.
-    * Click <a href="https://github.com/department-of-veterans-affairs/devops/raw/master/ssh/config" target="_blank">this link</a> and copy the entire URL of the new tab.
-      1. From within the terminal (Mac/Linux) or Git Bash (Windows), run the following command making sure to change `$URL` to the one you now have copied (i.e. `https://raw.githubusercontent.com/department-of-veterans-affairs/devops/master/ssh/config\?token\=ANNHPNCZI2YPEPZFLIAOGQS7GVQSE`): `curl -o ~/.ssh/config $URL`. 
+    * Click <a href="https://github.com/department-of-veterans-affairs/devops/raw/master/ssh/config" target="_blank">this link</a>
+    * Right click and save the resulting file to ~/.ssh/config, or alternately,
+    * copy the entire URL of the new tab and from within the terminal (Mac/Linux) or Git Bash (Windows), run the following command making sure to change `$URL` to the one you now have copied (i.e. `https://raw.githubusercontent.com/department-of-veterans-affairs/devops/master/ssh/config?token=xxxyyy`): `curl -o ~/.ssh/config $URL`. 
 
 ```
-❯ curl -o ~/.ssh/config https://raw.githubusercontent.com/department-of-veterans-affairs/devops/master/ssh/config\?token\=ANNHPNCZI2YPEPZFLIAOGQS7GVQSE
+❯ curl -o ~/.ssh/config https://raw.githubusercontent.com/department-of-veterans-affairs/devops/master/ssh/config?token=xxxyyy
 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  5804  100  5804    0     0  15602      0 --:--:-- --:--:-- --:--:-- 15602
@@ -247,7 +248,13 @@ To test your proxy connectivity, the best option is to run the following command
 
 You should get output that includes `HTTP/1.1 302 FOUND`. If not, check that the SOCKS proxy server is running. You can run `$ nc -z 127.0.0.1 2001` as a first step.
 
-### Chrome & Firefox
+### Connecting your browser to the proxy
+There are two alternatives to connecting your browser to the proxy.
+
+1. Install SwitchyOmega: browser extension that will let you use the proxy just for certain domains
+1. Use the `socks.sh` script: a script will set up OSX with a system-level proxy - this is useful for those who want to use Safari, or who don't want to use browser extensions
+
+#### Set up SwitchyOmega for Chrome & Firefox
 
 1. Install Proxy SwitchyOmega.
 
@@ -277,7 +284,7 @@ You should get output that includes `HTTP/1.1 302 FOUND`. If not, check that the
 
 1. Check your connection by navigating to Sentry at http://sentry.vfs.va.gov.
 
-### Socks script
+#### Use the Socks script
 An alternative to SwitchyOmega is to use [the `socks` script](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/scripts/socks). The `socks` script loads your key into the SSH agent, starts the socks proxy, and sets up your system to proxy only URLs that require the proxy. It has the advantage of not requiring any third-party extensions, and it works with Chrome and Firefox browsers.
 
 ### Using the va.sh helper script

--- a/scripts/socks/README.md
+++ b/scripts/socks/README.md
@@ -19,7 +19,7 @@ Make sure to comment out any `IdentitiesOnly yes` directives set at the top leve
 Once this is saved, try the following commands:
 
 ```
-$ ssh-add -K ~/.ssh/*gov*
+$ ssh-add -K ~/.ssh/id_rsa_vagov
 $ ssh socks -D 2001 -N
 ```
 
@@ -31,7 +31,9 @@ $ ./socks.sh     # check status
 $ ./socks.sh off # turn off socks proxy
 ```
 
-The script assumes you have stored your key using "gov" somewhere within name (`~/.ssh/*gov*`). If you put it elsewhere or name it otherwise, you can set the VA_SOCKS_KEYFILE variable before invoking it. The script also sets up a proxy for the "Wi-Fi" network by default; if you are using a different network, you can override the SOCKS_NETWORK environment variable - for example:
+The script assumes you have stored your key at (`~/.ssh/id_rsa_vagov`). If you put it elsewhere or name it otherwise, you can set the VA_SOCKS_KEYFILE variable before invoking it (like this: `VA_SOCKS_KEYFILE=~/.ssh/my_vagov_privatekey`).
+
+The script also sets up a proxy for the "Wi-Fi" network by default; if you are using a different network, you can override the SOCKS_NETWORK environment variable - for example:
 
 ```
 $ SOCKS_NETWORK="USB 10/100/1000 LAN" ./socks.sh on
@@ -40,7 +42,6 @@ $ SOCKS_NETWORK="USB 10/100/1000 LAN" ./socks.sh off
 
 The socks script will start the socks proxy, configure the proxy settings on your computer to use a `proxy.pac` file, and start a small webserver to serve that file up. The proxy.pac file will send only a few URLs to the proxy, sending everything else directly to the internet.
 
-Finally, you'll need to configure your browser to use the system proxy if you use this script. This has been tested on OSX 10.14
-and 10.15, and works with Safari, Firefox, and Chrome.
+Finally, If you want to use a browser other than Chrome or Safari, you'll need to configure your browser to use the system proxy. This has been tested on OSX 10.14 and 10.15, and works with Chrome, Firefox and Safari. Chrome and Safari use the system proxy by default; you can set it up for Firefox by following [these instructions](https://support.mozilla.org/en-US/kb/connection-settings-firefox).
 
-If you don't want to use the proxy.pac route, another option is to install a proxy switcher into your browser - [details here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/internal-tools.md#chrome--firefox).
+If you don't want to use this approach, another option is to install a proxy switcher into your browser - [details here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/internal-tools.md#chrome--firefox).

--- a/scripts/socks/socks.sh
+++ b/scripts/socks/socks.sh
@@ -18,8 +18,8 @@ AUTOCONFIG_PORT=9500
 # from https://stackoverflow.com/a/246128/4907881
 PROXY_PAC_LOCATION="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/*gov*}"
-socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/*gov*}"
+socks_add_key_cmd="ssh-add -K ${VA_SOCKS_KEYFILE:-~/.ssh/id_rsa_vagov}"
+socks_del_key_cmd="ssh-add -d ${VA_SOCKS_KEYFILE:-~/.ssh/id_rsa_vagov}"
 socks_start_cmd="ssh socks -D ${WEB_PORT} -N";
 socks_kill_cmd="pkill -f \"$socks_start_cmd\"";
 webserver_start_cmd="ruby -run -e httpd ${PROXY_PAC_LOCATION} -p ${AUTOCONFIG_PORT} --bind-address 127.0.0.1"


### PR DESCRIPTION
* Update internal-tools doc to clarify that socks.sh and SwitchyOmega are alternatives
* Update socks.sh to avoid the use of *gov* which ended up causing issues with the script;
the problem is, it would try to load public keys as well, and fail. Thus, it
has been changed to reference id_rsa_vagov, which is the suggested keyname.
It is also possible to override the keyname, and instructions are given
in the script for these cases.