### PR TITLE
Updating headings for screen reader accessibility

### DIFF
--- a/platform/research/research-history.md
+++ b/platform/research/research-history.md
@@ -2,9 +2,9 @@
 
 This does not include research for Appeals projects, which is stored in different repos. 
 
-**Updating This? Follow this format:** 
+## Template (copy and paste below)
 
-#### Date: Research Study Name** (H4 Level)
+### Date: Research Study Name** (H3 Level)
 *Team Name, Research Lead(s)*
 
 - Number of participants
@@ -12,72 +12,72 @@ This does not include research for Appeals projects, which is stored in differen
 - List of keywords
 
 ------
-### August 2021
+## August 2021
 
-#### August 20-34: Alert/Action Items Discovery Research
+### August 20-34: Alert/Action Items Discovery Research
 *Authenticated Experience, Lead Researcher: Tressa Furner*
 - Number of participants: 8 Veterans 
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/my-va/action-items-discovery/research)
 - List of keywords: alerts, action items, notifications, My VA, card pattern
 
-### July 2021
+## July 2021
 
-#### July 28-August 11: VA facility selection interactions A/B test
+### July 28-August 11: VA facility selection interactions A/B test
 *VA Online Scheduling (VAOS), Lead Researcher: Peter Russo*
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/research/2021-august-facilities-ab-test/README.md)
 - Keywords: select, dropdown, sorting pattern, variant test, distance sort, location sort
 
-#### July 27-30: Find a Form PDF Downloading Usability Research
+### July 27-30: Find a Form PDF Downloading Usability Research
 *Decision Tools, Lead Researcher: Cindy Merrill*
 - Number of participants: 11 (10 Veterans, 1 family member of a Veteran; 4 screen reader users)
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/find-a-va-form/post-mvp-releases/research)
 - List of keywords: alert boxes, hint text, instructions, forms, download, digital signature, accessibility, search results, headings 
 
-#### July 21-23:  Comparison Tool Redesign - Profile Page
+### July 21-23:  Comparison Tool Redesign - Profile Page
 *Booz Allen: Amy Knox, Jen Jones, Emma Waters*
  - Number of participants: 7 
  - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/redesign/research/usabilitytesting-july2021)
  - **Keywords:** Comparison Tool, profile page, "on this page" navigation 
 
-#### June 15 - July 12: Facility Locator - VAMC VHA Mobile Redesign - Stakeholder interviews
+### June 15 - July 12: Facility Locator - VAMC VHA Mobile Redesign - Stakeholder interviews
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - Number of participants: 16 VA employees (Public Affairs Officers, Emergency Managers, Clinic Managers, Physicians, Nurse Managers)
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/product/vamc-vha-mobile-redesign/discovery)
 - List of keywords: Mobile clinics, Mobile Medical Units, Critical deployable resources, MMU, MUV, CDR, rural health, telehealth, telemedicine, PAOs, VAMC location pages, emergency response  
 
-#### July 1 - July 1: VA Health Care Copayment Tool MVP Usability Study - Mobile
+### July 1 - July 1: VA Health Care Copayment Tool MVP Usability Study - Mobile
 *Debt Resolution, Lead Researchers: Riley Orr (Amida), Rebecca Walsh (Ad Hoc)*
 - Number of participants: 10 Veterans (All use VA health care; 5 on Android; 5 on iPhone)
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/Debt%20Resolution/Medical_Copays/research/jun-2021)
 - List of keywords: Mobile, Veterans, Veterans Health Administration, Veteran Patient Statements, copays, health care, debt, financial assistance, Pay.gov, experimental design 
 
-### June 2021
+## June 2021
 
-#### June 23-29: Check-in MVP Usability Veteran-facing Research
+### June 23-29: Check-in MVP Usability Veteran-facing Research
 *Healthcare experience, Lead Researcher: Kristen McConnell*
 - Number of participants: 10 Veterans
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/research/veteran-facing/mvp-usability/README.md)
 - List of keywords: Veterans, appointments, check-in, kiosk, staff members, text message check-in, digital check-in, medical appointments, contact information, insurance
 
-#### June 8-25: Facility Locator - Assistive Technology Discovery and Usability Study
+### June 8-25: Facility Locator - Assistive Technology Discovery and Usability Study
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - Number of participants: 7 Veterans (3 blind, 3 low vision, 1 cognitive disability, dyslexia)
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research/user-research/screenreader-usability-study)
 - List of keywords: Veterans,  accessibility, assistive technology, screen reader, screenreader, blind, low vision, dyslexia, JAWS, ZoomText, Fusion, VO, voice over, VoiceOver dictation, Dragon, orientation, wayfinding, VA.gov home page, site search, global search, Facility Locator, Google search, search behavior
 
-#### June 16-18:  Comparison Tool Redesign - Compare
+### June 16-18:  Comparison Tool Redesign - Compare
 *Booz Allen: Amy Knox, Jen Jones, Emma Waters*
  - Number of participants: 8 
  - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/redesign/research/usability-testing-june2021)
  - **Keywords:** Comparison Tool, comparison table, add and remove selections from comparison 
 
-#### June 14-17: VA.gov profile notification settings usability study
+### June 14-17: VA.gov profile notification settings usability study
 *Authenticated experience, Lead Researcher: Liz Lantz*
 - Number of participants: 8 Veterans
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/notifications/notification-preferences/discovery-and-research)
 - Keywords: notifications, settings, SMS text messages, email notifications, removing contact information, appointment reminders, opt-in, opt-out, unsubscribe, read/edit views, missing contact information 
 
-#### June 14th: Virtual Agent Inclusive Design interviews
+### June 14th: Virtual Agent Inclusive Design interviews
 *Virtual Agent, Lead Researcher: Shane Strassberg*
 
 - Number of participants: 2
@@ -86,13 +86,13 @@ This does not include research for Appeals projects, which is stored in differen
 
 - List of keywords: Veterans, Virtual Agent, Chatbot, Disabled, Visual impairment, Accessibility
 
-#### June 1-8: VAOS facility preferences generative research / VA.gov profile facility settings usability research
+### June 1-8: VAOS facility preferences generative research / VA.gov profile facility settings usability research
 *Collaborative study: VAOS (Peter Russo) and Authenticated Experience (Liz Lantz)*
 - Number of participants: 9
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/appointments/va-online-scheduling/research/may-2021-facilities-personalization-research)
 - Keywords: preferences, saved facilities, health facilities, health care, online scheduling, making an appointment, facility registrations, primary care
 
-#### June 1st: Virtual Agent Proof of Concept 
+### June 1st: Virtual Agent Proof of Concept 
 *Virtual Agent, Lead Researcher: Shane Strassberg*
 
 - Number of participants: 44
@@ -101,52 +101,52 @@ This does not include research for Appeals projects, which is stored in differen
 
 - List of keywords: Veterans, Virtual Agent, Chatbot
 
-### May 2021
+## May 2021
 
-#### May 25-27:  Comparison Tool Redesign - Search
+### May 25-27:  Comparison Tool Redesign - Search
 *Booz Allen: Amy Knox, Jen Jones, Emma Waters*
  - Number of participants: 7 
  - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/redesign/research/usability-testing-may2021)
  - **Keywords:** Comparison Tool, name search, location search 
 
-#### May 17 - May 25: Emergency Care Mashup
+### May 17 - May 25: Emergency Care Mashup
 *Facilities Team, Lead Researcher: Nick Osmanski*
 
 - NUmber of participants: 9 (8 Veterans, 1 caregiver)
 - [Link to research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research/user-research/emergency-care-mashup)
 - List of keywords: Veterans, facility, locator, emergency care, search, locations
 
-#### May 5-17: 10-10EZ Discovery 
+### May 5-17: 10-10EZ Discovery 
 *Caregivers, Research Lead: Dené Gabaldón*
 
 - Number of participants: 1 pilot, 8 participants (6 Veterans, 3 POAs)
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/caregivers/10-10EZ/Research%20April-May%202021/End%20user%20discovery%20research) 
 - List of keywords: Veterans, POA, health care, application
 
-### April 2021
+## April 2021
 
-#### April 26 - May 5: Baseline Wayfinding on VA.gov
+### April 26 - May 5: Baseline Wayfinding on VA.gov
 *Public Websites, Lead Researcher: Cindy Merrill*
 
 - Number of participants: 13 (8 desktop, 5 mobile; 1 screenreader user)
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/public-websites/research/202104-baseline-wayfinding) 
 - List of keywords: Veterans, wayfinding, VA.gov home page, site search, Find a VA Form, Resources and Support, accessibility
 
-#### April 26 - April 30 Virtual Agent Branding Interviews
+### April 26 - April 30 Virtual Agent Branding Interviews
 *Virtual Agent, Lead Researcher: Shane Strassberg*
 
 - Number of participants: 16
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/virtual-agent/research/moderated-interviews)
 - List of keywords: Veterans, Virtual Agent, Chatbot, Voice, Tone, Branding
 
-#### April 22 - April 18: Medical Copayment Debt Portal Enhancement Discovery
+### April 22 - April 18: Medical Copayment Debt Portal Enhancement Discovery
 *Debt Resolution, Research Leads: Rebecca Walsh, Riley Orr*
 
 - Number of participants: 11
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/Debt%20Resolution/Medical_Copays/research/apr-2021) 
 - List of keywords: Veterans, Veterans Health Administration, Veteran Patient Statements, copays, health care, debt, financial assistance, Pay.gov 
 
-#### April 12 - 13: 1010-CG Round 2 Sign as Representative Usability Testing
+### April 12 - 13: 1010-CG Round 2 Sign as Representative Usability Testing
 *Caregiver Team, Lead Researcher: Shawna Hein, Dené Gabaldon*
 
 - Number of participants: 5
@@ -155,7 +155,7 @@ This does not include research for Appeals projects, which is stored in differen
 
 - List of keywords: veterans, caregivers, representative, POA, upload
 
-#### April 8 - 13: Check-in (Veteran-facing) Remote Discovery Research
+### April 8 - 13: Check-in (Veteran-facing) Remote Discovery Research
 *Healthcare Experience, Lead Researcher: Kristen McConnell*
 
 - Number of participants: 11
@@ -165,10 +165,10 @@ This does not include research for Appeals projects, which is stored in differen
 - List of keywords: Veterans, appointments, check-in, pre-check in, virtual appointments, kiosk, staff members, text message check-in, digital check-in, medical appointments, lab tests, pharmacy, contact information, next of kin, insurance, beneficiary travel mileage
 
 
-### March 2021
+## March 2021
 
 
-#### March 22 - April 5: Board Appeals (NOD) usability testing
+### March 22 - April 5: Board Appeals (NOD) usability testing
 *Claims and Appeals, Lead Researcher: Christian Valla*
 
 - Number of participants: 7
@@ -177,58 +177,58 @@ This does not include research for Appeals projects, which is stored in differen
 
 - Keywords: Board Appeals; Notice of Disagreement;
 
