### PR TITLE
Add unfurl options

### DIFF
--- a/.github/workflows/slackRemovalRequest.yml
+++ b/.github/workflows/slackRemovalRequest.yml
@@ -30,3 +30,5 @@ jobs:
           slack-channel: vsp-slack-user-management
           slack-text: Hello! Please remove ${{ steps.request.outputs.command-arguments }} from DSVA Slack based on issue URL ${{ github.event.issue.html_url }} 
           slack-optional-icon_emoji: ":wave:"
+          slack-optional-unfurl_links: "false"
+          slack-optional-unfurl_media: "false"


### PR DESCRIPTION
This PR might fix 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/29659

I don't think this is going to work... The [docs say](https://api.slack.com/methods/chat.postMessage#formatting), "By default links to media are unfurled, but links to text content are not" and I consider a github issue to be "text" not "media". But worth a try???? 

I could merge this into my fork and test it out there, or merge into master and test it out live. Open to suggestions. 