### PR TITLE
Adding DEPO 508 mandate

### DIFF
--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -6,13 +6,13 @@
 VSP Accessibility supports teams building on VA.gov to ensure that nobody is excluded from using products on VA.gov. We provide best practice guidance throughout the development cycle, build and recommend automated testing tools to flag accessibility issues, reducing the manual effort required to fix issues immediately before launch and post-la
 
 ## Table of contents
-* [DEPO mandate on Section 508 compliance](#depo-mandate-on-section-508-compliance)
+* [DEPO Platform accessibility standards](#depo-platform-accessibility-standards)
 * [How to contact us](#how-to-contact-us)
 * [What we do](#what-we-do)
 * [Working with us](#working-with-us)
 * [Resources and guides](#resources-and-guides)
 
-## DEPO mandate on Section 508 compliance
+## DEPO Platform accessibility standards
 
 **Teams need to fix all severity defect 0-4 accessibility issues**.
 

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -1,4 +1,4 @@
-*Last updated: March 20, 2020*
+*Last updated: October 22, 2020*
 *Owned by: VSP Accessibility*
 
 # Accessibility
@@ -95,7 +95,7 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
 ## Footnotes
-* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. DEPO will work with teams on a case by case basis. [↩](#f1)
+* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform within 1-2 sprints post-launch. [↩](#f1)
 
 ---
 ##### Revision History

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -95,7 +95,7 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
 ## Footnotes
-* <b id="f1">Footnote 1:</b> Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible post-launch. [↩](#footnote1)
+* <b id="f1">Footnote 1:</b> DEPO Platform acknowledges that some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible post-launch. [↩](#footnote1)
 
 ---
 ##### Revision History

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -95,7 +95,7 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
 ## Footnotes
-* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible. [↩](#footnote1)
+* <b id="f1">Footnote 1:</b> Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible post-launch. [↩](#footnote1)
 
 ---
 ##### Revision History

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -95,7 +95,7 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
 ## Footnotes
-* <b id="f1">Footnote 1:</b> DEPO Platform acknowledges that some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible post-launch. [↩](#footnote1)
+* <b id="f1">Footnote 1:</b> DEPO Platform acknowledges that some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with DEPO Platform as soon as possible post-launch. [↩](#footnote1)
 
 ---
 ##### Revision History

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -95,7 +95,7 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
 ## Footnotes
-* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform within 1-2 sprints post-launch. [↩](#f1)
+* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible. [↩](#f1)
 
 ---
 ##### Revision History

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -6,15 +6,33 @@
 VSP Accessibility supports teams building on VA.gov to ensure that nobody is excluded from using products on VA.gov. We provide best practice guidance throughout the development cycle, build and recommend automated testing tools to flag accessibility issues, reducing the manual effort required to fix issues immediately before launch and post-la
 
 ## Table of contents
+* [DEPO mandate on Section 508 compliance](#depo-mandate-on-section-508-compliance)
 * [How to contact us](#how-to-contact-us)
 * [What we do](#what-we-do)
 * [Working with us](#working-with-us)
 * [Resources and guides](#resources-and-guides)
 
+## DEPO mandate on Section 508 compliance
+
+**Teams need to fix all severity defect 0-4 accessibility issues**.
+
+**Launch requirements:**<br/>
+VFS teams must fix[ 508-defect-0](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#508-defect-0) and[ 508-defect-1](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#508-defect-1) issues before launching a Veteran-facing service. The DEPO Platform will enforce this minimum standard. <sup id="f1">[[1]](#f1)</sup>
+
+**Post-launch requirements:**<br/>
+VFS teams must iterate to resolve open[ 508-defect-2 through 508-defect-4 issues](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#post-launch-issues) to keep VA legally compliant. The DEPO Platform sends a public, weekly report to inform DEPO leadership of teams’ progress towards resolving issues.
+
+**So, what will VSP do to help you meet these requirements, and what are you expected to do?**<br/>
+Before requesting a staging review, VFS teams must do [foundational accessibility testing](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/staging-review-processes.md) and resolve or document any resulting issues. Be prepared to discuss your plan for when the unresolved issues might be addressed in the staging review meeting. 
+
+Teams with their own accessibility experts may be expected to do more robust testing beyond foundational accessibility tests. VSP will coordinate additional testing requirements on a case-by-case basis.
+
+VSP will do a final check to review testing findings and comment on issues where additional guidance is helpful.
+
 ## How to contact us
-VSP Accessibility contact: Trevor Pierce, `@Trevor Pierce` in Slack, `1Copenut` in Github
-Slack channels: [#vetsgov-accessibility](https://dsva.slack.com/channels/vetsgov-accessibility)
-Github labels: `508/Accessibility`
+* VSP Accessibility contact: Trevor Pierce, `@Trevor Pierce` in Slack, `1Copenut` in Github
+* Slack channels: [#vetsgov-accessibility](https://dsva.slack.com/channels/vetsgov-accessibility)
+* Github labels: `508/Accessibility`
 
 ## What we do
 VSP Accessibility ensures that accessibility and inclusive design are an integral part of product design and development on VA.gov.
@@ -76,9 +94,13 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Links and Buttons](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/links-and-buttons.md)
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
+## Footnotes
+* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. DEPO will work with teams on a case by case basis. [↩](#f1)
+
 ---
 ##### Revision History
 
 Date | Revisions Made | Author
 -----|----------------|--------
 Mar 20, 2020 | Reformatted using new template. | Gretchen Maciolek
+Oct 22, 2020 | Added DEPO 508 mandate. | Trevor Pierce

--- a/platform/accessibility/README.md
+++ b/platform/accessibility/README.md
@@ -17,7 +17,7 @@ VSP Accessibility supports teams building on VA.gov to ensure that nobody is exc
 **Teams need to fix all severity defect 0-4 accessibility issues**.
 
 **Launch requirements:**<br/>
-VFS teams must fix[ 508-defect-0](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#508-defect-0) and[ 508-defect-1](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#508-defect-1) issues before launching a Veteran-facing service. The DEPO Platform will enforce this minimum standard. <sup id="f1">[[1]](#f1)</sup>
+VFS teams must fix[ 508-defect-0](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#508-defect-0) and[ 508-defect-1](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#508-defect-1) issues before launching a Veteran-facing service. The DEPO Platform will enforce this minimum standard. <sup id="footnote1">[[1]](#f1)</sup>
 
 **Post-launch requirements:**<br/>
 VFS teams must iterate to resolve open[ 508-defect-2 through 508-defect-4 issues](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/defect-severity-rubric.md#post-launch-issues) to keep VA legally compliant. The DEPO Platform sends a public, weekly report to inform DEPO leadership of teams’ progress towards resolving issues.
@@ -95,7 +95,7 @@ Accessibility guidance is included in the following phases of the VSP Collaborat
 * [Screen Reader Fieldset Plus Legend Findings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/screenreader-fieldset-legend-label.md)
 
 ## Footnotes
-* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible. [↩](#f1)
+* <b id="f1">Footnote 1:</b>Some services must be launched into production before they can be reviewed for accessibility. Teams should coordinate a staging review with the DEPO Platform as soon as possible. [↩](#footnote1)
 
 ---
 ##### Revision History


### PR DESCRIPTION
I've added the final language Gretchen provided for the DEPO Section 508 mandate to teams. I tweaked her last sentence ever so slightly to reflect daily operational reality.

I am adding a footnote to the bottom for situations where apps have to launch to prod ahead of staging reviews, and how DEPO proposes to handle them.