-#### March 18 - April 9 2021 : Vet Center Services Unmoderated Taxonomy Study
+### March 18 - April 9 2021 : Vet Center Services Unmoderated Taxonomy Study
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - Number of participants: 41
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/vet-centers/services-taxonomy/taxonomy-study)
 - List of keywords: Vet Centers, mental health care, PTSD, health services, counseling, transition care, keywords
 
-### February 2021
+## February 2021
 
-#### Feb 22 - Feb 26: My VA 2.0 usability testing
+### Feb 22 - Feb 26: My VA 2.0 usability testing
 *Authenticated Experience, Lead Researcher: Tressa Furner*
 
 - Number of participants: 8
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/my-va/2.0-redesign/product/Research%20V2)
 - Keywords: My VA; Dashboard
 
-#### Feb 16 - Feb 19: Health Record (Medications, Allergies, and Immunizations)
+### Feb 16 - Feb 19: Health Record (Medications, Allergies, and Immunizations)
 *Health care Experience/Questionnaires, Lead Researcher: Kristen McConnell*
 
 - Number of participants: 7
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/questionnaire/research/health-record)
 - Keywords: health care, medications, immunizations, allergies, questionnaires, patient portal
  
-#### Feb 15 - Feb 19: Mobile Facility Locator Usability Study
+### Feb 15 - Feb 19: Mobile Facility Locator Usability Study
 *VSA Facilities, Lead Researchers: Christian Valla + Laurel Lawrence(Ad Hoc)*
 
 - Number of participants: TBD
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/mobile-experience)
 - Mobile, facility, locations
 
-#### Feb 9 - 12:  Comparison Tool Redesign Research
+### Feb 9 - 12:  Comparison Tool Redesign Research
 *Booz Allen: Amy Knox, Jen Jones, Emma Waters*
  - 12 Veteran/non-Veteran beneficiaries recruited: 8 desktop, 4 mobile (50% participation rate: 4 desktop, 2 mobile) 
  - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/redesign/research)
  - **Keywords:** Comparison Tool, school search, school comparison
 
 
-### January 2021
+## January 2021
 
-#### January 27 - February 8, 2021: VA.gov Search Usability Study
+### January 27 - February 8, 2021: VA.gov Search Usability Study
 *VA Global Search, Lead Researcher: Megan Gayle*
 
 - Number of participants: 10
 - [Link to the research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/on-site-search/research/user-research)
 - List of keywords: Global Search, Find a Form, Find a Facility, On-site Search
 
-#### Januray 29 - Feb 4, 2021 : Vet Center Product - Usability V2
+### Januray 29 - Feb 4, 2021 : Vet Center Product - Usability V2
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - Number of participants: 11 (10 Veterans, 4 Vet Center clients, 1 Army reservist)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/vet-centers/discovery/client-usability-tests)
 - List of keywords: Vet Centers, mental health care, facility detail page, locations
 
-#### Jan 21 - Feb 05: VAOS Appointments List Usability Study
+### Jan 21 - Feb 05: VAOS Appointments List Usability Study
 *VA Online Scheduling, Lead Researcher: Peter Russo*
 
 - Number of participants: 5
@@ -236,12 +236,12 @@ This does not include research for Appeals projects, which is stored in differen
 - Appointments, Scheduling, VAOS, Dashboard, Home page
 
 
-###  2020
+##  2020
 
 
-### December 2020
+## December 2020
 
-#### Dec 14-18: All "Primary care questionnaire" MVP Workflows Research
+### Dec 14-18: All "Primary care questionnaire" MVP Workflows Research
 *Health care Experience/Questionnaires, Lead Researcher: Kristen McConnell*
 
 - Number of participants: 10
@@ -250,7 +250,7 @@ This does not include research for Appeals projects, which is stored in differen
 
 
 
-#### December 14-17: Keep Me Informed Usability Testing
+### December 14-17: Keep Me Informed Usability Testing
 *Office of the CTO. Lead researcher: Lauryl Zenobi*
 
 - Number of participants: 11
@@ -260,7 +260,7 @@ This does not include research for Appeals projects, which is stored in differen
 - Keywords: covid-19 vaccine, vaccine updates, coronavirus
 
 
-#### December 14 - December 18: IRIS Usability Testing 
+### December 14 - December 18: IRIS Usability Testing 
 
 *IRIS Redesign. Lead researcher: Rachel M. Murray*
 
@@ -271,14 +271,14 @@ This does not include research for Appeals projects, which is stored in differen
 - Keywords: IRIS, contact us form, inquiry
 
 
-#### December 9-16 : Vet Center Product - Usability V1
+### December 9-16 : Vet Center Product - Usability V1
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - Number of participants: 9 (All Veterans, 2 Vet Center clients)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/vet-centers/discovery/veteran-usability-tests)
 - List of keywords: Vet Centers, mental health care, facility detail page, locations
 
 
-#### Nov 30- Dec 7th: Direct Deposit for Edu
+### Nov 30- Dec 7th: Direct Deposit for Edu
 *Authenticated Experience, Lead Researcher: Jim Adams*
 
 - Number of participants: 5
@@ -286,9 +286,9 @@ This does not include research for Appeals projects, which is stored in differen
 - List of keywords: Direct Deposit, compensation, pension, benefits, education, change, update
 
 
-### November 2020
+## November 2020
 
-#### November 19 - December 15: 526 Usability test (PTSD flow)
+### November 19 - December 15: 526 Usability test (PTSD flow)
 *GovernmentCIO, BAM 1. Lead researcher: Christian Valla
 
 -16 participants (4-8 therapists / social workers. 8-12 veterans) 
@@ -297,120 +297,120 @@ This does not include research for Appeals projects, which is stored in differen
 
 
 
-#### November 18 - November 24: Medallia Usability Testing
+### November 18 - November 24: Medallia Usability Testing
 *VSP Contact Center Team. Lead researcher: Ian McCullough*
 
 - 9 participants (all veterans)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/platform/medallia/research)
 
-#### November 13 - December 7: Community Care Provider Selection Research** 
+### November 13 - December 7: Community Care Provider Selection Research** 
 *VAOS, Peter Russo*
 
 - 8 Veterans
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/va-online-scheduling/research/oct-2020-cc-provider-discovery/research-plan-cc-discovery.md)
 - Scheduling, Appointments
 
-#### November 6 - November 20: Community Care Request Manager Research
+### November 6 - November 20: Community Care Request Manager Research
 *GovernmentCIO, VSA Facilities, Lead researcher: Chris Logan
 
 -7 participants (6 CCRMs / 1 CCRM Supervisor) 
 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/community-care)
 
-#### November 3 - 6:  Comparison Tool Redesign Research / School Ratings
+### November 3 - 6:  Comparison Tool Redesign Research / School Ratings
 *Booz Allen: Amy Knox, Jen Jones, Emma Waters*
  - 8 Veteran/non-Veteran beneficiaries 
  - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/redesign/research)
  - **Keywords:** Comparison Tool, Veteran ratings, school selection 
 
 
-#### November 2 - 4 : Wizard Migration Usability Study
+### November 2 - 4 : Wizard Migration Usability Study
 *Public Websites: Liz Lantz, Christian Valla, Megan Gayle, Josh Kim*
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/public-websites/how-to-apply-wizards/discovery/research)
 - **Keywords:** wizard pattern, education benefits, alerts
 
-#### September 17 - November 9 : IRIS / Contact Center Content Process Research
+### September 17 - November 9 : IRIS / Contact Center Content Process Research
 *Public Websites: Liz Lantz*
 - 31 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/content/tier-2-content-IA-and-design/learning-center-mvp/discovery-and-research/iris)
 - **Keywords:** Call center, contact center, content governance, IRIS, Oracle Service Cloud, help desk, GI Bill help desk, MHV technical support, LEAF
 
-### October 2020
+## October 2020
 
-#### October 15 - 27:  Comparison Tool Redesign Research
+### October 15 - 27:  Comparison Tool Redesign Research
 *Booz Allen: Amy Knox, Jen Jones, Emma Waters*
  - 10 Veteran/non-Veteran beneficiaries, 5 School Certifying Officials, 20+ stakeholders
  - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/redesign/research)
  - **Keywords:** Comparison Tool, school search, school selection 
 
-#### October 15 - 19 : Usability Testing the MVP Upcoming Appointment Questionnaire
+### October 15 - 19 : Usability Testing the MVP Upcoming Appointment Questionnaire
 *Ad Hoc: VSA Health care Experience/Questionnaires, Kristen McConnell*
 - 8 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/questionnaire/research/mvp-usability)
 - **Keywords:** Veterans, Questionnaires, Upcoming appointment, Primary care, Health care, Usability testing 
 
-#### September 30 - October 16 : Vet Center - Veteran Client - Discovery Interviews
+### September 30 - October 16 : Vet Center - Veteran Client - Discovery Interviews
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - 15 participants (8 clients)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/vet-centers/discovery/veteran-interviews)
 
-### August 2020
+## August 2020
 
-#### August 20 - November 30: UAT testing. HLR and BDD.
+### August 20 - November 30: UAT testing. HLR and BDD.
 *GovernmentCIO, BAM 1. Lead researcher: Christian Valla
 
 -12 participants 
 
 - [Research folder] N/A.
 
-#### August 31 - September 11: Learning center nomenclature card sort
+### August 31 - September 11: Learning center nomenclature card sort
 *Public Websites: Liz Lantz*
 - 39 Veteran participnts, 9 SME participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/content/tier-2-content-IA-and-design/learning-center-mvp/discovery-and-research/card-sort)
 
 **Keywords:** categorization, nomenclature, tags, categories, audience, topics, labels, content authoring, tier 2, benefit-adjacent, VA account and profile, Records
 
-#### August 20-28 : Vet Center - Outreach Specialist - Discovery Interviews
+### August 20-28 : Vet Center - Outreach Specialist - Discovery Interviews
 *VSA Facilities, Lead Researcher: Leyda Hughes (Ad Hoc)*
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/vet-centers/discovery/outreach-specialist-interviews)
 
-#### August 19-20: VA.gov mobile study (mobile month)
+### August 19-20: VA.gov mobile study (mobile month)
 *VSA: Shawna Hein and Liz Lantz*
 - 6 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/cross-team-initiatives/mobile-month/research)
 **Keywords:** mobile usability, mobile header, navigation, more in this section, right rail, claim status, facility locator, map view, alert usability
 
-#### August 10-14 Patient Generated Data Discovery Research
+### August 10-14 Patient Generated Data Discovery Research
 *VA Lighthouse APIs: Lauryl Zenobi*
 - 9 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/lighthouse-ux/tree/master/patient-generated-data)
 **Key words:** Veterans, Clinicians, PGD, Wearables, Data-sharing, Clinical workflows
 
 
