### PR TITLE
Removing Dror from the offboarding-template cc list

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboarding-request.md
+++ b/.github/ISSUE_TEMPLATE/offboarding-request.md
@@ -34,4 +34,4 @@ Fill out name of individual and *Description* section below.
  - [ ] Sentry access removed (if applicable)
  - [ ] Google analytics, and Domo access removed (if applicable) 
  
- CC: @department-of-veterans-affairs/vsp-operations ,  @department-of-veterans-affairs/vsp-product-support , @department-of-veterans-affairs/vsp-analytics-insights, @drorva, @mchelen-gov
+ CC: @department-of-veterans-affairs/vsp-operations ,  @department-of-veterans-affairs/vsp-product-support , @department-of-veterans-affairs/vsp-analytics-insights, @mchelen-gov


### PR DESCRIPTION
Dror has changed positions and is no longer needed on the cc list within the offboarding-request template.

https://dsva.slack.com/archives/CBU0KDSB1/p1631124987384400