### PR TITLE
Deprecating Collaboration Cycle documentation on Github

### DIFF
--- a/platform/working-with-vsp/vsp-collaboration-cycle/README.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/README.md
@@ -1,3 +1,11 @@
+# We're moving our docs! 
+
+### You can find [the latest version of this page](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/index.html) on the Platform website.
+
+### Still can't find what you're looking for? Reach out to [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) on Slack.
+
+-------
+
 # Platform Collaboration Cycle
 
 The Platform Collaboration Cycle is where Platform reviewers provide support and guidance to VFS teams to help ensure the products they are building on VA.gov meet platform standards.  

--- a/platform/working-with-vsp/vsp-collaboration-cycle/change-documentation/README.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/change-documentation/README.md
@@ -1,3 +1,13 @@
+# We're moving our docs! 
+
+### You can find [the latest version of this page](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/Change-history.1768259657.html) on the Platform website.
+
+### Still can't find what you're looking for? Reach out to [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) on Slack.
+
+
+------
+
+
 ## Collaboration Cycle - Change Log
 
 

--- a/platform/working-with-vsp/vsp-collaboration-cycle/collab-cycle-get-started.md
+++ b/platform/working-with-vsp/vsp-collaboration-cycle/collab-cycle-get-started.md
@@ -1,3 +1,12 @@
+
+# We're moving our docs! 
+### You can find [the latest version of this page](https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/Getting-started.1760493650.html) on the Platform website.
+
+### Still can't find what you're looking for? Reach out to [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1) on Slack.
+
+
+------
+
 # Getting started with the Collaboration Cycle 
 Before engaging with the Collaboration Cycle, please review the guidance and questions below to help Platform determine what level of support, which practice areas, and which touchpoints are needed for your work. If you don’t know the answer to a question, then it’s too early for you to engage with the Collaboration Cycle.
 


### PR DESCRIPTION
Adding messages to Collaboration Cycle documents to point to new location on Platform Website. 