-#### August 10 - 12
+### August 10 - 12
 *CTO health team: Ryan Thurlwell*
 
 - 6 participants (out of 8), 1 round
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/covid-vaccine-trials/research)
 - COVID-19 COVID vaccine clinical trials research registry medical trials medical research
 
-#### August 3-7: IRIS general Discovery Interviews 
+### August 3-7: IRIS general Discovery Interviews 
 *ThoughtWorks: Rachel M. Murray
 
 - 7 participants, 1 round 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/iris)
 
-#### August 3-5: Learning Center MVP Usability Study
+### August 3-5: Learning Center MVP Usability Study
 *Ad Hoc: Public Websites, Liz Lantz*
 
 - 8 participants, 1 round 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/content/tier-2-content-IA-and-design/learning-center-mvp/discovery-and-research)
 
-### July 2020
+## July 2020
 
-#### July 7-30: VAOSr and Express Care
+### July 7-30: VAOSr and Express Care
 *DEPO team, Melissa Schaff*
 
 - 15 participants
@@ -419,46 +419,46 @@ This does not include research for Appeals projects, which is stored in differen
 
 **Keywords**: vaos, vaosr, online scheduling, express care, covid, coronavirus, user research, usabilty testing 
 
-#### July 13-16: Facility Locator - Urgent Care Mashup (usability test)
+### July 13-16: Facility Locator - Urgent Care Mashup (usability test)
 *Ad Hoc: VSA Facilities, Leyda Hughes*
 - 8 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research/user-research/urgent-care-mashup)
 
-#### July 6-9: VA Form 22-10203 - Apply for Rogers STEM Scholarship, Round 2  
+### July 6-9: VA Form 22-10203 - Apply for Rogers STEM Scholarship, Round 2  
 *Booz Allen: Amy Knox, Cindy Cruz, Jen Jones*
 
 - 6 participants  
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/stem/stem-standalone-10203/research) 
 
-#### July 1-10: Connected Accounts (privacy, consent and authorization) - Lighthouse 
+### July 1-10: Connected Accounts (privacy, consent and authorization) - Lighthouse 
 *Ad Hoc: Carey Otto, Evangeline Garreau, Maria Vidart-Delgado 
 
 - 11 participants 
 - [Research folder](https://github.com/department-of-veterans-affairs/lighthouse-ux/tree/master/privacy/connected-accounts)
 
-### June 2020
+## June 2020
 
-#### June 25-29: Claim status tool. Usability test / Collaborative design exersise 
+### June 25-29: Claim status tool. Usability test / Collaborative design exersise 
 *GovernmentCIO, BAM 1. Lead researcher: Christian Valla
 
 -12 participants 
 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/research/co-design-usability-June)
 
-#### June 22-24: GI Bill Comparison Tool - School Ratings Discovery Interviews 
+### June 22-24: GI Bill Comparison Tool - School Ratings Discovery Interviews 
 *Booz Allen: Amy Knox, Cindy Cruz, Jen Jones*
 
 - 8 participants  
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/school-ratings/research)
 
-#### June 10-15: Facility Locator - Operating Status Study
+### June 10-15: Facility Locator - Operating Status Study
 *Ad Hoc: VSA Facilities, Leyda Hughes, Aricka Lewis*
 
 - 8 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research/user-research/facility-status)
 
 
-#### June: Usability testing for Form 21-686c / staging environment
+### June: Usability testing for Form 21-686c / staging environment
 *eBenefits: Nicolaus Wygonik, Jim Adams*
 
 - 9 participants
@@ -466,16 +466,16 @@ This does not include research for Appeals projects, which is stored in differen
 
 **Keywords**: Depandents, Depandants (British), 686, Form 21-686, Claims, Usabilty Testing
 
-#### June 3-5: VA Form 22-10203 - Apply for Rogers STEM Scholarship  
+### June 3-5: VA Form 22-10203 - Apply for Rogers STEM Scholarship  
 *Booz Allen: Amy Knox, Cindy Cruz, Jen Jones*
 
 - 7 participants  
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/stem/stem-standalone-10203/research) 
 
 
-### May 2020
+## May 2020
 
-#### May 18: Covid-19 screening tool
+### May 18: Covid-19 screening tool
 *DEPO team, Jeff Barnes*
 
 - 7 participants
@@ -485,7 +485,7 @@ This does not include research for Appeals projects, which is stored in differen
 
 **Keywords**: covid, coronavirus, screener, mobile, user research, usabilty testing
 
-#### May 11-15: My VA Redesign discovery (formerly logged-in homepage discovery)
+### May 11-15: My VA Redesign discovery (formerly logged-in homepage discovery)
 *Authenticated Experience, Liz Lantz*
 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/my-va/2.0-redesign/discovery-and-research) 
@@ -499,7 +499,7 @@ This does not include research for Appeals projects, which is stored in differen
 
 **Keywords**: My VA redesign, personalization, dashboard, notifications, alerts, co-design, collaborative design, participatory design, generative research
  
-#### May 1-8: Express Care
+### May 1-8: Express Care
 *DEPO team, Melissa Schaff*
 
 - 11 participants
@@ -508,241 +508,241 @@ This does not include research for Appeals projects, which is stored in differen
 
 **Keywords**: express care, virtual care, online appointments, video appointments, urgent care, vaos, covid, coronavirus, user research, usabilty testing 
  
-#### May 06: Comparative analysis. Status tracking
+### May 06: Comparative analysis. Status tracking
 *BaM 1, Lead Researcher: Christian Valla*
 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/research/April-2020-dicovery-concept-usability)
 
-### April 2020
+## April 2020
 
-#### April 27: Previous Research Review: Claim Status Tool.
+### April 27: Previous Research Review: Claim Status Tool.
 *BaM 1, Lead Researcher: Christian Valla*
 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/research/April-2020-dicovery-concept-usability)
 
-#### April 20-30: View my representative (POA)/ View payment history** (H4 Level)
+### April 20-30: View my representative (POA)/ View payment history** (H4 Level)
 *eBenefits, Nick Wygonik*
 
 - Eight participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/vsa/teams/ebenefits/features/view-update-POA/research-design)
 
-#### April 15-20: Medical Device Tool Usability Test
+### April 15-20: Medical Device Tool Usability Test
 *BaM2, Rebecca Walsh & Riley Orr*
 - 10 participants 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/medical-device-tool/research/usability-march20)
 
-#### April 6-10: Combining profile and account (Profile 2.0)
+### April 6-10: Combining profile and account (Profile 2.0)
 *Authenticated Experience, Tressa Furner*
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/profile/Combine%20Profile%20and%20Account/Research)
 
-#### April 2-20: COVID-19 Information & Chatbot
+### April 2-20: COVID-19 Information & Chatbot
 *ThoughtWorks, Todd Stanich*
 - 13 participants (two rounds)
 - [Research folder](https://github.com/department-of-veterans-affairs/covid19-chatbot/tree/master/docs/research) 
 
-### March 2020
+## March 2020
 
-#### March 18-20: BDD Initial Usability test 
+### March 18-20: BDD Initial Usability test 
 *GovernmentCIO, BAM1. Lead researcher: Christian Valla
 
 -10 participants
 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/disability-compensation-claim/bdd/BDD%20Research/Initial-usability-March2020)
 
-#### March 4-6: Facility Locator User Search Expectations
+### March 4-6: Facility Locator User Search Expectations
 *Ad Hoc: VSA Facilities, Aricka Lewis*
 
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research/user-research/FL-Search-march2020)
 
-#### March 2-4: GI Bill Comparison Tool - Caution Flags & Reducing Veteran Risk in School Selection  
+### March 2-4: GI Bill Comparison Tool - Caution Flags & Reducing Veteran Risk in School Selection  
 *Booz Allen: Amy Knox, Cindy Cruz*
 
 - 8 participants  
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/research/caution-flags/prototype-phase) 
 
-### February 2020
+## February 2020
 
-#### February 21-February 25: SSO Login Manage Benefits Pages - Alert Box Updates
+### February 21-February 25: SSO Login Manage Benefits Pages - Alert Box Updates
 *Bridget Hapner, Martha Wilkes*
 
 - 6 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/sso/ux-research)
 - Themes and keywords: warning alert, minimize scrolling, consolidate information, multiple CTAs, My VA Health, Cerner, facility registration
 
-#### February 19-March 6: eBenefits Form 21-686c Add/Remove Dependents Workflows
+### February 19-March 6: eBenefits Form 21-686c Add/Remove Dependents Workflows
 *Aricka Lewis, James Adams*
 
 - 8 participants 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/features/view-update-dependents/research-design/686-form-gating-0220/686-usability-research-plan.md)
 
-#### February 3-4: VA Form 22-1995 STEM Scholarship & Education Routing Wizard Usability Testing, Redux
+### February 3-4: VA Form 22-1995 STEM Scholarship & Education Routing Wizard Usability Testing, Redux
 *Booz Allen: Amy Knox, Theresa McMurdo*
 
 - 3 participants (4 scheduled, 1 canceled / no-show)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/stem/research/wizard-update/prototype-phase) 
 
-### January 2020
+## January 2020
 
-#### January 30 - February 3: Yellow Ribbon - Find Participating Schools MVP
+### January 30 - February 3: Yellow Ribbon - Find Participating Schools MVP
 *Public Websites, Liz Lantz*
 - 12 participants (12 scheduled, 2 no show)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/public-websites/yellow-ribbon-mvp/research)
 
 **Keywords:** Yellow Ribbon program, benefits comprehension, user search behaviors, search results, education benefits, understanding of benefits, awareness of benefits, tabular data, tables, cards, comparison lists. 
 
-#### January 28 - 29: STEM Scholarship Education Routing 
+### January 28 - 29: STEM Scholarship Education Routing 
 *BAH: Amy Knox, Theresa McMurdo*
 - 6 participants 
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/stem/research/wizard-update/prototype-phase/stem-wizard-update-prototype-research-discussion-guide.md)
 
-#### January 27 - 31: VA Form 22-1995 STEM Scholarship & Education Routing Wizard Usability Testing 
+### January 27 - 31: VA Form 22-1995 STEM Scholarship & Education Routing Wizard Usability Testing 
 *Booz Allen: Amy Knox, Theresa McMurdo*
 
 - 3 participants (6 scheduled, 3 canceled / no-show)
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/stem/research/wizard-update/prototype-phase) 
 
-#### January 16 - 17, 20-21: VSA Caregiver 1010CG Usability
+### January 16 - 17, 20-21: VSA Caregiver 1010CG Usability
 *Ad Hoc: Johnathan Nelson, Shawna Hein*
 - 14 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/caregivers/1010cg-mvp/usability-testing-jan2020/research-plan.md)
 
-#### January 16 - 23: VAOS UAT Phase III 
+### January 16 - 23: VAOS UAT Phase III 
 *Lauren Alexanderson*
 - 15 participants 
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/research/january-2020-uat/research_plan.md)
 
