### PR TITLE
Content auto deploy update

### DIFF
--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -115,7 +115,12 @@ For now, the job will not retry or re-queue upon failure.
 
 The pipeline will [use a cron trigger](https://www.jenkins.io/doc/book/pipeline/syntax/#triggers) to run on the desired schedule.
 
-The initial schedule will be hourly between 8am and 8pm on weekdays. Ideally, after incrementally increasing the deploy frequency, the deploy would run every 5 minutes.
+We will roll out the content auto deploy gradually based on the following:
+
+- Daily for 1-2 days
+- 3 times a day for 1-2 days
+
+Then lastly, the schedule will be hourly between 8am and 8pm EST on weekdays. Ideally, after incrementally increasing the deploy frequency, the deploy would run every 5 minutes.
 
 ```
 node('vagov-autodeploy') {

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -71,7 +71,7 @@ The initial schedule will run between 8am and 8pm ET to align with CMS support h
 - At first, it will be set to run hourly as a conservative cadence.
 - It will then be incrementally adjusted to a higher frequency as the build system allows.
 
-To avoid deploying when content hasn't changed since the previous deploy, the job will compare the export data (e.g., using and archiving the checksums of the tarballs).
+To avoid deploying when content hasn't changed since the previous deploy, the job will compare the GraphQL query data (e.g., using and archiving the checksums of the cached tarballs).
 
 To differentiate between the auto-deploys, we will refer to the new one as the **content-only auto-deploy** and the existing one as the **daily or full auto-deploy**.
 
@@ -164,17 +164,9 @@ The following behaviors should be observed cumulatively as they are implemented.
 2. Job runs on the defined schedule.
 3. Deploy doesn't proceed when no new content has been published.
 
-### Logging
-
-On top of the existing build logs, the new content-only deploy will output logs for the new transformation processes in the CMS export build.
-
 ### Debugging
 
 The auto-deploy pipeline can be debugged by reading its console output. The S3 bucket can be checked to confirm whether the build has been deployed.
-
-The CMS export build will validate the input and output schemas of the transformers, so errors related to the build itself can be debugged using that output.
-
-As with the full build, during the rollout, there will be a comparison of GraphQL and CMS export builds to report errors when discrepancies between the two are found. The script used for this comparison will have some console output as well as an output JSON file describing the discrepancies.
 
 To determine whether a page exists in the Drupal content, we can go to [`staging.va.gov/drupal/debug/`](staging.va.gov/drupal/debug/). This page is not available in production, however.
 

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -213,7 +213,6 @@ There are no new privacy concerns with the auto-deploy as user data is not invol
 
 ### Work Estimates
 
-- Create a new content-only deploy job (5 pts)
 - Run the partial deploy on a schedule (3 pts)
 - Auto-deploy only new content (3 pts)
 

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -2,13 +2,13 @@
 
 **Author(s):** Jhonny Gonzalez, Eugene Doan, Theo Bentum  
 **Last Updated:** February 22, 2021  
-**Status:** Draft | **In Review** | Approved  
+**Status:** Draft | In Review | **Approved**  
 **Approvers:**
-- [ ] Tim Wright
-- [ ] Neil Hastings
-- [ ] Steve Wirt
-- [ ] Dror Matalon
-- [ ] Michael Fleet
+- [x] Tim Wright
+- [x] Neil Hastings
+- [x] Steve Wirt
+- [x] Dror Matalon
+- [x] Michael Fleet
 
 ## Overview
 

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -120,7 +120,7 @@ We will roll out the content auto deploy gradually based on the following:
 - Daily for 1-2 days
 - 3 times a day for 1-2 days
 
-Then lastly, the schedule will be hourly between 8am and 8pm EST on weekdays. Ideally, after incrementally increasing the deploy frequency, the deploy would run every 5 minutes.
+Then lastly, the schedule will be hourly between 8am and 8pm EST on weekdays.
 
 ```
 node('vagov-autodeploy') {

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -71,8 +71,6 @@ The initial schedule will run between 8am and 8pm ET to align with CMS support h
 - At first, it will be set to run hourly as a conservative cadence.
 - It will then be incrementally adjusted to a higher frequency as the build system allows.
 
-To avoid deploying when content hasn't changed since the previous deploy, the job will compare the GraphQL query data (e.g., using and archiving the checksums of the cached tarballs).
-
 To differentiate between the auto-deploys, we will refer to the new one as the **content-only auto-deploy** and the existing one as the **daily or full auto-deploy**.
 
 ## Specifics
@@ -137,20 +135,6 @@ node('vagov-autodeploy') {
   }
 }
 ```
-
-#### Preventing deploys of existing content
-
-On successful deploys, the tarball containing the GraphQL query data used in the build should be archived in S3. The key should resemble `s3://vetsgov-website-builds-s3-upload/content/vagovprod_{CACHE_KEY}.tar.bz2`.
-
-The GraphQL query data can be cached and retrieved by using the [drupal-aws-cache.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/drupal-aws-cache.js) script.
-
-Then on subsequent deploys, the GraphQL query data from Drupal will be compared to the cached tarball data of the previous successful deploy. This ensures that we only run the build when content has changed.
-
-Alternatively, we can also get the cache key and tarbell of the newly pulled Drupal data by running the same [drupal-aws-cache.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/drupal-aws-cache.js) script, and utilizing the [getDrupalCacheKey](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/drupal-aws-cache.js#L42) function. The two cache keys from both tarbells can be compared. The build will run only if the MD5 checksums of the two tarballs differ.
-
-For convenience, we could also upload the checksum to `s3://vetsgov-website-builds-s3-upload/data/checksum.txt`. With that, the pipeline would not have to download the full tarball for the comparison.
-
-To help content editors know when the content has been last updated, we might want to timestamp when a new tarball is used and include that info in the generated `BUILD.txt`.
 
 ### Code Location
 

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -1,12 +1,12 @@
-# Automatic Deploy of Content Built from CMS Export Data
+# Automatic Deploy of Content Built
 
-**Author(s):** Jhonny Gonzalez, Eugene Doan  
-**Last Updated:** February 2, 2021  
+**Author(s):** Jhonny Gonzalez, Eugene Doan, Theo Bentum  
+**Last Updated:** February 22, 2021  
 **Status:** Draft | **In Review** | Approved  
 **Approvers:**
-- [ ] Dan Shank
-- [x] Neil Hastings
-- [x] Steve Wirt
+- [ ] Tim Wright
+- [ ] Neil Hastings
+- [ ] Steve Wirt
 - [ ] Dror Matalon
 - [ ] Michael Fleet
 
@@ -14,32 +14,18 @@
 
 ### Objective
 
-This document explores an approach to running automatic deploys (auto-deploys) of content built using CMS (content management system) export data.
+This document explores an approach to running automatic deploys (auto-deploys) of content built using GraphQL queries.
 The approach also considers a feasible frequency for the build and deploy that does not overload the build system.
-
-This document _does not_ discuss the design of the full build and deploy using CMS export data.
 
 The intended audience are front-end (FE) and DevOps engineers on the Veteran-facing Services Platform (VSP) and the CMS teams.
 
 ### Background
 
-#### Content build and transformers
+#### Content build
 
 The VA.gov website is built from the `vets-website` repo. The build outputs static HTML content, React applications, and styling.
 
-The static content is built through a Metalsmith pipeline using data pulled from the Drupal-based CMS and the [`vagov-content` repo](https://github.com/department-of-veterans-affairs/vagov-content/).
-
-Currently, the data from the Drupal server is fetched with a GraphQL query. However, the GraphQL-based build has limitations in maintainability and scalability, so an alternative is being developed to replace it.
-
-This implementation, the CMS export build, involves the [use of transformers](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/cms-integration) to transform CMS export data into a content model that matches that of the GraphQL data.
-
-The CMS export data is a JSON static file representation of the content in the Drupal database.
-- It's fetched as a tar file that contains a collection of JSON files.
-- The files represent both Drupal node and non-node content (which includes, but is not limited to, paragraphs, taxonomy, and menu items).
-
-Transformers act as a [data transformation layer](https://en.wikipedia.org/wiki/Data_transformation) to change the CMS Export data into a format the templates can digest.
-
-In the same manner as the GraphQL data, the transformed CMS export data would then be applied to the Liquid templates to generate the HTML files in the build.
+The static content is built through a Metalsmith pipeline using data pulled from the Drupal-based CMS via GraphQL queries and the [`vagov-content` repo](https://github.com/department-of-veterans-affairs/vagov-content/).
 
 #### Deployment
 
@@ -71,14 +57,14 @@ To deploy content changes at will, that "auto-deploy" job is manually triggered 
 
 - Content writers want to quickly draft, publish, and deploy content.
   - However, `vets-website` is only deployed to production once per day.
-  - The CMS team can run content-only deploys independently of the daily production deploy, but that is triggered manually.
+  - The CMS team can run content-only deploys independently of the daily production deploy, but that must be triggered manually.
 - The content-only deploy does not include automated accessibility checks.
 - In local development, engineers can encounter confusing build errors that are due to the mismatch in outdated locally cached content and updated Liquid templates.
 
 ### High Level Design
 
 There will be a new content-only auto-deploy job in addition to the existing full auto-deploy.
-- It will build content with CMS export data.
+- It will build content with GraphQL query data.
 - It will be a recurring job that executes on a more frequent schedule than the daily prod deploy.
 
 The initial schedule will run between 8am and 8pm ET to align with CMS support hours.
@@ -115,39 +101,21 @@ stage('Autodeploy content') {
 }
 ```
 
-#### Using the CMS export to build content
-
-In order for the content-only auto-deploy to use the CMS export data, the [build command](https://github.com/department-of-veterans-affairs/vets-website/blob/master/jenkins/common.groovy#L189) in the `build` function in `jenkins/common.groovy` will have to include the `--use-cms-export` flag.
-
 As it's a content-only deploy, it will build using the latest release instead of the latest commit of of `vets-website`.
 - This matches the behavior of the current content-only deploy.
 - The daily production deploy will continue deploying from the latest commit and retain the responsibility of tagging releases.
 
-If this work is done before the full build has transitioned to using the CMS export, the inclusion of the flag will be contingent on the `contentOnly` parameter to the function.
-
 #### Validating the build
-
-The implementation of the full CMS export build pipeline is expected to introduce a step that compares the diffs between GraphQL and CMS export builds.
-- That validation should be included in this pipeline as well while it's being rolled out.
-- The comparison step will be removed once the CMS export build is fully released.
 
 For now, the job will not retry or re-queue upon failure.
 - Such failures might be related to build diffs, broken links, or other validations.
 - The goal is for the job to recur at more frequent intervals, so we can look for a successful run in the next scheduled deploy.
 
-#### Deploying the build
-
-The pipeline will archive the CMS export build in S3 at a different key than the current GraphQL builds.
-
-For example, it might be `s3://vetsgov-website-builds-s3-upload/cms-export/${ref}/${envName}.tar.bz2`, where `ref` is the commit hash and `envName` is the environment (one of `vagovdev`, `vagovstaging`, or `vagovprod`).
-
-The subpath `cms-export` in the key will namespace the archived CMS export build separately from the current GraphQL build. This will enable testing and debugging of the new pipeline without intefering with the current deploy process.
-
 #### Scheduling the deploy
 
 The pipeline will [use a cron trigger](https://www.jenkins.io/doc/book/pipeline/syntax/#triggers) to run on the desired schedule.
 
-The initial schedule will be hourly between 8am and 8pm on weekdays. Ideally, the deploy would run every 5 minutes.
+The initial schedule will be hourly between 8am and 8pm on weekdays. Ideally, after incrementally increasing the deploy frequency, the deploy would run every 5 minutes.
 
 ```
 node('vagov-autodeploy') {
@@ -167,13 +135,15 @@ node('vagov-autodeploy') {
 
 #### Preventing deploys of existing content
 
-On successful deploys, the tarball containing the CMS export data used in the build should be archived in S3. A possible key might be `s3://vetsgov-website-builds-s3-upload/cms-export/data/latest.tar.bz2`.
+On successful deploys, the tarball containing the GraphQL query data used in the build should be archived in S3. The key should resemble `s3://vetsgov-website-builds-s3-upload/content/vagovprod_{CACHE_KEY}.tar.bz2`.
 
-The CMS export build [currently reads the tarball directly from the response body](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/drupal/api.js#L147) and should be modified to save it to a file.
+The GraphQL query data can be cached and retrieved by using the [drupal-aws-cache.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/drupal-aws-cache.js) script.
 
-Then on subsequent deploys, the tarball downloaded from Drupal will be compared with the tarball of the previous successful deploy. The build will run only if the MD5 checksums of the two tarballs differ. This ensures that we only run the build when content has changed.
+Then on subsequent deploys, the GraphQL query data from Drupal will be compared to the cached tarball data of the previous successful deploy. This ensures that we only run the build when content has changed.
 
-For convenience, we could also upload the checksum to `s3://vetsgov-website-builds-s3-upload/cms-export/data/checksum.txt`. With that, the pipeline would not have to download the full tarball for the comparison.
+Alternatively, we can also get the cache key and tarbell of the newly pulled Drupal data by running the same [drupal-aws-cache.js](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/drupal-aws-cache.js) script, and utilizing the [getDrupalCacheKey](https://github.com/department-of-veterans-affairs/vets-website/blob/master/script/drupal-aws-cache.js#L42) function. The two cache keys from both tarbells can be compared. The build will run only if the MD5 checksums of the two tarballs differ.
+
+For convenience, we could also upload the checksum to `s3://vetsgov-website-builds-s3-upload/data/checksum.txt`. With that, the pipeline would not have to download the full tarball for the comparison.
 
 To help content editors know when the content has been last updated, we might want to timestamp when a new tarball is used and include that info in the generated `BUILD.txt`.
 
@@ -235,7 +205,7 @@ There are no new privacy concerns with the auto-deploy as user data is not invol
   - [The queue of content-only deploys should naturally resolve conflicts without any special handling.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/18393)
 
 - Is there a way to get the time of the last updated published content in Drupal and use that to determine if we should build or not?
-  - If we have access to that information, we may not need to compare the CMS export tarballs.
+  - If we have access to that information, we may not need to compare the GraphQL query data.
 
 - Will this new auto-deploy continue fail on broken links?
   - With a high enough rate of deploy, failing on broken links would not be ideal.
@@ -247,27 +217,24 @@ There are no new privacy concerns with the auto-deploy as user data is not invol
 
 #### Risks
 
-- Newly added content from CMS without associated transformer schemas could fail the build.
-  - New content introduces the possibility of new discrepancies, which would fail any validations that depend on diffs between the GraphQL and CMS export builds.
-  - Having more content will inflate the runtime of the content-only deploy and could potentially exceed the scheduled interval.
-  - The best defense against this is accounting for null and empty fields in transformers.
+- Having more content will inflate the runtime of the content-only deploy and could potentially exceed the scheduled interval.
 
 ### Work Estimates
 
-- Create a new content-only deploy job for CMS export builds (5 pts)
+- Create a new content-only deploy job (5 pts)
 - Run the partial deploy on a schedule (3 pts)
 - Auto-deploy only new content (3 pts)
 
 ### Alternatives
 
-Ideally, content would get deployed immediately as content writers make changes. However, the CMS export process is not suited for multiple invocations in quick succession, so we opted for a process that will essentially batch and deploy content changes as appropriate.
+Ideally, content would get deployed immediately as content writers make changes. However, the GraphQL queries are not suited for multiple invocations in quick succession, so we opted for a process that will essentially batch and deploy content changes as appropriate.
 
 ### Future Work
 
 - There are plans to transition from Jenkins to CircleCI for our build pipeline. The auto-deploy job will have to be brought over to CircleCI at that time.
   - The `vets-website` CircleCI infrastructure is hosted on a public domain.
   - CircleCI does not have access to the CMS Drupal server, which is hosted within the internal VA network.
-  - To circumvent the need for access to the VA network, we could run a job that keeps an up-to-date cache of the CMS export data.
+  - To circumvent the need for access to the VA network, we could run a job that keeps an up-to-date cache of the GraphQL query data.
   - We might consider running that job as a Lambda function or a CodeBuild pipeline.
 - To improve the runtime, we might want to explore incremental deploys.
 
@@ -275,6 +242,7 @@ Ideally, content would get deployed immediately as content writers make changes.
 
 | Date         | Revisions Made | Author          |
 | ------------ | -------------- | --------------- |
+| Feb 22, 2021 | Removed the use of CMS export in favor of GraphQL  | Theo Bentum |
 | Feb 2, 2021 | Updated approvals. Clarified background about CMS export data. | Eugene Doan |
 | Jan 26, 2021 | <ul><li>Made nuanced corrections about the implementation. Clarified related sections and terminology.</li><li>Elaborated on validation error handling, including a new question about broken links.</li><li>Included proposal for timestamping updated content.</li><li>Added details about future plans to move to CircleCI.</li></ul> | Eugene Doan |
 | Jan 21, 2021 | Cleaned up Background. Added info to Alternatives. | Eugene Doan |

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -120,7 +120,7 @@ We will roll out the content auto deploy gradually based on the following:
 - Daily for 1-2 days
 - 3 times a day for 1-2 days
 
-Then lastly, the schedule will be hourly between 8am and 8pm EST on weekdays.
+Then lastly, the schedule will be hourly between 9AM and 4PM EST on weekdays.
 
 ```
 node('vagov-autodeploy') {

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -115,7 +115,7 @@ The pipeline will [use a cron trigger](https://www.jenkins.io/doc/book/pipeline/
 
 We will roll out the content auto deploy gradually based on the following:
 
-- Daily for 1-2 days
+- Daily for 1-2 days at 11 AM EST
 - 3 times a day for 1-2 days
 
 Then lastly, the schedule will be hourly between 9AM and 4PM EST on weekdays.

--- a/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
+++ b/platform/engineering/design-docs/2020-12-10-auto-deploy-cms-build.md
@@ -1,4 +1,4 @@
-# Automatic Deploy of Content Built
+# Automatic Deploy of Content
 
 **Author(s):** Jhonny Gonzalez, Eugene Doan, Theo Bentum  
 **Last Updated:** February 22, 2021  


### PR DESCRIPTION
Updates to the Content Auto Deploy Design Doc. Removes the use of CME export in favor of GraphQL.