### PR TITLE
Update access request template w/ GTL instead of COR

### DIFF
--- a/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.md
+++ b/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.md
@@ -17,7 +17,7 @@ assignees: ''
 # Description
 - Please provide your Contracting Officer's Representative (COR) name.
    > Janet Doe
-- Please provide your Government Team Lead (GTL) name. This is the contractor responsible for your onboarding process.
+- Please provide your Vendor Onboaring Representative name. This is the person from the contracting company responsible for your onboarding process.
    > Janet Doe
 - Please provide your name.
    > Jane Doe

--- a/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.md
+++ b/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.md
@@ -15,7 +15,9 @@ assignees: ''
 5. When the issue is closed you will be notified and can continue with on-boarding setup
 
 # Description
-- Please provide your Government Team Lead (GTL) name.
+- Please provide your Contracting Officer's Representative (COR) name.
+   > Janet Doe
+- Please provide your Government Team Lead (GTL) name. This is the contractor responsible for your onboarding process.
    > Janet Doe
 - Please provide your name.
    > Jane Doe

--- a/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.md
+++ b/.github/ISSUE_TEMPLATE/Environment-Access-Request-Template.md
@@ -15,7 +15,7 @@ assignees: ''
 5. When the issue is closed you will be notified and can continue with on-boarding setup
 
 # Description
-- Please provide your Contracting Officer's Representative (COR) name.
+- Please provide your Government Team Lead (GTL) name.
    > Janet Doe
 - Please provide your name.
    > Jane Doe


### PR DESCRIPTION
From @mchelen 👉  https://dsva.slack.com/archives/CJYRZK2HH/p1626965018096200

> the process for OCTODE approval of AWS access requests has been updated to use GTL (Government Team Lead) instead of COR. can someone update the Github issue template to match?