-#### January 16 - 23: Facility Locator Urgent Care PDF & Content
+### January 16 - 23: Facility Locator Urgent Care PDF & Content
 *Ad Hoc: Aricka Lewis*
 - 5 Participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/facility-locator/research/user-research/urgent-care-PDF/research-plan.md)
 
-#### January 16 - 17: Facility Locator Urgent Care PDF Testing
+### January 16 - 17: Facility Locator Urgent Care PDF Testing
 *AdHoc: Aricka Lewis*
 - 8 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/facility-locator/research/user-research/urgent-care-PDF/research-plan.md)
 
-#### January 15 - 22: Higher Level Review Usability Testing##
+### January 15 - 22: Higher Level Review Usability Testing##
 *Christian Valla, Kevin Stachura*
 9 participants (15 scheduled, 2 cancelled, 4 no-show)
 Research folder: https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/decision-reviews/higher-level-review/research
 
-#### January 6 - 8: STEM Scholarship Application
+### January 6 - 8: STEM Scholarship Application
 *BAH: Amy Knox, Theresa McMurdo*
 - 6 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/stem/research/wizard-update/research-plan.md)
 
-### December 2019
+## December 2019
 
-#### December 11 - 16: Facility Locator, Urgent Care Usability Testing
+### December 11 - 16: Facility Locator, Urgent Care Usability Testing
 *Ad Hoc: Aricka Lewis*
 - 5 Participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/facility-locator/research/user-research/urgent-care/research-plan.md)
 
-#### December 9 - 20: VAOS UAT Phase II 
+### December 9 - 20: VAOS UAT Phase II 
 *Lauren Alexanderson*
 - 30 participants 
 - Research Plan 
 
-#### December 5 - 12: Medical Device Tool Discovery
+### December 5 - 12: Medical Device Tool Discovery
 *AdHoc: Rebecca Walsh, Amida: Riley Orr*
 - 11 participants 
 - [Research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/medical-device-tool/research/discovery-nov19/research-plan.md)
 
-#### December 2 - 10: Global UX, Local Navigation, November/December 2019
+### December 2 - 10: Global UX, Local Navigation, November/December 2019
 *Kevin Hoffman*
 - 16 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/global/left-nav/research-plan.md)
 
-### November 2019
+## November 2019
 
-#### November 18 - 27: VAOS UAT Phase I (View Only) 
+### November 18 - 27: VAOS UAT Phase I (View Only) 
 *VA: Lauren Alexanderson*
 - 25 participants
 
-#### November 18 - 26: Benefits Rated Disabilities / View Dependents Usability Testing
+### November 18 - 26: Benefits Rated Disabilities / View Dependents Usability Testing
 *GovCIO: James Adams*
 - 15 participants 
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/research/disabilities-dependents-usability-1119/disabilities-dependents-usability-research-plan.md)
 
-#### November 18 - 26: Design System GI Bill Learn More Component Testing 
+### November 18 - 26: Design System GI Bill Learn More Component Testing 
 *AdHoc: Emily Waggoner*
 - 10 participants 
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/product-dev-support/research/additional-info-tooltip-modal-usability/research-plan.md)
 
-#### November 13 - 15: Authenticated Experience/Personalization: Candidate Address - Override Usability
+### November 13 - 15: Authenticated Experience/Personalization: Candidate Address - Override Usability
 *VA: Samara Strauss*
 - 5 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/profile/contact-information/address-validation/user%20testing/Research%20Plan.md)
 
-### October 2019
+## October 2019
 
-#### October 30 - November 6: Pittsburgh Global UX and Navigation 
+### October 30 - November 6: Pittsburgh Global UX and Navigation 
 *VA: Kevin Hoffman*
 - 16 participants
 - [Research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/global/left-nav/research-plan.md)
 
-#### October 28 – November 1: Facility Locator Discovery
+### October 28 – November 1: Facility Locator Discovery
 *Ad Hoc: Aricka Lewis*
 - 7 participants
 - [Research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/facility-locator/research/discovery-sprints/user-research/research-plan.md)
 
-#### October 16 - 17: SCO Content Migration - Moderated Usability Testing  
+### October 16 - 17: SCO Content Migration - Moderated Usability Testing  
 *Booz Allen: Amy Knox, Theresa McMurdo*
 - 5-6 participants
 - [Research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/office-administration/vba/sco-migration/research/research-plan.md)
 
-#### October 4 - 8: VSA eBenefits
+### October 4 - 8: VSA eBenefits
 *AdHoc: Aricka Lewis*
 - 10 participants
 - [Research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/ebenefits/research/research-plan.md)
 
-#### October 1 - 7: DS Logon
+### October 1 - 7: DS Logon
 *Ad Hoc: Lauryl Zenobi, Evangeline Garreau*
 - 9 participants
 - [Research plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/login/ds-logon/research/09-18-mct-logon-research-plan.md)
 
-### September 2019
+## September 2019
 
-#### September 11 - 17; 16-19: VA Health Records for Apple UAT - Part I, II, and III **
+### September 11 - 17; 16-19: VA Health Records for Apple UAT - Part I, II, and III **
 *Alex Kozak, Arman Shariati, Sara Bonner*
 - 45 participants 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/medical-records/apple-health-api/research/2019-09-UAT)
 
-#### September 9 - 13: VAOS Usability **
+### September 9 - 13: VAOS Usability **
 *DSVA: Lauren Alexanderson*
 - 15 participants 
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/appointments/research/aug19-usability-testing-new-ux/research-plan-aug19-usability.md)
 
-#### September 9 - 11: SCO Content Migration  
+### September 9 - 11: SCO Content Migration  
 *Booz Allen: Amy Knox, Theresa McMurdo*
 - 8-9 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/office-administration/vba/sco-migration/research)
 
-#### September 4 - 9: Direct Deposit UAT **
+### September 4 - 9: Direct Deposit UAT **
 *GovCIO: Arthur Green*
 - 10 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/direct-deposit/discovery-research/UAT/research-plan.md)
 
-#### Early September 2019
+### Early September 2019
 *Authenticated experience: Samara Strauss*
 - [Personalization 2.0 research summary](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Personalization/Personalization%202.0/Discovery%20%26%20Research/Personalization%202.0%20Discovery%20Summary%20%26%20Strategy.md)
 
-### August 2019
+## August 2019
 
-#### August 27 - 30: CARMA Caregiver Discovery **
+### August 27 - 30: CARMA Caregiver Discovery **
 *Riley Orr*
 - 16 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Products/caregivers/research/discovery-aug-2019/research-plan.md) 
 
-#### August 27, 29: Get Care Prototype Usability R1 **
+### August 27, 29: Get Care Prototype Usability R1 **
 *AdHoc: Caitlin Weber*
 - 12 participants 
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/patient-portal/get-care/research/usability)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/patient-portal/get-care/research/usability/research_plan.md)
 
-#### August 22 - 23, 2019: Facility - operating status - Veteran experience
+### August 22 - 23, 2019: Facility - operating status - Veteran experience
 
 _VA.gov CMS team: Eric Chiu_
 
@@ -750,582 +750,582 @@ _VA.gov CMS team: Eric Chiu_
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20operating%20status%20discovery%20-%20August%202019/operating%20status%20-%20veteran%20experience)
 
 
-#### August 22 - 23, 2019: Facility - operating status - author experience
+### August 22 - 23, 2019: Facility - operating status - author experience
 
 _VA.gov CMS team: Lapedra Tolson_
 
 * 2 participants 
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20operating%20status%20discovery%20-%20August%202019/operating%20status%20-%20author%20experience)
 
-#### August 21 - 28: Higher-Level Review Usability Testing **
+### August 21 - 28: Higher-Level Review Usability Testing **
 *DSVA: Carola Ponce*
 - 12 Participants 
 - Research Plan
 
-#### August 16-23: Get Care Discovery **
+### August 16-23: Get Care Discovery **
 *AdHoc: Caitlin Weber*
 - 11 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/patient-portal/get-care/research/discovery)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/patient-portal/get-care/research/discovery/research_plan.md)
 
-#### August 14 - 16: GIBCT Sec 107, Round 3 Moderated Usability Testing 
+### August 14 - 16: GIBCT Sec 107, Round 3 Moderated Usability Testing 
 *Booz Allen: Amy Knox*
 - 8-10 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/school-comparison-tool/colmery-act-2019/research/sec-107/gibct-107-research-plan-round-3.md)
 
-#### August 5 - 16: Personalization 2.0 Separating Service Member Interviews **
+### August 5 - 16: Personalization 2.0 Separating Service Member Interviews **
 - 5 participants 
 - [Research Folder](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Personalization/Personalization%202.0/Discovery%20%26%20Research/Service%20Member%20Interviews)
 
-#### August 5 - 12: VSP Onboarding - Round 2 (VSA) **
+### August 5 - 12: VSP Onboarding - Round 2 (VSA) **
 *VSP Platform Support: Layla Soileau*
 - 3 VSA teams
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/Platform/Onboarding/research/Onboarding-VSA-AUG-2019)
 
-### July 2019
+## July 2019
 
-#### July 24 - July 30: CCN Discovery **
+### July 24 - July 30: CCN Discovery **
 - 8 participants
 - Research Plan
 
-#### July 10-11: Automation Impact on 526 Usability **
+### July 10-11: Automation Impact on 526 Usability **
 - 8 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/research/jul-2019/research-plan-unicorns-526-automation.md)
 
-#### July 9 - 10: GIBCT 107 Remote Moderated Usability Testing **
+### July 9 - 10: GIBCT 107 Remote Moderated Usability Testing **
 *Booz Allen: Amy Knox, Theresa McMurdo*
 - 10 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/school-comparison-tool/colmery-act-2019/research/sec-107/gibct-107-research-plan.md)
 
-#### July 8-15: Education End-to-End Experience Usability Testing **
+### July 8-15: Education End-to-End Experience Usability Testing **
 - 22 participants
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/research)
 
-#### July 8-12: Dashboard 2.0 interviews
+### July 8-12: Dashboard 2.0 interviews
 *Dragons/Personalization: Samara Strauss*
 - 6 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Personalization/Personalization%202.0/Discovery%20%26%20Research/Dashboard%20interviews)
 
-#### July 8-10: Usability Research - GIBCT Colmery Sec 107 - Schools, Branches & Extensions 
+### July 8-10: Usability Research - GIBCT Colmery Sec 107 - Schools, Branches & Extensions 
 *BAH Team, Research Lead: Amy Knox, Theresa McMurdo*
 - 6-8 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/colmery-act-2019/research/sec-107)
 
-### June 2019
+## June 2019
 
-#### June 20 to July 3 2019: Usability Feedback Sessions - Discovery for MVP AMA Forms Veteran Facing tool.
+### June 20 to July 3 2019: Usability Feedback Sessions - Discovery for MVP AMA Forms Veteran Facing tool.
 *Research Lead: Carola Ponce. Product Lead: Steve Kovaks*
 - We talked to 12 Veterans, 8 men and 4 women.
 - [Discovery Notes](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/decision-reviews/research)
 
