### PR TITLE
Update analytics-implementation-and-qa-request-template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/analytics-implementation-and-qa-request-template.md
+++ b/.github/ISSUE_TEMPLATE/analytics-implementation-and-qa-request-template.md
@@ -96,3 +96,4 @@ An example of a completed request template can be found [here](https://github.co
 ## Definition of Done
 - [ ] All appropriate issue tagging is completed
 - [ ] All AC completed
+- [ ] VSP: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1d219oL1zCvCvnv1Bx-dI-GMzwgbarLv9_bzMSa3ULjA/edit#gid=1710283887) is updated


### PR DESCRIPTION
Updating this template in support of making the Platform Collaboration Point Tracker read only per [this ticket.](https://app.zenhub.com/workspaces/vsp---product-support-5f85b91c14d8df0018fac414/issues/department-of-veterans-affairs/va.gov-team/17533)