### PR TITLE
Add link to contract testing documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -215,6 +215,14 @@
                 >VSP QA Philosophy</a
               >
             </div>
+            <div class="border-b py-2">
+              <a
+                target="_blank"
+                href="https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/testing/contract-testing/README.md"
+                class="practice-area-link text-blue-800 hover:underline"
+                >Contract Testing</a
+              >
+            </div>
           </div>
           <div class="practice-area">
             <div class="pb-4 border-b">


### PR DESCRIPTION
Regarding ticket #14020 - https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/14020

Add link to contract testing documentation from https://department-of-veterans-affairs.github.io/va.gov-team/