### PR TITLE
Change VSP to Platform in Collaboration Cycle documentation 

### DIFF
--- a/.github/ISSUE_TEMPLATE/analytics-implementation-and-qa-request-template.md
+++ b/.github/ISSUE_TEMPLATE/analytics-implementation-and-qa-request-template.md
@@ -93,7 +93,6 @@ An example of a completed request template can be found [here](https://github.co
 - [ ] [All items of checklist have been executed](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/insights-analytics/customer-support-guide-v2.md#%EF%B8%8F-checklist-before-closing-any-ticket)
 - [ ] QA has been completed
 - [ ] Events have been added to `Product` and `Benefit Hub` Content Groups
-- [ ] VFS team completes brief [Platform Collaboration Cycle Feedback](https://adhoc.optimalworkshop.com/questions/20260uu8-0-0/questions/before) survey
 
 
 ## Definition of Done

--- a/.github/ISSUE_TEMPLATE/analytics-implementation-and-qa-request-template.md
+++ b/.github/ISSUE_TEMPLATE/analytics-implementation-and-qa-request-template.md
@@ -93,10 +93,10 @@ An example of a completed request template can be found [here](https://github.co
 - [ ] [All items of checklist have been executed](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/insights-analytics/customer-support-guide-v2.md#%EF%B8%8F-checklist-before-closing-any-ticket)
 - [ ] QA has been completed
 - [ ] Events have been added to `Product` and `Benefit Hub` Content Groups
-- [ ] VFS team completes brief [VSP Collaboration Cycle Feedback](https://adhoc.optimalworkshop.com/questions/20260uu8-0-0/questions/before) survey
+- [ ] VFS team completes brief [Platform Collaboration Cycle Feedback](https://adhoc.optimalworkshop.com/questions/20260uu8-0-0/questions/before) survey
 
 
 ## Definition of Done
 - [ ] All appropriate issue tagging is completed
 - [ ] All AC completed
-- [ ] VSP: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886) is updated
+- [ ] Platform: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886) is updated

--- a/.github/ISSUE_TEMPLATE/collab-cycle-kickoff.md
+++ b/.github/ISSUE_TEMPLATE/collab-cycle-kickoff.md
@@ -12,8 +12,8 @@ assignees: andreahewitt-odd, shiragoodman
 - [ ] VFS: Answer the questions below.
 - [ ] VFS: Link to this issue once created in vfs-platform-support in Slack; tag @vsp-product-support-members.
 - [ ] VFS: Attach any available artifacts.
-- [ ] VSP: Review the responses and comment in ticket with recommended touchpoints and practice area involvement.
-- [ ] VSP: Add project/feature to the [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=266151061).
+- [ ] Platform: Review the responses and comment in ticket with recommended touchpoints and practice area involvement.
+- [ ] Platform: Add project/feature to the [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=266151061).
 - [ ] VFS: Close this ticket when all steps above are completed.
 
 ## Artifacts (if available)
@@ -110,4 +110,4 @@ Please note that Domo is on pause until end of June. See [here](https://github.c
 
 
 ## Additional information
-Please refer to the [VSP Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/working-with-vsp/vsp-collaboration-cycle) on Github for more information about the Collaboration Cycle.
+Please refer to the [Platform Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/working-with-vsp/vsp-collaboration-cycle) on Github for more information about the Collaboration Cycle.

--- a/.github/ISSUE_TEMPLATE/design-intent-collaboration.md
+++ b/.github/ISSUE_TEMPLATE/design-intent-collaboration.md
@@ -15,6 +15,7 @@ assignees: shiragoodman, allison0034
 - [ ] Platform: After meeting is held, create feedback tickets and link to the Design Intent ticket (if no feedback, please comment stating that).
 - [ ] VFS: Respond appropriately to Platform feedback tickets.
 - [ ] Platform: Update [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=266151061).
+- [ ] VFS: Close this ticket when all steps above are completed.
 
 ## Questions
 ### Has your product been reviewed by the OCTO-DE Design Lead?

--- a/.github/ISSUE_TEMPLATE/design-intent-collaboration.md
+++ b/.github/ISSUE_TEMPLATE/design-intent-collaboration.md
@@ -20,11 +20,11 @@ assignees: shiragoodman, allison0034
 ### Has your product been reviewed by the OCTO-DE Design Lead?
 - [ ] Yes
 - [ ] No
-### Has your team met with Sitewide Content for content support?
+### Has your team met with the Sitewide Content team for content support?
 - [ ] Yes*
 - [ ] No
 
-\*If yes, please be sure to include your Content brief (if available) and any other relevant artifacts
+\*If yes, please be sure to include your Content brief (if available) and any other relevant content artifacts
 
 ## Artifacts
 - Link to [product outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/product-management/product-outline-template.md)
@@ -43,7 +43,7 @@ assignees: shiragoodman, allison0034
 
 ## Scheduling
 
-### What is your preferred time slot per the [VSP Collaboration Meetings Calendar](https://calendar.google.com/calendar/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0%40group.calendar.google.com&ctz=America%2FNew_York)? 
+### What is your preferred time slot per the [Platform Collaboration Meetings Calendar](https://calendar.google.com/calendar/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0%40group.calendar.google.com&ctz=America%2FNew_York)? 
 **Date/time:**
  
 Please note:
@@ -53,5 +53,5 @@ Please note:
 - Please select a time slot at least 2 business days from request date.
 
 ## Additional information
-Please refer to the [VSP Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.
+Please refer to the [Platform Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.
 

--- a/.github/ISSUE_TEMPLATE/full-accessibility-and-508-office-audit.md
+++ b/.github/ISSUE_TEMPLATE/full-accessibility-and-508-office-audit.md
@@ -8,23 +8,23 @@ assignees: 1Copenut, shiragoodman, noahgelman
 ---
 
 ## Steps to complete the Full Accessibility & 508 Audit: 
-- [ ] VFS: Verify all accessibility defects that were identified at Staging Review have been fixed before requesting a full audit *(VSP understands that other teams may be accountable for fixing the defects identified at Staging Review. These defects are exempt and will not block a team from scheduling this touchpoint)*
+- [ ] VFS: Verify all accessibility defects that were identified at Staging Review have been fixed before requesting a full audit *(Platform understands that other teams may be accountable for fixing the defects identified at Staging Review. These defects are exempt and will not block a team from scheduling this touchpoint)*
 - [ ] VFS Product Manager: Create this issue and fill in your team and feature name in the title
 - [ ] VFS: Link to this issue once created in [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) in Slack; tag @ Trevor Pierce
-- [ ] VSP: Create sub-issues attached to this epic with findings. Audits are performed on a first-come-first-serve basis and are scheduled with each biweekly sprint
+- [ ] Platform: Create sub-issues attached to this epic with findings. Audits are performed on a first-come-first-serve basis and are scheduled with each biweekly sprint
 - [ ] VFS: Coordinate with the VA 508 Office to address accessibility findings
-- [ ] VSP: Update [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886)
+- [ ] Platform: Update [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886)
 
 ## Artifacts
 - Access information for the tool or feature in staging. Do not put staging credentials in your `va.gov-team` ticket; store or reference them in a .md file in the `va.gov-team-sensitive` repository
 - Link to verification that accessibility checks are complete:
-  - (preferred) Link to your [TestRail VSP accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc).
+  - (preferred) Link to your [TestRail Platform accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc).
 OR
   - Link to a doc in your product folder that indicates all required checks from the accessibility [staging review prep](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/staging-review-processes.md) doc are complete.
 - List of known issues (with links to tickets when applicable)
 
 ## Additional information
-As part of this review, VSP will send your product to VA's 508 office for approval (as applicable).
+As part of this review, Platform will send your product to VA's 508 office for approval (as applicable).
 
-Please refer to the [Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.
+Please refer to the [Platform Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.
 

--- a/.github/ISSUE_TEMPLATE/full-accessibility-and-508-office-audit.md
+++ b/.github/ISSUE_TEMPLATE/full-accessibility-and-508-office-audit.md
@@ -14,6 +14,7 @@ assignees: 1Copenut, shiragoodman, noahgelman
 - [ ] Platform: Create sub-issues attached to this epic with findings. Audits are performed on a first-come-first-serve basis and are scheduled with each biweekly sprint
 - [ ] VFS: Coordinate with the VA 508 Office to address accessibility findings
 - [ ] Platform: Update [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886)
+- [ ] VFS: Close this ticket when all steps above are completed.
 
 ## Artifacts
 - Access information for the tool or feature in staging. Do not put staging credentials in your `va.gov-team` ticket; store or reference them in a .md file in the `va.gov-team-sensitive` repository

--- a/.github/ISSUE_TEMPLATE/ia-request.md
+++ b/.github/ISSUE_TEMPLATE/ia-request.md
@@ -7,10 +7,10 @@ assignees: mnorthuis, shiragoodman
 
 ---
 ## What this is:
-Work with VSP Information Architecture experts to finalize the IA of your product for VA.gov
+Work with Platform Information Architecture experts to finalize the IA of your product for VA.gov
 
 ## When to use this: 
-After you have received a response to your Collaboration Cycle kick-off ticket that indicates Information Architect Request is needed. 
+After you have received a response to your Collaboration Cycle kickoff ticket that indicates Information Architect Request is needed. 
 
 ## Requested artifacts:
 *Provide artifacts as available. If not available at the time this issue is created, please add information as it becomes available.*
@@ -37,7 +37,7 @@ After you have received a response to your Collaboration Cycle kick-off ticket t
 
 ## Definition of Done
 - [ ] VFS: Creates issue and provides all required information above
-- [ ] VSP: Completes final IA feedback/recommendation
-- [ ] VSP: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886) is updated
+- [ ] Platform: Completes final IA feedback/recommendation
+- [ ] Platform: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886) is updated
 - [ ] VFS: Closes issue once all IA feedback/recommendations are implemented
 

--- a/.github/ISSUE_TEMPLATE/midpoint-review.md
+++ b/.github/ISSUE_TEMPLATE/midpoint-review.md
@@ -44,10 +44,10 @@ Please note:
 ## Meeting attendees from requesting team*
 \*Only required for synchronous meetings.
 - Product Manager (required): name
-- DEPO Product lead (recommended): name
-- DEPO Design lead (required): Ryan Thurlwell
+- OCTO-DE Product lead (recommended): name
+- OCTO-DE Design lead (required): Ryan Thurlwell
 - Anyone else from your team who significantly contributed to the artifacts provided (required): names
-- Content, IA, accessibility, and QA specialists (if applicable): name(s)
+- VFS Content, IA, accessibility, and QA specialists (if applicable): name(s)
 
 ## Additional information
 Please refer to the [Platform Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.

--- a/.github/ISSUE_TEMPLATE/midpoint-review.md
+++ b/.github/ISSUE_TEMPLATE/midpoint-review.md
@@ -32,7 +32,7 @@ Would you like this review to be asynchronous? Please refer to the Midpoint Revi
 - [ ] Yes
 - [ ] No
  
-What is your preferred time slot per the [VSP Collaboration Meetings Calendar](https://calendar.google.com/calendar/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0%40group.calendar.google.com&ctz=America%2FNew_York)? **date/time**
+What is your preferred time slot per the [Platform Collaboration Meetings Calendar](https://calendar.google.com/calendar/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0%40group.calendar.google.com&ctz=America%2FNew_York)? **date/time**
  
 Please note:
 - Time slots are required for both synchronous meetings and asynchronous reviews.
@@ -50,4 +50,4 @@ Please note:
 - Content, IA, accessibility, and QA specialists (if applicable): name(s)
 
 ## Additional information
-Please refer to the [VSP Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.
+Please refer to the [Platform Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.

--- a/.github/ISSUE_TEMPLATE/request-contact-center-review-template.md
+++ b/.github/ISSUE_TEMPLATE/request-contact-center-review-template.md
@@ -12,11 +12,11 @@ assignees: jwoodman5, kimberley2019
 ## What this form is for
 Use this template to request a Contact Center review of your product.
 
-Please review the Self service Product Guide Template [link](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/self-service-product-guide-template.md) and the Contact Center Review How to [link](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md)
+Please review the Self-service Product Guide Template [link](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/self-service-product-guide-template.md) and the Contact Center Review How to [link](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/contact-center/request-contact-center-review.md)
  
 
 ## Description
-*Please provide the name(s) of your product and a high level description of your product.*
+*Please provide the name(s) of your product and a high-level description of your product.*
 
 ### Launch Date
 *Please provide the launch or rollout date and details.*
@@ -37,6 +37,6 @@ Please review the Self service Product Guide Template [link](https://github.com/
 
 
 ## Acceptance Criteria
-- [ ] VSP Contact Center QA has been completed 
-- [ ] VSP Contact Center sends artifacts to appropriate contact centers
-- [ ] VSP: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886) is updated
+- [ ] Platform: Contact Center QA has been completed 
+- [ ] Platform: Contact Center sends artifacts to appropriate contact centers
+- [ ] Platform: [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=1116695886) is updated

--- a/.github/ISSUE_TEMPLATE/staging-review.md
+++ b/.github/ISSUE_TEMPLATE/staging-review.md
@@ -38,10 +38,10 @@ OR
 
 ## Meeting attendees from requesting team
 - Product Manager (required): name
-- DEPO Product lead (recommended): name
-- DEPO Design lead (required): Ryan Thurlwell
+- OCTO-DE Product lead (recommended): name
+- OCTO-DE Design lead (required): Ryan Thurlwell
 - Anyone else from your team who significantly contributed to the artifacts provided (required): name(s)
-- Content, IA, accessibility, and QA specialists (if applicable): name(s)
+- VFS Content, IA, accessibility, and QA specialists (if applicable): name(s)
 
 ## Scheduling
 What is your preferred time slot per the [Platform Collaboration Meetings Calendar](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York)? **date/time**

--- a/.github/ISSUE_TEMPLATE/staging-review.md
+++ b/.github/ISSUE_TEMPLATE/staging-review.md
@@ -1,6 +1,6 @@
 ---
 name: Staging Review
-about: Request a VSP staging review
+about: Request a Platform staging review
 title: Staging Review [Team Name - Feature Name]
 labels: vsp-product-support, collaboration-cycle, staging-review, collab-cycle-review
 assignees: andreahewitt-odd, Shiragoodman
@@ -11,13 +11,13 @@ assignees: andreahewitt-odd, Shiragoodman
 
 - [ ] VFS Product Manager: Create this issue and fill in your team and feature name in the title.
 - [ ] VFS: Link to this issue once created in [#vfs-platform-support](https://dsva.slack.com/channels/vfs-platform-support) in Slack; tag @vsp-product-support-members. 
-- [ ] VSP: Schedule meeting with VSP reviewers and requesting team attendees (as listed below)
+- [ ] Platform: Schedule meeting with Platform reviewers and requesting team attendees (as listed below)
 - [ ] VFS: At least 4 days before scheduled meeting, you must complete list of artifacts below
 - [ ] VFS: Verify that access information has been provided for the tool or feature in staging. Do not put staging credentials in your va.gov-team ticket; store or reference them in a .md file in the va.gov-team-sensitive repository.
-- [ ] VSP: Create feedback tickets and link to the Staging Review ticket (if no feedback, please comment stating that). 
+- [ ] Platform: Create feedback tickets and link to the Staging Review ticket (if no feedback, please comment stating that). 
 - [ ] VFS: Respond to VSP feedback tickets.
 - [ ] VFS: Update this ticket with the product’s launch date after it has gone live.
-- [ ] VSP: Update [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=266151061).
+- [ ] Platform: Update [Platform Collaboration Point Tracker](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=266151061).
 - [ ] VFS: Close this ticket when the review is complete.
 
 
@@ -31,7 +31,7 @@ assignees: andreahewitt-odd, Shiragoodman
 - Link to your product test cases/test plan in TestRail with test execution logs ([learn more](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/qa-artifacts.md#test-plan)) _for QA practice area review_
 - Link to your [Coverage for References](https://dsvavsp.testrail.io/index.php?/reports/view/12) and [Summary(Defects)](https://dsvavsp.testrail.io/index.php?/reports/view/14) reports in TestRail _for QA practice area review_
 - Link to verification that accessibility checks are complete:
-  - (preferred) Link to your [TestRail VSP accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc).
+  - (preferred) Link to your [TestRail Platform accessibility test plan template](https://dsvavsp.testrail.io/index.php?/suites/view/14&group_by=cases:section_id&group_order=asc).
 OR
   - Link to a doc in your product folder that indicates all required checks from the accessibility [staging review prep](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/staging-review-processes.md) doc are complete.
 - List of known issues (with links to tickets when applicable)
@@ -44,7 +44,7 @@ OR
 - Content, IA, accessibility, and QA specialists (if applicable): name(s)
 
 ## Scheduling
-What is your preferred time slot per the [VSP Collaboration Meetings Calendar](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York)? **date/time**
+What is your preferred time slot per the [Platform Collaboration Meetings Calendar](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York)? **date/time**
  
 Please note:
 - All times are shown in ET. 
@@ -53,4 +53,4 @@ Please note:
 - Please select a time slot at least 4 business days from request date.
 
 ## Additional information
-Please refer to the [VSP Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.
+Please refer to the [Platform Collaboration Cycle README](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/README.md) on Github for more information about the Collaboration Cycle.

--- a/platform/working-with-vsp/vsp-collaboration-cycle/README.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/README.md
@@ -27,7 +27,7 @@ When you’re ready to start the Collaboration Cycle process, submit our kickoff
 Once submitted, we'll comment on the ticket with the recommended Collaboration Cycle touchpoints, as well as what practice areas will be involved in your reviews. Those recommended touchpoints will also be added to our tracking spreadsheet (linked below) for reference. 
 
 ### 3. Prepare for and schedule your touchpoints
-When you’re ready to schedule your recommended touchpoints, review the guidelines outlined in each of the touchpoints below to prepare. Then use our Platform Collaboration Meeting Calendar (linked below) to find a time.  
+When you’re ready to schedule your recommended touchpoints, review the guidelines outlined in each of the touchpoints below to prepare. Then use our Platform Collaboration Meetings Calendar (linked below) to find a time.  
 
 Guidance for each touchpoint:
    

--- a/platform/working-with-vsp/vsp-collaboration-cycle/README.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/README.md
@@ -1,8 +1,8 @@
-# VSP Collaboration Cycle
+# Platform Collaboration Cycle
 
-The VSP Collaboration Cycle is where VSP reviewers provide support and guidance to VFS teams to help ensure the products they are building on VA.gov meet platform standards.  
+The Platform Collaboration Cycle is where Platform reviewers provide support and guidance to VFS teams to help ensure the products they are building on VA.gov meet platform standards.  
 
-VSP provides guidance in Design, Content, Information Architecture, QA, and Accessibility practice areas. Teams should engage with the Collaboration Cycle when they begin building or iterating on their VA.gov content and/or product. 
+The Platform provides guidance in Design, Content, Information Architecture, QA, and Accessibility practice areas. Teams should engage with the Collaboration Cycle when they begin building or iterating on their VA.gov content and/or product. 
 
 ## Table of contents
 - [The Collaboration Cycle process](#the-collaboration-cycle-process)
@@ -24,10 +24,10 @@ When you’re ready to start the Collaboration Cycle process, submit our kickoff
 
 [Collaboration Cycle Kickoff ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+shiragoodman&labels=vsp-product-support%2C+collaboration-cycle%2C+collab-cycle-review&template=collab-cycle-kickoff.md&title=Collaboration+Cycle+Kickoff+%5BTeam+Name%2C+Feature+Name%5D)
 
-Once submitted, VSP will comment on the ticket with the recommended Collaboration Cycle touchpoints, as well as what practice areas will be involved in your reviews. Those recommended touchpoints will also be added to our tracking spreadsheet (linked below) for reference. 
+Once submitted, we'll comment on the ticket with the recommended Collaboration Cycle touchpoints, as well as what practice areas will be involved in your reviews. Those recommended touchpoints will also be added to our tracking spreadsheet (linked below) for reference. 
 
 ### 3. Prepare for and schedule your touchpoints
-When you’re ready to schedule your recommended touchpoints, review the guidelines outlined in each of the touchpoints below to prepare. Then use our VSP Collaboration Meeting Calendar (linked below) to find a time.  
+When you’re ready to schedule your recommended touchpoints, review the guidelines outlined in each of the touchpoints below to prepare. Then use our Platform Collaboration Meeting Calendar (linked below) to find a time.  
 
 Guidance for each touchpoint:
    
@@ -44,18 +44,18 @@ Guidance for each touchpoint:
 
 ## Resources
 
-[**VSP Collaboration Meetings Calendar**](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York)
+[**Platform Collaboration Meetings Calendar**](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York)
 
 On this calendar, you will see:
 
-- Available days and times  for scheduling a touchpoint with VSP (indicated by "CALENDAR BLOCK")
+- Available days and times for scheduling a touchpoint with Platform (indicated by "CALENDAR BLOCK")
 - Already scheduled Collaboration Cycle touchpoints
 - Design Office Hours
 - Collaboration Cycle Office Hours
 
 [**Platform Collaboration Point Tracker**](https://docs.google.com/spreadsheets/d/1OgPyEvUlNF6EnaYMFAXJkV6FKOvZnlPnbOQ2fAJ7W7A/edit#gid=266151061)
 
-This is VSP's source of truth for which Collaboration Cycle touchpoints are recommended for each product. This spreadsheet includes links to Github tickets as well as Zoom recordings. This spreadsheet is not editable by VFS teams, so if you notice anything is missing, please let us know!
+This is Platform's source of truth for which Collaboration Cycle touchpoints are recommended for each product. This spreadsheet includes links to Github tickets as well as Zoom recordings. This spreadsheet is not editable by VFS teams, so if you notice anything is missing, please let us know!
 
 ## Practice areas supported by the Collaboration Cycle
 #### Design
@@ -100,8 +100,8 @@ This is VSP's source of truth for which Collaboration Cycle touchpoints are reco
 
 ## Contact us
 - First time working with us? Review the guidance in [Getting started with the Collaboration Cycle](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/collab-cycle-get-started.md#questions-about-your-product). If you’re able to answer all the questions, then submit a Github [Collaboration Cycle Kickoff](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+shiragoodman&labels=vsp-product-support%2C+collaboration-cycle%2C+collab-cycle-review&template=collab-cycle-kickoff.md&title=Collaboration+Cycle+Kickoff+%5BTeam+Name%2C+Feature+Name%5D) ticket to find out which touchpoints we recommend for your product.
-- Ready to schedule a touchpoint? Follow the guidance for each touchpoint under [VSP Collaboration Cycle Touchpoints](#3-prepare-for-and-schedule-your-touchpoints).
-- Have a question about one of our practice areas? Come to our weekly Collaboration Cycle Office Hours listed in the [VSP Collaboration Meetings Calendar](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York).
+- Ready to schedule a touchpoint? Follow the guidance for each touchpoint under [Platform Collaboration Cycle Touchpoints](#3-prepare-for-and-schedule-your-touchpoints).
+- Have a question about one of our practice areas? Come to our weekly Collaboration Cycle Office Hours listed in the [Platform Collaboration Meetings Calendar](https://calendar.google.com/calendar/u/0/embed?src=adhocteam.us_4dn3o77gcm5e3vbiedlha96tc0@group.calendar.google.com&ctz=America/New_York).
 - Need immediate assistance? Reach out to @vsp-product-support-members on the [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) channel.
 
 ## Change history

--- a/platform/working-with-vsp/vsp-collaboration-cycle/collab-cycle-get-started.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/collab-cycle-get-started.md
@@ -1,12 +1,12 @@
 # Getting started with the Collaboration Cycle 
-Before engaging with the Collaboration Cycle, please review the guidance and questions below to help VSP determine what level of support, which practice areas, and which touchpoints are needed for your work. If you don’t know the answer to a question, then it’s too early for you to engage with the Collaboration Cycle.
+Before engaging with the Collaboration Cycle, please review the guidance and questions below to help Platform determine what level of support, which practice areas, and which touchpoints are needed for your work. If you don’t know the answer to a question, then it’s too early for you to engage with the Collaboration Cycle.
 
 **Are you ready to engage with the Collaboration Cycle?**
 
-If yes, then a VFS Product Manager should submit a ticket for an asynchronous [Collaboration Cycle Kickoff](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+shiragoodman&labels=vsp-product-support%2C+collaboration-cycle%2C+collab-cycle-review&template=collab-cycle-kickoff.md&title=Collaboration+Cycle+Kickoff+%5BTeam+Name%2C+Feature+Name%5D). VSP will respond in the GitHub ticket with the recommended Collaboration Cycle touchpoints, as well as any other additional information the team should know.
+If yes, then a VFS Product Manager should submit a ticket for an asynchronous [Collaboration Cycle Kickoff](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+shiragoodman&labels=vsp-product-support%2C+collaboration-cycle%2C+collab-cycle-review&template=collab-cycle-kickoff.md&title=Collaboration+Cycle+Kickoff+%5BTeam+Name%2C+Feature+Name%5D). We'll respond in the GitHub ticket with the recommended Collaboration Cycle touchpoints, as well as any other additional information the team should know.
 
 ## Questions about your product
-These questions will help VSP learn more about your product and determine which practice areas and touchpoints are needed for your work.
+These questions will help Platform learn more about your product and determine which practice areas and touchpoints are needed for your work.
 
 ### 1. Will your work result in visible changes to the user experience?
 
@@ -66,7 +66,7 @@ Examples of **changes to the user flow** include:
  - Adding a new section to a form 
  - Moving from a wizard to one thing per page form model
 
-### 7. Are there any changes to urls, navigation or entry points?
+### 7. Are there any changes to urls, navigation, or entry points?
 
 Examples of **changes to url, navigation, or entry points** include:
  - Moving an online tool or content page within the site or needing to retire/redirect a page

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-accessibility-audit.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-accessibility-audit.md
@@ -6,7 +6,7 @@ Did we recommend a Full Accessibility and 508 Office Audit in the Collaboration 
 
 Schedule a full audit when your product is launched to production, when code is relatively stable. All accessibility defects that were identified at Staging Review must be fixed before requesting a full audit.* **Note:** This touchpoint should be scheduled as early as possible. 
 
-_*VSP understands that other teams may be accountable for fixing the defects identified at Staging Review. These defects are exempt and will not block a team from scheduling this touchpoint._
+_*Platform understands that other teams may be accountable for fixing the defects identified at Staging Review. These defects are exempt and will not block a team from scheduling this touchpoint._
 
 ## What is the collaboration format?
 

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-analytics-request.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-analytics-request.md
@@ -5,7 +5,7 @@ Did we recommend an Analytics Request in the Collaboration Cycle Kickoff issue t
 After you have defined your KPIs and are determining which user interactions would be beneficial to track before you build your product/application.
 
 ## What is the collaboration format?
-Asynchronous review. If VSP Analytics & Insights has any clarifying questions, we will reach out on the Github ticket for a synchronous 30-minute meeting.
+Asynchronous review. If Platform Analytics & Insights has any clarifying questions, we will reach out on the Github ticket for a synchronous 30-minute meeting.
 
 ## What is the objective of this touchpoint?
 Begin setup of Google Analytics so we can understand how Veterans are using VA.gov.
@@ -18,7 +18,7 @@ VFS Product Manager submits an [Analytics Implementation and QA Request](https:/
   - Product manager (required)
   - DEPO product lead (required)
   - Front-end engineering point of contact (required)
-- VSP brings:
+- Platform brings:
   - Google Tag Manager specialists
 
 ## What artifacts do I provide?
@@ -28,4 +28,4 @@ VFS Product Manager submits an [Analytics Implementation and QA Request](https:/
   - Authenticated test-user logins, when applicable. Do not put staging credentials in your va.gov-team ticket; store or reference them in a .md file in the va.gov-team-sensitive repository
   - Your product URL(s), including any unauthenticated landing pages that precede your tool. For example, if your product is a multistep Veteran-facing tool, please provide the full path of URLs, noting any conditional logic that would take users to a different URL path for the tool
 ## What is the outcome of this touchpoint?
-VSP will help configure Google Analytics tracking for reporting and will help support analyzing resulting data. 
+Platform will help configure Google Analytics tracking for reporting and will help support analyzing resulting data. 

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-design-intent.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-design-intent.md
@@ -43,7 +43,7 @@ VFS provides:
 - Any other artifacts you have so far
 
 ## What is the outcome of this touchpoint?
-Platform reviewers will document their feedback, if applicable, in a GitHub ticket. Tickets will be made available to VFS teams no later than EOD the next business day following the meeting. In addition, OCTO-DE/Platform may:
+Platform reviewers will document their feedback, if applicable, in a GitHub ticket. Feedback tickets will be made available to VFS teams no later than EOD the next business day following the meeting. In addition, OCTO-DE/Platform may:
 
  -  Recommend applicable Design System components and/or patterns
  -  Identify needs for creating/updating Design System components and/or patterns

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-ia-request.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-ia-request.md
@@ -3,7 +3,7 @@
 Did we recommend an IA Request in the Collaboration Cycle Kickoff issue ticket? If so, follow the below guidelines to get started.
 
 ## When should I request this touchpoint?
-The IA Request should be opened as soon as you receive a response to your Collaboration Cycle kick-off ticket that indicates Information Architect Request is needed. This ensures IA can be discussed and established as early as possible in the design process and allows time for collaboration with other teams that are identified as needed support for static content and entry points, such as sitewide content or CMS teams. 
+The IA Request should be opened as soon as you receive a response to your Collaboration Cycle Kickoff ticket that indicates Information Architect Request is needed. This ensures IA can be discussed and established as early as possible in the design process and allows time for collaboration with other teams that are identified as needed support for static content and entry points, such as sitewide content or CMS teams. 
 
 ## What is the collaboration format?
 Asynchronous collaboration and review. 

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-ia-request.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-ia-request.md
@@ -3,15 +3,15 @@
 Did we recommend an IA Request in the Collaboration Cycle Kickoff issue ticket? If so, follow the below guidelines to get started.
 
 ## When should I request this touchpoint?
-The IA Request should be opened as soon as you receive a response to your Collaboration Cycle kick-off ticket that indicates Information Architect Request is needed.  This ensures IA can be discussed and established as early as possible in the design process and allows time for collaboration with any other teams that are identified as needed support for static content and entry points such as Sitewide content or CMS. 
+The IA Request should be opened as soon as you receive a response to your Collaboration Cycle kick-off ticket that indicates Information Architect Request is needed. This ensures IA can be discussed and established as early as possible in the design process and allows time for collaboration with other teams that are identified as needed support for static content and entry points, such as sitewide content or CMS teams. 
 
 ## What is the collaboration format?
 Asynchronous collaboration and review. 
 
 ## What is the objective of this touchpoint?
-Collaborate with VSP’s Information Architect to finalize where your product/feature will live within the overall VA.gov IA. This includes reviewing entry points, user flows, breadcrumbs, URL, and other key details before developing in staging. 
+Collaborate with Platform’s Information Architect to finalize where your product/feature will live within the overall VA.gov IA. This includes reviewing entry points, user flows, breadcrumbs, URL, and other key details before developing in staging. 
 
-VSP’s Information Architect has a high-level view of the entire VA.gov experience and can help ensure that your new or updated content fits well in that ecosystem.
+Platform’s Information Architect has a high-level view of the entire VA.gov experience and can help ensure that your new or updated content fits well in that ecosystem.
 
 ## How do I request this touchpoint?
 VFS Product Manager submits an [IA Request ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=mnorthuis%2C+shiragoodman&labels=vsp-product-support%2C+collaboration-cycle%2C+collab-cycle-review&template=ia-request.md&title=IA+Request+%5BTeam-Name%2C+Feature-Name%5D).
@@ -25,4 +25,4 @@ VFS brings:
 - Completed information architecture worksheet in the IA Request template (Optional)
 
 ## What is the outcome of this touchpoint?
-VSP provides a finalized information architecture recommendation, including IA structure, URLs, breadcrumbs, navigation changes, and entry and exit points. Redirect guidance is also included, if applicable.
+Platform provides a finalized information architecture recommendation, including IA structure, URLs, breadcrumbs, navigation changes, and entry and exit points. Redirect guidance is also included, if applicable.

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-midpoint-review.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-midpoint-review.md
@@ -8,9 +8,9 @@ When you have determined your initial solution approach and have prototypes or m
 Synchronous 30-minute meeting (recommended), or asynchronous review
 
 ## What is the objective of this touchpoint?
-VSP reviewers will confirm that your prototypes or mockups are consistent with existing patterns and standards. They’ll provide feedback to help ensure your product is ready for successful usability testing.
+Platform reviewers will confirm that your prototypes or mockups are consistent with existing patterns and standards. They’ll provide feedback to help ensure your product is ready for successful usability testing.
 
-We recommend a synchronous meeting if this is the first time you’re introducing VSP to your product and/or iteration. However, if you would like an asynchronous review, VSP will provide feedback on the artifacts you provide to guide VFS teams toward VA.gov platform standards.
+We recommend a synchronous meeting if this is the first time you’re introducing Platform to your product and/or iteration. However, if you would like an asynchronous review, we'll provide feedback on the artifacts you provide to guide VFS teams toward VA.gov platform standards.
 
 ## How do I request this touchpoint?
 VFS Product Manager submits a [Midpoint Review ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+shiragoodman&labels=vsp-product-support%2C+content-ia-team%2C+collaboration-cycle%2C+collab-cycle-review&template=midpoint-review.md&title=Midpoint+Review+%5BTeam+Name%2C+Feature+Name%5D).
@@ -21,14 +21,15 @@ VFS brings:
   - DEPO product lead (recommended)
   - Anyone else from your team who significantly contributed to the artifacts provided (required)
   - Content, IA, accessibility, and QA specialists (if applicable)
-VSP brings (when applicable):
+  
+Platform brings (when applicable):
 - Design 
 - Accessibility 
 - Content 
 - Information architecture 
 - QA 
 - Product 
-- VSP’s DEPO co-leads 
+- Platform’s DEPO co-leads 
 - Analytics
 
 ## What artifacts do I provide?
@@ -36,11 +37,11 @@ VFS provides:
 - Link to [product outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/product-management/product-outline-template.md)
 - Link to or attach prototype or mockups
 - Link to content brief (if applicable)
-- Link to or specify the artifact that represents this initiative's content source of truth (for example, mockup, prototype, Github, Word outline, or elsewhere) 
+- Link to or specify the artifact that represents this initiative's content source of truth (for example, mockup, prototype, Github, Word outline, or preview link) 
 - Link to [research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/research/research-plan-template.md) and [conversation guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/research/planning/conversation-guide-template.md)
 - Link to regression test plan ([learn more](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/qa-artifacts.md#regression-test-plan)) (if there isn't already a regression test plan for this feature in TestRail) for QA practice area review
 - Link to test cases/test plan in TestRail ([learn more](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/quality-assurance/qa-artifacts.md#test-plan)) (even if just a draft) for QA practice area review
 
 ## What is the outcome of this touchpoint?
-VSP reviewers document feedback in a GitHub ticket.
+Platform reviewers document feedback in a GitHub ticket.
 

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-midpoint-review.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-midpoint-review.md
@@ -18,7 +18,7 @@ VFS Product Manager submits a [Midpoint Review ticket](https://github.com/depart
 ## Who attends this touchpoint?
 VFS brings:
   - Product manager (required)
-  - DEPO product lead (recommended)
+  - OCTO-DE product lead (recommended)
   - Anyone else from your team who significantly contributed to the artifacts provided (required)
   - Content, IA, accessibility, and QA specialists (if applicable)
   
@@ -29,7 +29,7 @@ Platform brings (when applicable):
 - Information architecture 
 - QA 
 - Product 
-- Platform’s DEPO co-leads 
+- Platform’s OCTO-DE co-leads 
 - Analytics
 
 ## What artifacts do I provide?

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-privacy-security-review.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-privacy-security-review.md
@@ -17,7 +17,7 @@ VFS Lead Engineer or Product Manager submits a [Privacy and Security Review tick
 VFS brings:
 - Lead engineer (required)
 - Product manager (required)
-- DEPO product lead (required)
+- OCTO-DE product lead (required)
 - Anyone else on your team whose presence is needed to speak to the technical architecture and security concerns (required)
 
 Platform brings:

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-privacy-security-review.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-privacy-security-review.md
@@ -8,7 +8,7 @@ When the product is in staging and before you begin rollout, allowing enough tim
 Asynchronous review. A synchronous 30-minute meeting may be requested.
 
 ## What is the objective of this touchpoint?
-Ensure your feature meets VSP's privacy and security standards.
+Ensure your feature meets Platform's privacy and security standards.
 
 ## How do I request this touchpoint?
 VFS Lead Engineer or Product Manager submits a [Privacy and Security Review ticket](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/new?assignees=f1337%2C+joeniquette&labels=vsp-product-support%2C+collaboration-cycle%2C+collab-cycle-review&template=privacy-and-security-review.md&title=Readiness+Review+%5BTeam-Name%2C+Feature-Name%5D) in va.gov-team-sensitive repository.
@@ -20,7 +20,7 @@ VFS brings:
 - DEPO product lead (required)
 - Anyone else on your team whose presence is needed to speak to the technical architecture and security concerns (required)
 
-VSP brings:
+Platform brings:
 - Engineering experts (Michael Fleet and/or Joe Niquette, others as needed)
 
 ## What artifacts do I provide?
@@ -39,9 +39,9 @@ VFS provides:
 - Review the guidance on [hosting a security review](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/security/hosting-a-security-review.md)
 
 ## What is the outcome of this touchpoint?
-VSP provides a list in a Github ticket of concrete action items that need to be addressed before product rollout. 
+Platform provides a list in a Github ticket of concrete action items that need to be addressed before product rollout. 
 
 When the VFS team has completed action items, they should assign the Security Review ticket back to @Michael Fleet, who will confirm completion and close out the issue, signaling approval of the Privacy and Security review.
 
-If no issues are raised during the Privacy and Security review, then VSP will approve the product for launch. 
+If no issues are raised during the Privacy and Security review, then Platform will approve the product for launch. 
 

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-staging-review.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-staging-review.md
@@ -8,7 +8,7 @@ Before you begin launch, allowing enough time to implement feedback. This will v
 Synchronous 30-minute meeting
 
 ## What is the objective of this touchpoint?
-Get feedback on your completed build before rolling out to users. VSP will identify any launch-blocking issues that must be addressed prior to launch.
+Get feedback on your completed build before rolling out to users. Platform will identify any launch-blocking issues that must be addressed prior to launch.
 
 ## How do I request this touchpoint?
 VFS Product Manager submits a [Staging Review ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=andreahewitt-odd%2C+Shiragoodman&labels=vsp-product-support%2C+collaboration-cycle%2C+staging-review%2C+collab-cycle-review&template=staging-review.md&title=Staging+Review+%5BTeam+Name+-+Feature+Name%5D).
@@ -19,15 +19,15 @@ VFS brings:
    - DEPO product lead (recommended)
    - Anyone else from your team who significantly contributed to the artifacts provided (required)
    - Content, IA, accessibility, and QA specialists (if applicable)
-   - 
-VSP brings (when applicable):
+   
+Platform brings (when applicable):
    - Design
    - Accessibility
    - Content
    - QA
    - Product
    - Information architecture
-   - VSP’s DEPO co-leads
+   - Platform’s DEPO co-leads
    - Analytics (optional)
 
 ## What artifacts do I provide?
@@ -37,7 +37,7 @@ VFS provides:
 - Link to the tool or feature  in staging. Do not put staging credentials in your va.gov-team ticket; store or reference them in a .md file in the va.gov-team-sensitive repository.
 - Link to [test user information, passwords, and tasks](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/staging-test-accounts-accessible-example.md) in the va.gov-team-sensitive repo (if applicable)
 - Link to content brief (if applicable)
-- Link to or specify the artifact that represents this initiative's content source of truth (for example, mockup, prototype, Github, Word outline, or elsewhere) 
+- Link to or specify the artifact that represents this initiative's content source of truth (for example, mockup, prototype, Github, Word outline, or staging or preview link) 
 - Link to your [QA test plan](https://dsvavsp.testrail.io/index.php?/suites/view/2&group_by=cases:section_id&group_order=asc) in TestRail with [test results](https://dsvavsp.testrail.io/index.php?/runs/view/7&group_by=cases:section_id&group_order=asc) for QA practice area review
 - Link to your [Coverage for References](https://dsvavsp.testrail.io/index.php?/reports/view/12) and [Summary(Defects)](https://dsvavsp.testrail.io/index.php?/reports/view/14) reports in TestRail for QA practice area review
 - Review the [staging accessibility review processes](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/guidance/staging-review-processes.md)
@@ -60,10 +60,10 @@ OR
 - List of known issues (with links to tickets when applicable)
 - Please provide these artifacts at least **4 days before the scheduled review meeting**.
 
-VSP brings:
+Platform brings:
 
 - Feedback on the artifacts from the following practice areas: design, accessibility, content, QA, I/A (and optional: product, analytics, engineering).
 
 
 ## What is the outcome of this touchpoint?
-VSP reviewers document their feedback in a GitHub ticket. VSP will escalate critical issues if necessary to ensure they are addressed prior to launch. VSP will identify launch-blocking accessibility issues and provide assistance, if requested, in getting issues resolved.
+Platform reviewers document their feedback in a GitHub ticket. Platform will escalate critical issues if necessary to ensure they are addressed prior to launch. We'll identify launch-blocking accessibility issues and provide assistance, if requested, in getting issues resolved.

--- a/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-staging-review.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/touchpoint-staging-review.md
@@ -16,7 +16,7 @@ VFS Product Manager submits a [Staging Review ticket](https://github.com/departm
 ## Who attends this touchpoint?
 VFS brings:
    - Product manager (required)
-   - DEPO product lead (recommended)
+   - OCTO-DE product lead (recommended)
    - Anyone else from your team who significantly contributed to the artifacts provided (required)
    - Content, IA, accessibility, and QA specialists (if applicable)
    
@@ -27,7 +27,7 @@ Platform brings (when applicable):
    - QA
    - Product
    - Information architecture
-   - Platform’s DEPO co-leads
+   - Platform’s OCTO-DE co-leads
    - Analytics (optional)
 
 ## What artifacts do I provide?


### PR DESCRIPTION
This PR is for replacing "VSP"  with "Platform" in the Collaboration Cycle github pages: