### PR TITLE
Include links in offboarding doc for quicker access

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboarding-request.md
+++ b/.github/ISSUE_TEMPLATE/offboarding-request.md
@@ -31,20 +31,20 @@ Please provide the following information about the individual being offboarded:
   > ex: SOCKS, Pagerduty, Google analytics, etc.
  
  
-## AC
+## Acceptance Criteria
 *Performed by Platform team*
- - [ ] Remove from [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=0)
- - [ ] Remove global/config.yml / SOCKS Access removed (if applicable)
-   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to create a PR to update the `global/config.yml` file and remove the public SSH key. You'll need the user's email address associated with their public key.
- - [ ] AWS Access removed  (if applicable)
-   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to remove user's entry from DSVA AWS. You'll need the user's AWS user name (typically FIRST_NAME.LAST_NAME).
- - [ ] DSVA Slack (if applicable)
+ - [ ] DSVA Slack (if applicable. Search for them in Slack)
    > A comment on this ticket prefixed with `/request` (i.e. `/request FirstName LastName`) will send a message to the Slack admins automatically!
- - [ ] User removed from the VA GitHub Org
-   > Fill out request found [here](https://github.com/department-of-veterans-affairs/github-user-requests/issues/new?assignees=&labels=remove-user&template=user-remove.yml&title=Remove+User+from+Org%3A+%5Busername%5D).
- - [ ] Pagerduty access removed (if applicable) 
- - [ ] Datadog account disabled (if applicable)
- - [ ] Sentry access removed (if applicable)
+ - [ ] Remove from [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=0) (if applicable)
+ - [ ] Remove from global/config.yml / SOCKS Access removed (if applicable. Search their email in [config.yml](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/global/config.yml))
+   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to create a PR to update the `global/config.yml` file and remove the public SSH key. You'll need the user's email address associated with their public key.
+ - [ ] AWS Access removed  (if applicable. Search their name in [AWS IAM](https://console.amazonaws-us-gov.com/iamv2/home#/home))
+   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to remove user's entry from DSVA AWS. You'll need the user's AWS user name (typically FIRST_NAME.LAST_NAME).
+ - [ ] User removed from the VA GitHub Org (if applicable. Check [department-of-veterans-affairs/people](https://github.com/orgs/department-of-veterans-affairs/people))
+   > Fill out request found [here](https://github.com/department-of-veterans-affairs/github-support/issues/new?assignees=&labels=remove-user&template=user-remove.yml&title=Remove+User+from+Org%3A+%5Busername%5D). 
+ - [ ] Pagerduty access removed (if applicable. Check [pd users](https://dsva.pagerduty.com/users-new))
+ - [ ] Datadog account disabled (if applicable. Check [Datadog users](https://app.datadoghq.com/organization-settings/users))
+ - [ ] Sentry access removed (if applicable. Check [Sentry members](http://sentry.vfs.va.gov/settings/vsp/members/))
  - [ ] Google analytics, and Domo access removed (if applicable) 
  - [ ] Bot user GitHub account(s) YubiKey(s) removed
    > Typically only applies to Operations team members
@@ -52,5 +52,5 @@ Please provide the following information about the individual being offboarded:
    > Refers to the `va-bot`, `va-vfs-bot`, and `va-vsp-bot` users
    
    > Documentation for this process can be found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/1908932642/Remove+YubiKeys+of+Offboarded+Operations+Team+Members)
- 
+
  CC: @department-of-veterans-affairs/vsp-operations ,  @department-of-veterans-affairs/vsp-analytics-insights

--- a/.github/ISSUE_TEMPLATE/offboarding-request.md
+++ b/.github/ISSUE_TEMPLATE/offboarding-request.md
@@ -32,7 +32,7 @@ Please provide the following information about the individual being offboarded:
  
  
 ## Acceptance Criteria
-*Performed by Platform team*
+*Performed by Platform team. Detailed instructions found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/2097545323/Offboard+Team+Member)*
  - [ ] DSVA Slack (if applicable. Search for them in Slack)
    > A comment on this ticket prefixed with `/request` (i.e. `/request FirstName LastName`) will send a message to the Slack admins automatically!
  - [ ] Remove from [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=0) (if applicable)


### PR DESCRIPTION
I was writing up a page in Confluence that documented this offboarding process. But I figured I would add direct links to this page so we're able to search for the person faster during offboarding. The Confluence page will be more of a, "I've never done this before and need some handholding." or "I've been on vacation too long and forget how to do this" kinda document that goes into more detail. Now that I think about it, maybe I should add a link to that page in this markdown file. Thoughts? *edit: I added a link* 😄 

I also moved the DSVA Slack ☑️ to the top of the to-dos.

**This is what the page will look like:**
https://github.com/department-of-veterans-affairs/va.gov-team/blob/offboarding_updates2/.github/ISSUE_TEMPLATE/offboarding-request.md