### PR TITLE
Modded product development checklist wrt downtime notifications

### DIFF
--- a/platform/working-with-vsp/orientation/Product Development Checklist.md
+++ b/platform/working-with-vsp/orientation/Product Development Checklist.md
@@ -19,7 +19,10 @@ _Note: as always, use the [#vfs-platform-support](https://dsva.slack.com/channel
 - [ ] Everything is [508 Accessible](https://github.com/department-of-veterans-affairs/va.gov-team/blob/de1d32ebfc17d4b887133e33d946ece5a12913d8/platform/accessibility/README.md) and there are no Sev 1 accessibility bugs `*`
 - [ ] Everything is written in [plain language](https://design.va.gov/content-style-guide/) `*`
 - [ ] Everything is consistent with VA's [Design System](https://design.va.gov/) `*`
-- [ ] [Downtime notifications and error messages](https://design.va.gov/patterns/messaging-error-messages) are documented 
+- [ ] Downtime notifications and error messages:
+  - [ ] [Error message style guide](https://design.va.gov/patterns/messaging-error-messages) are documented 
+  - [ ] [Error message verbiage](https://design.va.gov/patterns/messaging-dictionary)
+  - [ ] [Error message configuration instructions](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/tools/downtime-notifications/)
 - [ ] [End-to-end manual QA](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/README.md) is complete and no Sev1 bugs `*`
 - [ ] [End-to-end UAT](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/research/planning/what-is-uat.md)(with real users) complete and no Sev1 bugs
 - [ ] Availability and latency targets are defined `*`

--- a/platform/working-with-vsp/orientation/Product Development Checklist.md
+++ b/platform/working-with-vsp/orientation/Product Development Checklist.md
@@ -21,7 +21,7 @@ _Note: as always, use the [#vfs-platform-support](https://dsva.slack.com/channel
 - [ ] Everything is consistent with VA's [Design System](https://design.va.gov/) `*`
 - [ ] Downtime notifications and error messages:
   - [ ] [Error message verbiage](https://design.va.gov/patterns/messaging-dictionary)
-  - [ ] [Error message style guide](https://design.va.gov/patterns/messaging-error-messages) are documented 
+  - [ ] [Error message style guide](https://design.va.gov/patterns/messaging-error-messages)
   - [ ] [Error message configuration instructions](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/tools/downtime-notifications/)
 - [ ] [End-to-end manual QA](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/README.md) is complete and no Sev1 bugs `*`
 - [ ] [End-to-end UAT](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/research/planning/what-is-uat.md)(with real users) complete and no Sev1 bugs

--- a/platform/working-with-vsp/orientation/Product Development Checklist.md
+++ b/platform/working-with-vsp/orientation/Product Development Checklist.md
@@ -20,8 +20,8 @@ _Note: as always, use the [#vfs-platform-support](https://dsva.slack.com/channel
 - [ ] Everything is written in [plain language](https://design.va.gov/content-style-guide/) `*`
 - [ ] Everything is consistent with VA's [Design System](https://design.va.gov/) `*`
 - [ ] Downtime notifications and error messages:
-  - [ ] [Error message style guide](https://design.va.gov/patterns/messaging-error-messages) are documented 
   - [ ] [Error message verbiage](https://design.va.gov/patterns/messaging-dictionary)
+  - [ ] [Error message style guide](https://design.va.gov/patterns/messaging-error-messages) are documented 
   - [ ] [Error message configuration instructions](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/tools/downtime-notifications/)
 - [ ] [End-to-end manual QA](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/README.md) is complete and no Sev1 bugs `*`
 - [ ] [End-to-end UAT](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/research/planning/what-is-uat.md)(with real users) complete and no Sev1 bugs


### PR DESCRIPTION
Changed product development checklist to include more detailed docs around handling downtime notifications.

The previous checklist only pointed to the notifications style guide.  I have now included links to the notification language and code configuration instructions (in addition to the style guide).

**@rroueche, seeking feedback before merge: Does the proposed change capture all the information that you would like a VFS dev to have, when tackling error messages?**

# Old checklist
<img width="684" alt="Screen Shot 2020-10-27 at 3 24 27 PM" src="https://user-images.githubusercontent.com/6895034/97357945-8ad7dc80-1868-11eb-9385-8cdd72f4a356.png">

Link: [Downtime notifications and error messages](https://design.va.gov/patterns/messaging-error-messages) are documented <-- this links to the error message style guide

# Proposed checklist
<img width="688" alt="Screen Shot 2020-10-27 at 3 24 02 PM" src="https://user-images.githubusercontent.com/6895034/97358033-a511ba80-1868-11eb-9c6a-8b9a96ebcbd6.png">

Links, in order of appearance in the screenshot:
- [Error message verbiage](https://design.va.gov/patterns/messaging-dictionary) (the screenshot above is old; the white text reading "are documented" has been removed in the MD file)
- [Error message style guide](https://design.va.gov/patterns/messaging-error-messages)
- [Error message configuration instructions](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/tools/downtime-notifications/)

