### PR TITLE
Chore: Update infra/ops issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/ops_issue_template.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 ## Who is the devops resource on your team?
-_Please use their github username, if applicable (optional, please if unused)_
+_Please use their github username, if applicable (optional, please delete if unused)_
 
 @github-name
 

--- a/.github/ISSUE_TEMPLATE/ops_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/ops_issue_template.md
@@ -6,6 +6,10 @@ labels: devops, needs-grooming, operations
 assignees: ''
 
 ---
+## Who is the devops resource on your team?
+_Please use their github username, if applicable (optional, please if unused)_
+
+@github-name
 
 ## Description
 _What details are necessary for understanding the specific work or request tracked by this issue?_


### PR DESCRIPTION
## Description

It was brought up in retro that we may want to include in our issue template who their dedicated devops resource is.

In an effort to enable devops within other teams and meet the vision of cross functional teams, this PR is asking teams to provide devops resource github handle for the following reasons:

- See what resources devops person is missing to enable them (first step)
- Devops resource entered to follow along with the ticket 
  - If it is out of their scope/domain, it would be a good learning opportunity if similar requests arises in the future