### PR TITLE
Remove deprecated field

### DIFF
--- a/.github/workflows/slackRemovalRequest.yml
+++ b/.github/workflows/slackRemovalRequest.yml
@@ -29,7 +29,6 @@ jobs:
           slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
           slack-channel: vsp-slack-user-management
           slack-text: Hello! Please remove ${{ steps.request.outputs.command-arguments }} from DSVA Slack based on issue URL ${{ github.event.issue.html_url }} 
-          slack-optional-as_user: "false"
           slack-optional-icon_emoji: ":robot_face:"
           slack-optional-unfurl_links: "false"
           slack-optional-unfurl_media: "false"


### PR DESCRIPTION
The changes I made in https://github.com/department-of-veterans-affairs/va.gov-team/pull/39355 broke the `/request` action because `as_user` is apparently deprecated. 
Failed job: https://github.com/department-of-veterans-affairs/va.gov-team/runs/5757128975?check_suite_focus=true
It might be related to the version that we're on, but not really worth investigating, since it's a change no one is asking for 😅 

(From quick googling, it seems like `icon-emoji` should work by itself, without `as_user`, so I'll leave the emoji field since it's not hurting anything and might work sometime in the future.)