-#### June 24-28: Direct deposit usability testing 
+### June 24-28: Direct deposit usability testing 
 *Dragons/Personalization: Samara Strauss*
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/direct-deposit/discovery-research/usability-research)
 
-#### June 25 - 27, 2019: Facility - usability testing in Pittsburgh
+### June 25 - 27, 2019: Facility - usability testing in Pittsburgh
 
 _VA.gov CMS team: Eric Chiu, Meghana Khandekar, Ryan Sibley, Lapedra Tolson, Jane Newman, Rachel Kauff, Kate Saul_
 
 * 22 participants 
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20usability%20testing%20in%20PGH%20-%20June%202019)
 
-#### June 25 - 27, 2019: AX usability testing in Pittsburgh
+### June 25 - 27, 2019: AX usability testing in Pittsburgh
 
 _VA.gov CMS team: Meghana Khandekar, Ryan Sibley, Lapedra Tolson, Jane Newman, Rachel Kauff, Kate Saul_
 
 * 8 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/content/cms/authoring-experience/research/ax%20research%20-%20usability%20testing%20in%20PGH%20-%20June%202019)
 
-#### June 20-July 3: Appeals Higher Level Review Discovery Research 
+### June 20-July 3: Appeals Higher Level Review Discovery Research 
 *Appeals Team, Research Lead: Carola Ponce*
 - 20 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/decision-reviews/research/research-discovery.md)
 
-#### June 19-July 2: Urgent Care Usability Study (Under the Mission Act) 
+### June 19-July 2: Urgent Care Usability Study (Under the Mission Act) 
 *DSVA Design/Research, Research Lead: Kevin Hoffman*
 - 7 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/community-care/urgent-care/research/jun-2019)
 
-#### June 17-24: Education Product Health Dashboard MVP 
+### June 17-24: Education Product Health Dashboard MVP 
 *Platform Analytics & Insights Team, Research Lead: Layla Soileau*
 - 6 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/Platform/Teams/Analytics%20and%20Insights/Research/June%202019:%20Education%20Product%20Health%20Dashboard%20MVP)
 
-#### June 17 - 21: Exploration of Veterans Perspectives of their VA Health Data
+### June 17 - 21: Exploration of Veterans Perspectives of their VA Health Data
 *DSVA: Jane Newman*
 - 10 participants 
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/patient-portal/health-data)
 
-#### June 17-19: HCA Dashboard updates UAT 
+### June 17-19: HCA Dashboard updates UAT 
 *Dragons/Personalization: Samara Strauss*
 - 4 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/application)
 
-#### June 14-18: Usability Research VET TEC Course Comparison using the GIBCT, Round 2 
+### June 14-18: Usability Research VET TEC Course Comparison using the GIBCT, Round 2 
 *BAH Team, Research Lead: Amy Knox, Theresa McMurdo*
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/colmery-act-2019/research)
 
-#### June 10-23: Exploration of Veterans Perspectives of their VA Health Data - In-person & Remote
+### June 10-23: Exploration of Veterans Perspectives of their VA Health Data - In-person & Remote
 *VEO Team, Research Lead: Jane Newman*
 - 9 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/patient-portal/health-data)
 
-#### June 3-4: Usability Research VetTec Course Comparison using the GIBCT
+### June 3-4: Usability Research VetTec Course Comparison using the GIBCT
 *BAH Team, Research Lead: Amy Knox, Theresa McMurdo*
 - 5 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-comparison-tool/colmery-act-2019/research)
 
-### May 2019
+## May 2019
 
-#### May 20-24: HCA 2.0 User Acceptance Testing 
+### May 20-24: HCA 2.0 User Acceptance Testing 
 *Dragons Team, Research Lead: Samara Strauss*
 - 6 Participants
 - [Research Folder]()
 - [Research Plan]()
 
-#### May 20-24: Spanish language, Caregivers
+### May 20-24: Spanish language, Caregivers
 *Website Team, Research Leads: Jen Lee & Carola Ponce*
 - 6 participants
 - [Research Folder]()
 
-#### May 13-17: Spanish language, Veterans 
+### May 13-17: Spanish language, Veterans 
 *Website Team, Research Leads: Jen Lee & Carola Ponce*
 - 8 participants
 - [Research Folder]
 
 
-### April 2019
+## April 2019
 
-#### April 16 - May 10, 2019: Facility - Health services IA
+### April 16 - May 10, 2019: Facility - Health services IA
 
 _VA.gov CMS team: Meghana Khandekar, Kate Saul, Eric Chiu_
 
 * 17 participants via intercept testing, 255 participants for tree testing 
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20health%20services%20IA%20-%20May%202019)
 
-#### April 16-19: Dignified Burials Discovery
+### April 16-19: Dignified Burials Discovery
 *Team Special Forces, Research Lead: Zach Goldfine*
 - 6 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/dignified-burials/blob/master/Discovery)
 - [Research plan](https://github.com/department-of-veterans-affairs/dignified-burials/blob/master/Discovery/research_plan.md)
 
-#### April 10-12: GI Bill Comparison Tool Discovery/Usability 
+### April 10-12: GI Bill Comparison Tool Discovery/Usability 
 *BAH Team, Research Lead(s): Theresa McMurdo, Amy Knox*
 - 4 participants
 - [Research plan]
 
-#### April 10 – 15: HCA dashboard updates user testing
+### April 10 – 15: HCA dashboard updates user testing
 *Dragons, Research Lead(s): Samara Strauss*
 - 5 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/application/va-application/research/user-testing/dashboard-updates)
 
-### March 2019 
+## March 2019 
 
-#### March 27-29: Platform Research
+### March 27-29: Platform Research
 *Platypus team, Research Lead: Emily Waggoner*
 - 9 Participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/platform/documentation-site/research)
 
-#### March 25-29: 526 Usability 
+### March 25-29: 526 Usability 
 *Unicorns Team, Research Lead: Alex Taylor*
 - 6 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research)
 
-#### March 11 - 20: Sign In + Assistive Technology
+### March 11 - 20: Sign In + Assistive Technology
 *Griffins Identity team, Research Lead: Layla Soileau*
 - 7 participants
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/login)
 - [Results summary](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/login)
 
-#### March 6-12: HCA 2.0 Dupes Usability Testing 
+### March 6-12: HCA 2.0 Dupes Usability Testing 
 *DSVA: Samara Strauss*
 - 9 Participants 
 - Research Plan
 
-#### March 6-11: VetTec UAT Round 2 
+### March 6-11: VetTec UAT Round 2 
 *BAH Platform Team, Research Lead: Desiree Turner* 
 - 6 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/vettec-0994/research)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/application/vettec-0994/research/0994-research-plan-round-2-.md)
 
-#### March 5, 2019: AX Study 1
+### March 5, 2019: AX Study 1
 
 _VA.gov CMS team: Eileen Webb, Kevin Walsh_
 
 * 5 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/content/cms/authoring-experience/research/ax%20research%20-%20axstudy1%20-%20March%202019)
 
-#### March 5-15: VA.gov CMS: Office, User Research 1
+### March 5-15: VA.gov CMS: Office, User Research 1
 *VA.gov CMS team, Research Lead: Eric Chiu*
 - 5 to 7 participants (VSOs, journalists, Congressional staffers)
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/cms/office_formative_round_1)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/user-research/cms/office_formative_round_1/research%20plan.md)
 
-#### March 5-9: Health Care Application (HCA) 2.0 Dupes Usability
+### March 5-9: Health Care Application (HCA) 2.0 Dupes Usability
 *Dragons Team, Research Lead: Samara Strauss* 
 - 9 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/application)
 
-#### March 4-8: VetTec UAT (Rescheduled this for March) 
+### March 4-8: VetTec UAT (Rescheduled this for March) 
 *BAH Platform Team, Research Lead: Desiree Turner*
 - 1 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/application/vettec-0994/research)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/application/vettec-0994/research/0994-research-plan-round-2-.md)
 
-#### March 4-13, 2019: OPIA-Administration - discovery
+### March 4-13, 2019: OPIA-Administration - discovery
 
 _VA.gov CMS team: Eric Chiu_
 
 * 7 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/office-administration/offices/research/OPIA-Administration%20research%20-%20discovery%20-%20March%202019)
 
-#### February 27, 28, March 9-6: Vet Tec Usability Round 2
+### February 27, 28, March 9-6: Vet Tec Usability Round 2
 *Booz Allen: Amy Knox*
 - 6 Participants
 - Research Plan
 
-### February 2019
+## February 2019
 
-#### February 28, 2019: OPIA-Administration research - design studio
+### February 28, 2019: OPIA-Administration research - design studio
 
 _VA.gov CMS team: Jodi Leo_
 
 * 12 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/office-administration/offices/research/OPIA-Administration%20research%20-%20design%20studio%20-%20February%202019)
 
-#### February 20 - 27, 2019: Facility - usability testing - remote
+### February 20 - 27, 2019: Facility - usability testing - remote
 
 _VA.gov CMS team: Jodi Leo, Eric Chiu, Meghana Khandekar_
 
 * 10 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20usability%20testing%20remote%20-%20February%202019)
 
-#### February 1-25: 526 Modernization Add a New Condition
+### February 1-25: 526 Modernization Add a New Condition
 *Unicorns, Research Lead: Katelyn Caillouet & Alex Taylor*
 - 14 Veterans thus far
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/feb-2019)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/research/feb-2019/research-plan.md)
 
-#### February 19-22: Mission Act Community Care Sprint 
+### February 19-22: Mission Act Community Care Sprint 
 *Mission Act Community Care Sprint Team 2: Sheri Trivedi (OMB) and Lauryn Fantano (DDS)*
 - 5 Veterans
 - [Research Folder](https://github.com/usds/MISSION_Sprint/tree/master/user%20research)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/user-research/study-servicemembers/research-plan.md)
 
-#### February 19-21: VetTec Usability 
+### February 19-21: VetTec Usability 
 *Desiree Turner*
 - 6 participants
 
-#### February 8 - March 1, 2019: Facility - Facility IA
+### February 8 - March 1, 2019: Facility - Facility IA
 
 _CMS and Website Teams, Research Leads: Jeff Barnes & Mikki Northius_
 
 * 211 participants for tree testing the navigation (8-11 February), 348 participants for the close card sort for services listing (26 February - 1 March)
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20facility%20IA%20-%20February%202019)
 
-#### February 5-8: BAH VetTec Discovery 
+### February 5-8: BAH VetTec Discovery 
 *BAH Platform Team, Research Leads: Amy Knox & Theresa McMurdo*
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/application/vettec-0994/research)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/application/vettec-0994/research/0994-research-plan.md)
 
-### January 2019
+## January 2019
 
