### PR TITLE
Update preparing-content-for-translation.md

### DIFF
--- a/products/content/spanish-translation/coronavirus-mvp/preparing-content-for-translation.md
+++ b/products/content/spanish-translation/coronavirus-mvp/preparing-content-for-translation.md
@@ -30,6 +30,7 @@
 
 - [ ] Text avoids standalone phrases, except in headlines and subheadings.
 - [ ] Text contains no idioms, slang, jargon, or culturally specific information.
+- [ ] Text clarifies technical terms (cookies, software, database, etc.)
 
 | Like this | Not like this |
 |---|---|


### PR DESCRIPTION
Added a bullet on clarifying technical terms as much as possible, a few examples include:
- accept cookies on the website to see the display (cookies does not exist in Spanish, or at least in this sense)
- click on the button below (I would say, **select** or **go to** button below)
- This data is supplemented by x software (the word "software" does not exist in Spanish so I would say something similar to "platform" or something along those lines.