### PR TITLE
16645 document how to avoid flaky cypress tests

### DIFF
--- a/platform/testing/end-to-end/cypress-flaky-test-management.md
+++ b/platform/testing/end-to-end/cypress-flaky-test-management.md
@@ -1,0 +1,88 @@
+# Cypress Flaky Test Management
+
+## Table of Contents
+
+- [Introduction](#)
+- [How to Detect Flaky Tests](#)
+- [Call cy.injectAxe() When a New Page Loads](#)
+- [Race Conditions](#)
+  - [`exist` and `be-visible`](#)
+  - [`cy.click({ waitForAnimations: true })`](#)
+  - [Race Conditions Resources](#)
+
+## Introduction
+
+Flaky tests are tests that sometimes pass and sometimes fail without any changes to the code. This document offers suggestions on how to better detect flaky tests and how to fix or prevent them.
+
+## How to Detect Flaky Tests
+
+After writing your test, wrap each `describe` block in a `for` loop and iterate over it 20-30 times. Wrapping the `describe` block instead of the `it` block allows the Cypress Test Runner to display a pass or fail for each iteration. The number of times you iterate over the `describe` block is an arbitrary number but the higher the number the better; having a test pass multiple times should help you have confidence that your test is not flaky.
+
+Example:
+
+```javascript
+for (let i = 0; i < 20; i += 1) {
+  describe('the thing', () => {
+    it('it does this', () => {
+      // commands and assertions go here
+    });
+  });
+}
+```
+
+## Call cy.injectAxe() When a New Page Loads
+
+If you see an error like this:
+
+```
+TypeError: Cannot read property 'run' of undefined
+      at Context.eval (http://localhost:3001/__cypress/tests?p=src/platform/testing/e2e/cypress/support/index.js:25257:442975)
+```
+
+Chances are you forgot to call `cy.injectAxe()` before calling `cy.axeCheck()` after Cypress loads a new page.
+
+The `undefined` object referenced in the error is `axe` from the cypress-axe module:
+
+```
+return a.axe.run(t||a.document,u).then(function(e){var t=e.violations;
+```
+
+This error occurs because every time Cypress loads a new page by calling `cy.visit()`, `cy.wait(@alias)` (where `@alias` references a route), or `cy.click()` (when Cypress clicks on a element like a search button that loads a new page), the axe-core runtime must first be loaded into the page by calling `cy.inject()`.
+
+The [cypress-axe documentation](https://github.com/component-driven/cypress-axe#cyinjectaxe) explains:
+
+> This will inject the axe-core runtime into the page under test. You must run this after a call to `cy.visit()` and before you run the `checkA11y` command.
+>
+> You run this command with `cy.injectAxe()` either in your test, or in a `beforeEach`, as long as the visit comes first.
+
+However, as mentioned, it appears that this also applies to other calls that load a new page like `cy.wait(@alias)` or `cy.click()`.
+
+## Race Conditions
+
+Because Cypress is asynchronous, race conditions can occur when Cypress ‘gets ahead of the DOM’ and, for example, tries to find or click on an element of the page that hasn’t rendered yet. Errors that result from race conditions are sometimes difficult to track down. Here are a few tips and a list of useful resources:
+
+### `exist` and `be-visible`
+
+After calling `cy.get()` on an element, like a button for example, make sure it actually exists or is visible before calling `cy.click()` or some other function on it, like so:
+
+```javascript
+cy.get('button').should('exist');
+```
+
+or:
+
+```javascript
+cy.get('button').should('be.visible');
+```
+
+### `cy.click({ waitForAnimations: true })`
+
+`cy.click({ waitForAnimations: true })` should be used instead of `cy.click()` when Cypress clicks on elements that are animated, like accordions.
+
+This option tells Cypress to wait for elements to finish animating before executing the command.
+
+### Race Conditions Resources
+
+- [When Can the Test Click](https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/)
+- [Leveraging Flaky Tests to Identify Race Conditions Using Cypress](https://dresscode.renttherunway.com/blog/leveraging-flaky-tests)
+- [Retry-ability](https://docs.cypress.io/guides/core-concepts/retry-ability.html)

--- a/platform/testing/end-to-end/cypress-flaky-test-management.md
+++ b/platform/testing/end-to-end/cypress-flaky-test-management.md
@@ -16,7 +16,7 @@ Flaky tests are tests that sometimes pass and sometimes fail without any changes
 
 ## How to Detect Flaky Tests
 
-After writing your test, wrap each `describe` block in a `for` loop and iterate over it 20-30 times. Wrapping the `describe` block instead of the `it` block allows the Cypress Test Runner to display a pass or fail for each iteration. The number of times you iterate over the `describe` block is an arbitrary number but the higher the number the better. Having a test pass multiple times should help you have confidence that your test is not flaky.
+After writing your test, wrap each `describe` or `it` block in a `for` loop and iterate over it 20-30 times. The number of times you iterate through the loop is arbitrary but the higher the number the better. Having a test pass multiple times should give you confidence that your test is not flaky.
 
 Example:
 

--- a/platform/testing/end-to-end/cypress-flaky-test-management.md
+++ b/platform/testing/end-to-end/cypress-flaky-test-management.md
@@ -16,7 +16,7 @@ Flaky tests are tests that sometimes pass and sometimes fail without any changes
 
 ## How to Detect Flaky Tests
 
-After writing your test, wrap each `describe` block in a `for` loop and iterate over it 20-30 times. Wrapping the `describe` block instead of the `it` block allows the Cypress Test Runner to display a pass or fail for each iteration. The number of times you iterate over the `describe` block is an arbitrary number but the higher the number the better; having a test pass multiple times should help you have confidence that your test is not flaky.
+After writing your test, wrap each `describe` block in a `for` loop and iterate over it 20-30 times. Wrapping the `describe` block instead of the `it` block allows the Cypress Test Runner to display a pass or fail for each iteration. The number of times you iterate over the `describe` block is an arbitrary number but the higher the number the better. Having a test pass multiple times should help you have confidence that your test is not flaky.
 
 Example:
 
@@ -77,7 +77,7 @@ cy.get('button').should('be.visible');
 
 ### `cy.click({ waitForAnimations: true })`
 
-`cy.click({ waitForAnimations: true })` should be used instead of `cy.click()` when Cypress clicks on elements that are animated, like accordions.
+`cy.click({ waitForAnimations: true })` should be used instead of `cy.click()` when Cypress clicks on an element that is animated, like an accordion.
 
 This option tells Cypress to wait for elements to finish animating before executing the command.
 

--- a/platform/testing/end-to-end/cypress-flaky-test-management.md
+++ b/platform/testing/end-to-end/cypress-flaky-test-management.md
@@ -2,13 +2,13 @@
 
 ## Table of Contents
 
-- [Introduction](#)
-- [How to Detect Flaky Tests](#)
-- [Call cy.injectAxe() When a New Page Loads](#)
-- [Race Conditions](#)
-  - [`exist` and `be-visible`](#)
-  - [`cy.click({ waitForAnimations: true })`](#)
-  - [Race Conditions Resources](#)
+- [Introduction](#introduction)
+- [How to Detect Flaky Tests](#how-to-detect-flaky-tests)
+- [Call cy.injectAxe() When a New Page Loads](#call-cyinjectaxe-when-a-new-page-loads)
+- [Race Conditions](#race-conditions)
+  - [`exist` and `be-visible`](#exist-and-be-visible)
+  - [`cy.click({ waitForAnimations: true })`](#cyclick-waitforanimations-true-)
+  - [Race Conditions Resources](#race-conditions-resources)
 
 ## Introduction
 


### PR DESCRIPTION
In reference to ticket  - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/16645#issuecomment-751876550

This is new documentation about how to detect, avoid and fix flaky Cypress tests.