-#### January 28-February 1: Servicemember Research 
+### January 28-February 1: Servicemember Research 
 *Ad Hoc Website Team, Research Lead: Jeff Barnes*
 - 7 Servicemembers
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/content/audience-hubs/research/service-member)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/content/audience-hubs/research/service-member/research-plan.md)
 
-#### January 22-27: Family & Caregiver Audience Hub Tree Test 
+### January 22-27: Family & Caregiver Audience Hub Tree Test 
 *VA.gov Website Team, Research Lead: Jeff Barnes & Mikki Northius*
 - 184 Participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/Study-family-treetest)
 
-#### January 22-31: Appeals Status V3 
+### January 22-31: Appeals Status V3 
 *Appeals Team, Research Leads: Annie Nguyen & Allyce Husband* 
 - 9 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/appeals-status/v3)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/claim-appeal-status/appeals-status/v3/research-plan.md)
 
-#### January 14-18: Discovery Upload Tool 
+### January 14-18: Discovery Upload Tool 
 *API Team, Research Leads: Ian Hilton & Julia Elman* 
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/vets-contrib/blob/master/lighthouse/products/APIs/benefits-intake-api/research)
 - [Research Plan](https://github.com/department-of-veterans-affairs/vets-contrib/blob/master/lighthouse/products/APIs/benefits-intake-api/research/Digital_Mail_Upload_Form_Research_Plan.md)
 
-#### January 8-10, 2019: AX Discovery
+### January 8-10, 2019: AX Discovery
 
 _VA.gov CMS team: Megan Casey, Kevin Walsh_
 * 20 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/content/cms/authoring-experience/research/ax%20research%20-%20discovery%20-%20January%202019)
 
-#### January 8-10, 2019: Facility - Discovery
+### January 8-10, 2019: Facility - Discovery
 
 _VA.gov CMS team: C.M. Kennedy, Stephanie Lawrence_
 
 * 20 participants
 * [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/medical-centers/pittsburgh-pilot/research/Facility%20research%20-%20discovery%20-%20January%202019)
 
-### November 2018
+## November 2018
 
-#### November 13-15: Round 2 - Self-Service Tools CTAs
+### November 13-15: Round 2 - Self-Service Tools CTAs
 *Griffin, Research Lead: Layla Soileau*
 - 5 Veterans
 - Research Folder
 
-#### November 6-16: GI Bill Statement of Benefits Wizard
+### November 6-16: GI Bill Statement of Benefits Wizard
 *Rainbows, Research Lead: Katelyn Caillouet*
 - 6 Veterans completed
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/statement-of-benefits/research)
 - [Research Plan](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/statement-of-benefits/research/research-plan-110718.md)
 
-### October 2018
-#### October 22-26: Brand Consolidation Preview.VA.gov Remote Testing with VA-Veterans (WBC Study 8) 
+## October 2018
+### October 22-26: Brand Consolidation Preview.VA.gov Remote Testing with VA-Veterans (WBC Study 8) 
 *Team Hydra, Research Lead: Jeff Barnes*
 - 9 Veterans 
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/study-8) 
 
-#### October 15-16: Preview.VA.gov Mobile and Desktop in Durham, NC (WBC Study 7)
+### October 15-16: Preview.VA.gov Mobile and Desktop in Durham, NC (WBC Study 7)
 *Team Hydra, Research Lead: Jeff Barnes*
 - 18 participants, 7 mobile & 11 desktop
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/study-7)
 
-#### October 8-12: Health Care Application Duplicate Research 
+### October 8-12: Health Care Application Duplicate Research 
 *Not Affiliated With a Team, Research lead: Samara Strauss*
 - 7 Veterans who have submitted multiple applications for health care on Vets.gov 
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/application) 
 
-#### October 8-10: 526 Application 
+### October 8-10: 526 Application 
 *Unicorns Team, Research Lead: Alex Taylor*
 - 4 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/sep-oct-2018)
 
-### September 2018
+## September 2018
 
-#### September 17-21: Brand Consolidation - Preview.va.gov Remote Testing Non-VA Vets
+### September 17-21: Brand Consolidation - Preview.va.gov Remote Testing Non-VA Vets
 *Team Hydra | Research Lead: Jeff Barnes*
 - 8 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/study-6) 
 
-#### September 10 - 11: VA.gov MHV Login + SSO Contextual Messages
+### September 10 - 11: VA.gov MHV Login + SSO Contextual Messages
 *Griffins Team, Research Lead: Layla Soileau*
 - 7 Veterans
 - We talked to Veterans about logging in to VA.gov with MyHealtheVet, DS Logon, and ID.me. The participants evaluated the content and designs of various contextual messages and workflows that users may encounter when attempting to access various health tools.
 - Research Folder
 
-#### September 7-18: APIs - VA and USA Jobs 
+### September 7-18: APIs - VA and USA Jobs 
 *API Team, Research Lead: Julia Ellman*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/vets-contrib/tree/master/lighthouse/products/oauth/research)
 
-#### September 4-5: Benefits Recommendations 
+### September 4-5: Benefits Recommendations 
 *Dragons Team | Research Lead: Samara Strauss* 
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Personalization/Recommendations/Research/MVP%20Research)
 
-### August 2018
+## August 2018
 
-#### August 27-28: Brand Consolidation - Preview.va.gov Usability in Minneapolis
+### August 27-28: Brand Consolidation - Preview.va.gov Usability in Minneapolis
 *Team Hydra | Research Lead: Jeff Barnes*
 
 - 14 participants (8 desktop, 6 mobile)
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/study-5)
 
-#### August 21 – 27: Chalkmark test on "Find VA Benefits" page
+### August 21 – 27: Chalkmark test on "Find VA Benefits" page
 
 *Dragons Team | Research Lead: Samara Strauss*
 - 128 participants
 - [Reearch Folder](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Personalization/Recommendations/Research/MVP%20Research/Chalkmark%20Testing/Results%20Summary.md)
 
-#### August 15 - August 17: Veteran ID Card landing page - Content and design evaluation
+### August 15 - August 17: Veteran ID Card landing page - Content and design evaluation
 
 *Rainbows Team, Research Lead: Emily Waggoner*
 - 8 Veterans
 - We spoke to Veterans about their experiences with Veteran identification cards, and had them evaluate the content and design of the Veteran ID Card landing page.
 - [Research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/veteran-id-cards/landing-page): Includes plan, conversation guide, session notes, and summary
  
-#### August 2: Benefit Recommendations research at the Pentagon
+### August 2: Benefit Recommendations research at the Pentagon
 
 *Dragons Team | Research Lead: Samara Strauss*
 - 4 service members, 2 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Personalization/Recommendations/Research/MVP%20Research)
 - We spoke to 4 service members and 2 veterans about their perceptions and expectations around being asked "what benefits are you interested in?"
 
-#### August 1: Handbook Project - AbleVets Community Care Locator Alpha Phase Remote Usability Testing
+### August 1: Handbook Project - AbleVets Community Care Locator Alpha Phase Remote Usability Testing
 *AbleVets Handbook Team*
 - 5 Veterans
 - Research Folder
 
-### July 2018
+## July 2018
 
-#### July 14-16: Disability Claims (526), Self-Service Claims for Increase @ DAV Conference (Reno, NV)
+### July 14-16: Disability Claims (526), Self-Service Claims for Increase @ DAV Conference (Reno, NV)
 *Unicorns Team, research lead: Melissa Schaff*
 - 25 Veterans/VSOs/other stakeholders
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/jul-2018)
 - [Veteran Interviews/Notes](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/jul-2018/participant-notes)
 - [NSO Interviews/Notes](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/jul-2018/nso-notes)
 
-#### July 15-16: Colmery Act Usability Testing
+### July 15-16: Colmery Act Usability Testing
 *Rainbows Team, research lead: Emily Waggoner*
 - 7 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/opt-out/research)
 
-#### July 12-16: Brand Consolidation Tree Test 2
+### July 12-16: Brand Consolidation Tree Test 2
 *Merger Team, research lead: Jeff Barnes*
 - 596 Participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/study-4)
 
-#### July 12-16: Benefits Recommendations Discovery
+### July 12-16: Benefits Recommendations Discovery
 *Dragons Team, research lead: Samara Strauss*
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/vets.gov-team/tree/master/Products/Identity/Personalization/Recommendations/Research/MVP%20Research)
 
-### June 2018
+## June 2018
 
-#### June 26, 2018: Handbook Project - AbleVets Community Care Facility Locator Discovery
+### June 26, 2018: Handbook Project - AbleVets Community Care Facility Locator Discovery
 *AbleVets Handbook Team* 
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/community-care/urgent-care/research)
 
-#### Week of June 25: GI Bill Complaint Tool Discovery
+### Week of June 25: GI Bill Complaint Tool Discovery
 *Civic Digital Fellows Team + Rainbows Team, research lead: Natalie Moore & Mariam Maranja*
 - 3 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/school-feedback-tool/research)
 
-#### June 18 - 20: Brand Consolidation Navigation Tree Test
+### June 18 - 20: Brand Consolidation Navigation Tree Test
 *Merger Team, research lead: Jeff Barnes*
 - 715 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/user-research/study-4)
 
-#### Week of June 18: 686 Usability Research Round 2
+### Week of June 18: 686 Usability Research Round 2
 *Rainbows Team, research lead: Emily Waggoner* 
 - 4 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/declare-dependent/research/june-2018)
 
-#### June 4-8 - MHV Login Flows for ID.me
+### June 4-8 - MHV Login Flows for ID.me
 *Griffins Project, research lead: Liz Hunt*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/login/user-login/research) 
 
-### May 2018
+## May 2018
 
-#### May 2-11 - UAT on Personalization MVP
+### May 2-11 - UAT on Personalization MVP
 *Dragons Project, research leads Lauren Alexanderson + Mel Woodard*
 - 8 Veterans
 - Research Folder
 
-#### May 9-19 - Baseline Testing pre: Rebranding
+### May 9-19 - Baseline Testing pre: Rebranding
 *Merger Project, research lead: Mike Eng*
 - 4 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/research/merger/may-2018)
 
-#### mid-May 2018 - Accessibility Research
+### mid-May 2018 - Accessibility Research
 *Nebula Project, research lead: Elissa Frankle Olinsky*
 - 4 Veterans
 - Research Folder
 - [Link and Button Usability for Assistive Devices](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/accessibility/research/links-and-buttons.md)
 
-#### May 29-30, 2018 - Notifications Research
+### May 29-30, 2018 - Notifications Research
 *Rainbows Team, research lead: Samara Strauss*
 - 3 Veterans 
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/notifications)
 
-### April 2018
+## April 2018
 
-#### Week of 4/23 - 686 Usability Testing Round 1
+### Week of 4/23 - 686 Usability Testing Round 1
 *Rainbows Team, research leads: Judy Spiegel and Elissa Olinsky* 
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/declare-dependent/research/april-2018)
 
