### PR TITLE
Slack user removal request: Change icon to 🤖 

### DIFF
--- a/.github/workflows/slackRemovalRequest.yml
+++ b/.github/workflows/slackRemovalRequest.yml
@@ -29,6 +29,7 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: vsp-slack-user-management
           slack-text: Hello! Please remove ${{ steps.request.outputs.command-arguments }} from DSVA Slack based on issue URL ${{ github.event.issue.html_url }} 
-          slack-optional-icon_emoji: ":wave:"
+          slack-optional-as_user: "false"
+          slack-optional-icon_emoji: ":robot_face:"
           slack-optional-unfurl_links: "false"
           slack-optional-unfurl_media: "false"


### PR DESCRIPTION
Instead of the Slack icon seen here:
![image](https://user-images.githubusercontent.com/10993987/160864153-6c147901-81da-4e80-8359-556e0fb3e940.png)
This PR will change it to a 🤖 .  I asked Cory Trimm for his emoji opinion and he voted for the robot face. 

According to the [icon_emoji docs](https://api.slack.com/methods/chat.postMessage#arg_icon_emoji), we needed to explicitly set `as_user` to false (even though it defaults to false), so that's why the 👋  hadn't been showing up.