### PR TITLE
Lighthouse openapi_spec.yaml feedback revisions

### DIFF
--- a/products/va-event-stream/engineering/openapi_spec.yaml
+++ b/products/va-event-stream/engineering/openapi_spec.yaml
@@ -44,7 +44,7 @@ paths:
                     icn: 1008709396V637156
       responses:
         202:
-          description: Accepted. The event has been written to the stream but is not immediately available for retrieval.
+          description: Accepted. The event has been written to the stream but may not be immediately available for retrieval.
           content:
             application/json:
               schema:

--- a/products/va-event-stream/engineering/openapi_spec.yaml
+++ b/products/va-event-stream/engineering/openapi_spec.yaml
@@ -43,8 +43,8 @@ paths:
                   user:
                     icn: 1008709396V637156
       responses:
-        201:
-          description: Created
+        202:
+          description: Accepted. The event has been written to the stream but is not immediately available for retrieval.
           content:
             application/json:
               schema:
@@ -56,25 +56,25 @@ paths:
               schema:
                 $ref: "#/components/schemas/Errors"
         401:
-          description: Token is missing or is invalid.
+          description: Unauthorized. Token is missing or is invalid.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Errors"
         403:
-          description: Token is valid, but does not have proper authorization.
+          description: Forbidden. Token is valid, but does not have proper authorization.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Errors"
         429:
-          description: Rate limit exceeded.
+          description: Too many requests. Rate limit exceeded.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Errors"
         500:
-          description: An internal API error occured.
+          description: Internal server error. An unexpected API error occured.
           content:
             application/json:
               schema:

--- a/products/va-event-stream/engineering/openapi_spec.yaml
+++ b/products/va-event-stream/engineering/openapi_spec.yaml
@@ -7,10 +7,12 @@ servers:
 paths:
   /v0/events:
     post:
-      description: Receives VA system published data change events that may interest a veteran.
-      The system then places events on a stream where one or more consumers filter and process them.
-      Should an event pass a consumer's rules it will trigger an action or notification.
-      Notifications may include mobile push notifications, text messages, emails, or in-browser messages.
+      description: 
+        Receives VA system published data change events that may interest a veteran. 
+        The system then places events on a stream where one or more consumers filter 
+        and process them. Should an event pass a consumer's rules it will trigger an 
+        action or notification. Notifications may include mobile push notifications, 
+        text messages, emails, or in-browser messages.
       security:
         - Bearer: [ ]
       requestBody:
@@ -47,14 +49,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventResponse"
-        401:
-          description: Authentication is possible but has failed or not yet been provided.
+        400:
+          description: Bad Request. One or more validation errors have occurred.
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/Errors"
-        400:
-          description: Bad Request. One or more validation errors have occurred.
+        401:
+          description: Token is missing or is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+        403:
+          description: Token is valid, but does not have proper authorization.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Errors"
+        429:
+          description: Rate limit exceeded.
           content:
             application/json:
               schema:
@@ -68,6 +82,11 @@ paths:
 
 
 components:
+  securitySchemes:
+    Bearer:            
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     EventRequest:
       required:
@@ -78,8 +97,9 @@ components:
       properties:
         eventType:
           type: string
-          description: A constant name for a repeatable event from the source system. Naming convention follows 'contants' in C style languages; 
-          uppercase with underscores for spaces.
+          description: 
+            A constant name for a repeatable event from the source system. 
+            Naming convention follows 'constants' in C style languages; uppercase with underscores for spaces.
           example: NEW_MESSAGE
         payload:
           type: object
@@ -93,8 +113,9 @@ components:
           example: MHV_SECURE_MESSAGING
         user:
           type: object
-          description: A JSON object of user traits that will be used by consumers to identify users or retrieve additional user data.
-          Currently only MPI's ICN is supported.
+          description: 
+            A JSON object of user traits that will be used by consumers to identify users or retrieve additional user data.
+            Currently only MPI's ICN is supported.
           properties:
             icn:
               type: string

--- a/products/va-event-stream/engineering/openapi_spec.yaml
+++ b/products/va-event-stream/engineering/openapi_spec.yaml
@@ -84,10 +84,12 @@ paths:
 components:
   securitySchemes:
     Bearer:            
-      type: apiKey
+      type: oauth2
       name: Authorization
       in: header
       description: Pass the token in the 'Authorization' Header in the format 'Bearer {token}'. e.g. 'Bearer abcdefg1234567'.
+      authorizationUrl: https://api.va.gov/oauth2/event-stream/v0/authorization
+      tokenUrl: https://api.va.gov/oauth2/event-stream/v0/token
   schemas:
     EventRequest:
       required:

--- a/products/va-event-stream/engineering/openapi_spec.yaml
+++ b/products/va-event-stream/engineering/openapi_spec.yaml
@@ -84,9 +84,10 @@ paths:
 components:
   securitySchemes:
     Bearer:            
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+      type: apiKey
+      name: Authorization
+      in: header
+      description: Pass the token in the 'Authorization' Header in the format 'Bearer {token}'. e.g. 'Bearer abcdefg1234567'.
   schemas:
     EventRequest:
       required:


### PR DESCRIPTION
Updates to openapi_spec.yaml based on the feedback from the Lighthouse team.

- Fixes some swagger parsing errors for multi-line text. 
- Changes the success response to 202 from 201.
- Updates 401 and 403 response descriptions.
- Adds a 429 error response for when the rate limit is exceeded.
- `Bearer` security definition defined in components.