-#### April 17 - 25: Brand Consolidation Homepage Design User Research
+### April 17 - 25: Brand Consolidation Homepage Design User Research
 *Merger Team, research lead: Jeff Barnes*
 - 19 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/research/merger)
 
-#### April 10-20 - 526-Full Usability
+### April 10-20 - 526-Full Usability
 *Unicorns Project, research leads: Alex Taylor and Mike Eng*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/mar-2018)
 
-#### April 9-13 - Social Work and Suggestion Box usability
+### April 9-13 - Social Work and Suggestion Box usability
 *Nebula Project, research lead: Elissa Olinsky*
 - 4 Veterans
 - Research Folder
 
-#### April 5 - 20: Brand Consolidation "Other Resources" Card Sort
+### April 5 - 20: Brand Consolidation "Other Resources" Card Sort
 *Merger Team, research lead: Jeff Barnes*
 - 155 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/research/merger)
 
-#### April 5 - 20: Brand Consolidation Benefit Lifecycle Card Sort
+### April 5 - 20: Brand Consolidation Benefit Lifecycle Card Sort
 *Merger Team, research lead: Jeff Barnes*
 - 240 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/platform/research/merger)
 
-#### April 2-6 - Personalization MVP Usability
+### April 2-6 - Personalization MVP Usability
 *Dragons Project, research lead: Samara Strauss*
 - 5 Veterans
 - Research Folder
 
-### March 2018
+## March 2018
 
-#### Mar/Apr - MHV Upgrade
+### Mar/Apr - MHV Upgrade
 *Griffing Team, Research Lead: Mike Eng, moderated by Mike Eng*
 - 8 participants
 - Research Folder
 
-#### March 12-16 - Notifications Research
+### March 12-16 - Notifications Research
 *Dragons Team, Research Lead: Samara Strauss, moderated by Elissa Frankle Olinsky*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/identity-personalization/notifications)
 
-#### March 7-9 - VR&E Usability Research
+### March 7-9 - VR&E Usability Research
 *Rainbows Project, research leads: Mike Eng & Elissa Frankle Olinsky. This study was cut short due to stakeholder blocker issues.*
 - 4 Veterans
 - [VR & E research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/vocational-rehab/research)
 - [March 2018 notes](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/vocational-rehab/research/mar-2018)
 
-#### Personalization Card Sort (Mar 8-14)
+### Personalization Card Sort (Mar 8-14)
 *Dragons Project, research lead: Mel Woodard, synthesis by Elissa Olinsky*
 - 18 participants
 
-### January 2018
+## January 2018
 
-#### January 16-20 - Usability Testing Claims for Increase Prototype
+### January 16-20 - Usability Testing Claims for Increase Prototype
 *Unicorns Team, research leads: Mike Eng & Alex Taylor*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/jan-2018)
 
-#### January 9-22 - Education Benefits Information Architecture
+### January 9-22 - Education Benefits Information Architecture
 *Nebula Team, research lead: Mikki Northius & Elissa Olinsky*
 - Card Sort
 - 10 unmoderated participants, 3 moderated
 - Research Folder
 
-#### Veteran ID Card Discovery (Jan 2-12) & Usability (Jan 22-26)
+### Veteran ID Card Discovery (Jan 2-12) & Usability (Jan 22-26)
 *Rainbows Team, research lead: Lauren Alexanderson*
 - Discovery: 7 Veterans
 - Usability: 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/veteran-id-cards/research)
 
-#### Jan 16-20 - VR and E Research:
+### Jan 16-20 - VR and E Research:
 *Rainbows Team, research lead: Elissa Frankle Olinsky*
 - This round: 5 Veterans. 
 - [VR & E research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/vocational-rehab/research)
 - [Research Folder: January 2018](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/vocational-rehab/research/jan-2018)
 - (Note: This research has been a bit start-and-stop due to stakeholder blockers)
 
-### December 2017
+## December 2017
 
-#### December 6-21: Scheduling Accessibility/Usability Research
+### December 6-21: Scheduling Accessibility/Usability Research
 *Scheduling Sprint Team, research leads: Jeff Barnes & Lauren Alexanderson*
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/appointments/research/2017-studies/access-usability)
 
-#### Homepage Refresh Usability Research
+### Homepage Refresh Usability Research
 
 *Kudos Team, research lead: Paris Martin*
 
@@ -1334,28 +1334,28 @@ _VA.gov CMS team: C.M. Kennedy, Stephanie Lawrence_
 - [Research notes](https://www.optimalworkshop.com/a/adhoc/reframer/projects/11796/themes/55661)
 Majority synthesis done post-its
 
-### November 2017
+## November 2017
 
-#### Week of November 6, 2017: Discharge Upgrade Wizard
+### Week of November 6, 2017: Discharge Upgrade Wizard
 *Kudos Team, research lead: Natalie Moore*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/veteran-military-records/discharge-update)
 
-### October 2017
+## October 2017
 
-#### September 29-October 5: VR&E Research
+### September 29-October 5: VR&E Research
 *Rainbows Team, research lead: Elissa Frankle Olinsky*
 - 3 Veterans
 - [VR & E research folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/vocational-rehab/research)
 
-#### October 24-31: Scheduling Disoverability Research
+### October 24-31: Scheduling Disoverability Research
 *Scheduling Sprint Team, research lead: Lauren Alexanderson, moderated by Melissa Schaff*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/appointments/research/2017-studies/discoverability)
 
-### September 2017
+## September 2017
 
-#### September 29 - October 2: 526/Disability Compensation, VSOs
+### September 29 - October 2: 526/Disability Compensation, VSOs
 
 *Discovery Sprint: Unicorns Team, Research Lead: Melissa Schaff*
 
@@ -1365,25 +1365,25 @@ Majority synthesis done post-its
 - [Discovery Sprint Output](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/discovery/2017-vso/output)
 - [VSO Disability Claim Journey Map](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/discovery/2017-vso/output/journey-map)
 
-#### September 15-26: eBenefits Usability Claim for Increase
+### September 15-26: eBenefits Usability Claim for Increase
 
 *Unicorns Team, Research Lead: Laura Cochran*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research/sep-2017)
 
-#### September 9-14: Vets.gov Baseline Research
+### September 9-14: Vets.gov Baseline Research
 *Sitewide initiative, research lead: Elissa Frankle Olinsky* 
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/discovery/2017-vso/output/journey-map/vso-journey-disability-claim-11x17-10.20.17.pdf)
 
-### August 2017
+## August 2017
 
-#### Login Flow Improvements Rounds 1 (7/31-8/4) and 2 (8/28)
+### Login Flow Improvements Rounds 1 (7/31-8/4) and 2 (8/28)
 *Kudos Project, research lead:*Elissa Olinsky*
 - Round 1 - 5 Veterans
 - Round 2 - 5 Veterans
 
-#### August 17: 526/Disability Compensation, Veterans
+### August 17: 526/Disability Compensation, Veterans
 *Discovery Sprint: Unicorns Team, Research Lead: Melissa Schaff*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/discovery/2017-discovery-sprint)
@@ -1391,18 +1391,18 @@ Majority synthesis done post-its
 - [Discovery Sprint Output](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/discovery/2017-discovery-sprint/output)
 - [Veteran Disability Claim Journey Map](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/disability/526ez/discovery/2017-discovery-sprint/output/journey-map/veteran-journey-disability-claim-11x17-anonymous-9.4.17.pdf)
 
-### July 2017
+## July 2017
 
-#### July 5-7 - Letters
+### July 5-7 - Letters
 
 *Unicorns, Laura Cochran*
 
 - 4 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/veteran-military-records/documents-and-letters) 
 
-### June 2017
+## June 2017
 
-#### June 21-27 - Pre-Need
+### June 21-27 - Pre-Need
 *Kudos Team, Research Lead: Natalie Moore*
 - 4 Veterans 
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/burials-memorials/pre-need/discovery)
@@ -1412,108 +1412,108 @@ Majority synthesis done post-its
 - [Discovery brief](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/burials-memorials/pre-need/discovery/discoveryprojectbrief.md)
 - [Full notes participant one](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/burials-memorials/pre-need/discovery/user-research-session-1.md), [participant two](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/burials-memorials/pre-need/discovery/user-research-session-2.md), [participant three](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/burials-memorials/pre-need/discovery/user-research-session-3.md), [participant four](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/burials-memorials/pre-need/discovery/user-research-session-4.md)
 
-#### June 1-5 - Save in Progress
+### June 1-5 - Save in Progress
 - 4 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/global/sip-prefill/discovery)
 - Prototypes [Desktop](https://marvelapp.com/2hj59b1/screen/28358370), [Mobile](https://marvelapp.com/39bhc7f/screen/28363080)
 
-#### May 31-June 9 - Appeals Status Testing Round 3
+### May 31-June 9 - Appeals Status Testing Round 3
 *Research lead: Natalie Moore*
 - 6 Veterans
 - [Research Folder]()
 
 
-### May 2017
+## May 2017
 
-#### Late May - Pensions Formative Research
+### Late May - Pensions Formative Research
 *Rainbows Team, Research Lead: Alex Taylor*
 - 3 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/pension/research)
 
-#### May 17-24 - Usability Testing VA Letters
+### May 17-24 - Usability Testing VA Letters
 *Research Lead: Laura Cochran*
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/veteran-military-records/documents-and-letters)
 - Prototypes [Mockup](https://marvelapp.com/2jaea53/screen/29132668), test on staging
 
 
-#### May 15-18 - Rx Tracking and MHV Account Creation Usability
+### May 15-18 - Rx Tracking and MHV Account Creation Usability
 *Kudos Team, Research Lead: Natalie Moore*
 - 5 Veterans
 - Research Folder
 
-#### May 10-12 - GI Bill Enrollment Status
+### May 10-12 - GI Bill Enrollment Status
 *Unicorns Team, Research Lead: Laura Cochran*
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/statement-of-benefits/research)
 
-#### May - Appeals Usability Testing Round 2
+### May - Appeals Usability Testing Round 2
 *Research lead: Natalie Moore*
 - 2 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/appeals-status)
 
 
-### April 2017
+## April 2017
 
-#### April 27-May 2 - 5495 and 1990N Education Usability Testing
+### April 27-May 2 - 5495 and 1990N Education Usability Testing
 *Research Lead: Alex Taylor*
 - 3 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/1990n)
 
-#### April 19 - Appeals Usability Testing Round 1
+### April 19 - Appeals Usability Testing Round 1
 *Research lead: Natalie Moore*
 - 3 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/appeals-status)
 
-#### April 18 - My HealtheVet Account Creation Usability
+### April 18 - My HealtheVet Account Creation Usability
 *Research Lead: Natalie Moore*
 - 3 Veterans
 - Research Folder
 
-#### April 4-5 - Site Baseline (in-person)
+### April 4-5 - Site Baseline (in-person)
 
-### March 2017
+## March 2017
 
-#### March 31-April 7 - e-Benefits Testing
+### March 31-April 7 - e-Benefits Testing
 
-#### March 21-23 - Top Nav Treejack Test
+### March 21-23 - Top Nav Treejack Test
 *Research Lead: Mikki Northius*
 - 41 participants
 
 
-#### March 15 - Education 1990E Form + 5490 Form
+### March 15 - Education 1990E Form + 5490 Form
 *Research Lead: Alex Taylor*
 - 4 Veterans (or 4 Veterans each for 1990E and 5490?) 
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/1990e)
 
-#### March 7-8 - Facility Locator Usability Research
+### March 7-8 - Facility Locator Usability Research
 *Research Leads: Em Tav & Natalie Moore*
 - 5 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research-archive)
 
-#### March 2-10 - Site Baseline
+### March 2-10 - Site Baseline
 *Research Leads: Mary Ann Brody, Mikki Northuis, Laura Elena*
 - March 10 - BVA Baseline
 
-### February 2017
+## February 2017
 
-#### February 16-17 - Facility locator & Blue Button
+### February 16-17 - Facility locator & Blue Button
 *Research Leads: Natalie Moore and Sophia Dengo*
 - 5-6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research)
 
-### January 2017
+## January 2017
 
-#### Week of January 23 - Form 22-1995 (Education) Research
+### Week of January 23 - Form 22-1995 (Education) Research
 *Research Lead: Alex Taylor* 
 - 3 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/1995) 
 
-#### January 18-25 - Navigation & information architecture
+### January 18-25 - Navigation & information architecture
 *Research Lead: Mary Ann Broday, Mikki Northuis*
 - 6 Veterans
 - [Prototype link](http://y5gyfw.axshare.com/#p=home&g=1)
 
-#### January 12-13 - GI Bill Comparison Tool and Blue Button
+### January 12-13 - GI Bill Comparison Tool and Blue Button
 *Education Research: Sophia Dengo*
 - 5 Veterans
 - Prototype links
@@ -1521,182 +1521,182 @@ Majority synthesis done post-its
 - [GIBCT Mobile prototype](https://marvelapp.com/114cc83)
 - [Blue Button prototype](https://marvelapp.com/1j51h93)
 
-#### Health consent
+### Health consent
 - Prototype links
 - [Option one](https://marvelapp.com/4ieh29e/)
 - [Option two](https://marvelapp.com/4i63hi9/)
 
 
-### Missing projects here, need to fill in gaps
+## Missing projects here, need to fill in gaps
 
-### December 2016
+## December 2016
 
-#### Week of December 16? - Education Family of Forms Research
+### Week of December 16? - Education Family of Forms Research
 *Research Leads: Caitlin Weber & Mark Olson*
 - 6 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/family-of-forms)
 
-### November 2016
+## November 2016
 
-#### Week of November 7 - Vets.gov launch week
+### Week of November 7 - Vets.gov launch week
 - How can we best help with last-minute pre-launch work?
 
-### October 2016
+## October 2016
 
-#### Week of October 31
+### Week of October 31
 - Quick Question research session
 - Laura out at Code for America Summit
 
-#### October 27-28 - Prescription refill & secure messaging
+### October 27-28 - Prescription refill & secure messaging
 - 4 participants
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/secure-messaging/research)
 
-#### October 20-21 - Claims status and logon usability
+### October 20-21 - Claims status and logon usability
 - [Conversation Guide](https://github.com/department-of-veterans-affairs/sunsets-team/blob/master/track-claim-status/design-documents/research/usability-testing_10-20-2016.md)
 - [Summary findings](https://github.com/department-of-veterans-affairs/sunsets-team/blob/master/track-claim-status/design-documents/research/FeedbackSummary_10-21-16.md)
 - [Claims status prototype](https://marvelapp.com/1e48351) and [logon prototype](https://marvelapp.com/2g4f4b4)
 
-#### October 13-14 - Facility Finder & Logon
+### October 13-14 - Facility Finder & Logon
 - [Conversation Guide](https://github.com/department-of-veterans-affairs/vets.gov-research/blob/master/Projects/FacilityFinder-Login_10-13-2016/ConversationGuide-10-13-2016.md)
 - [Summary findings](https://github.com/department-of-veterans-affairs/vets.gov-research/blob/master/Projects/FacilityFinder-Login_10-13-2016/FacilityLocator-Login-SummaryFindings.md)
 
-#### October 6-7
+### October 6-7
 - [Quick Question](https://github.com/department-of-veterans-affairs/vets.gov-research/blob/master/quick_question_research.md) research session
 - Teams: [please submit questions here](https://github.com/department-of-veterans-affairs/vets.gov-research/issues/11)
 
-### September 2016
+## September 2016
 
-#### September 28-30: Facility Locator
+### September 28-30: Facility Locator
 *Research Lead: Natalie Moore?*
 - 4 Veterans
 - Branding/ navigation
 - [Conversation Guide](https://github.com/department-of-veterans-affairs/vets.gov-research/blob/master/Projects/Branding/Navigation%2C%20IA%2C%20Facility%20Locator_09.29.2016.md)
 - [Summary Findings 1](https://github.com/department-of-veterans-affairs/vets.gov-research/blob/master/Projects/Branding/Nav-FacilityFinder-SummaryFindings.md) and [Summary Findings 2](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/facilities/facility-locator/research-archive) 
 
-#### September 21-27 - Education 1990 Usability Test
+### September 21-27 - Education 1990 Usability Test
 *Research Lead: Alex Taylor?*
 - 4 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/1990)
 - [First wireframes](https://app.moqups.com/greg@adhocteam.us/l32hJ36b/view/page/ad9695a23), second prototype run locally.
 - [Summary results](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/education-careers/application/1990/discovery/key-findings-9-28-16.md)
 
-#### September 9-16 - Claims Status usability testing
+### September 9-16 - Claims Status usability testing
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/claim-appeal-status/claims-status)
 - [Prototype: Vets.gov Claims Status](https://marvelapp.com/2cch4ch/screen/15005515)
 - [Prototype: eBenefits Claims Status](https://marvelapp.com/2cf16da/screen/15034382)
 
 
-### August 2016
+## August 2016
 
-#### August 31 to Sept. 2 - Branding Research
+### August 31 to Sept. 2 - Branding Research
 *Research staff: Mary Ann, Mollie Ruskin, Emily Wright-Moore*
 - Participants: 5
 - Location: DC, in-person
 
-#### August 23-24 - Blind Veterans & Accessibility
+### August 23-24 - Blind Veterans & Accessibility
 *Research staff: Mary Ann & Courtney*
 - Participants: 10 encounters (conference)
 - Location: Milwaukee
 
-#### August 22-24 - Secure Messaging Discovery
+### August 22-24 - Secure Messaging Discovery
 *Research staff: Gina, Angel*
 - Participants: 3
 - Observation/ formative research with test account
 - Potentially talk to clinicians, MHV coordinators
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/secure-messaging/discovery)
 
-#### August 15-19 – 1990 Education Benefits Discovery
+### August 15-19 – 1990 Education Benefits Discovery
 *Research staff: Caitlin, Alex, Laura*
 - Participants: ~3 Vets, 2 VCEs
 - [Research Foldert](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/application/1990/discovery)
 
-#### August 3-26 - Information Architecture Tree Testing
+### August 3-26 - Information Architecture Tree Testing
 *Research staff: Mary Ann, Laura, Mariana*
 - Participants: ~30-50
 
-### July 2016
+## July 2016
 
-#### July 28-29 - Disability Benefits
+### July 28-29 - Disability Benefits
 - Research staff: Mary Ann & Laura
 - Participants: 5
 - Location: remote
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/disability/526ez/research)
 
-#### July 8 - Rx Refills Research II
+### July 8 - Rx Refills Research II
 *Research staff: Gina, Mary Ann, Laura*
 - Participants: 5
 - Location: Remote
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/prescription-refills/research/2016)
 
-### June 2016
+## June 2016
 
-#### June 23 - Rx Refills Research
+### June 23 - Rx Refills Research
 *Research staff: Gina, Alex Y-L (east coast) -- Laura, Angel, Mariana (west coast)*
 - Participants: 6 to 12
 - Location: In person
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/prescription-refills/research/2016)
 - Notes from research: Intercepts were challenging, and DC crew was stopped by facility staff for recording and taking photos.
 
-### May 2016
+## May 2016
 
-#### May 25-27 - Rx Refills
+### May 25-27 - Rx Refills
 *Research staff: Gina*
 - Participants: 2
 - Location: Remote
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/prescription-refills/research/2016)
 
 
-#### May 25 - HCA Usability testing
+### May 25 - HCA Usability testing
 *Research staff: Courtney and Gina*
 - Participants: 6 to 12
 - Location: Remote?
 
-#### May 12 and 13 - Vets.gov page template usability testing
+### May 12 and 13 - Vets.gov page template usability testing
 *Research staff: Mary Ann + (Gina?)*
 - Participants: 5
 - Location: remote
 - Link to prototype:https://marvelapp.com/1g53gge 
 
-### April 2016
+## April 2016
 
-#### 4/28, GIBCT Ratings Prototype
+### 4/28, GIBCT Ratings Prototype
 Sessions: 4
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/research)
 
-#### 4/21, Rx Discovery research
+### 4/21, Rx Discovery research
 Sessions: 5
 
-#### 4/8, New homepage prototype and Explore VA
+### 4/8, New homepage prototype and Explore VA
 Sessions: 5
 
-### March 2016
+## March 2016
 
-#### 3/24 - Healthcare Application
+### 3/24 - Healthcare Application
 *Research Lead: Mary Ann Brody and Em Tav*
 - Sessions: 3 Veterans
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/application)
 
-### February 2016
+## February 2016
 
-#### 2/29, San Francisco Card Sorting
+### 2/29, San Francisco Card Sorting
 Sessions: 6
 
-### January 2016
+## January 2016
 
-#### 1/21, Seattle Homeless Shelter Cardsorting
+### 1/21, Seattle Homeless Shelter Cardsorting
 Usability Sessions: 6
 Informal Sessions: 1 (Johannes)
 
-### December 2015
+## December 2015
 
-#### 12/15, GIBCT Usability Testing / Cognitive Walkthrough
+### 12/15, GIBCT Usability Testing / Cognitive Walkthrough
 *Research Lead: Mary Ann Brody*
 - Usability Sessions: 2
 - Informal Sessions: 1
 - [Research Folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/education-careers/research)
 
-### November 2015
+## November 2015
 
-#### 11/21 to 12/21
+### 11/21 to 12/21
 Usability Sessions: 3
 Informal: 4


### PR DESCRIPTION
Fixed skipped headings defect by bumping up `h3`s and `h4`s by one. This will make the research history document easier to scan for screen reader users in the future 🙏