### PR TITLE
Access request updates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -66,6 +66,18 @@ body:
       placeholder: e.g. Platform Security, Backend Engineer, Ad Hoc
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Your Product Manager (PM)
+      description: Provide the name and email of your Product Manager
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Your Product Owner (PO)
+      description: Provide the name and email of your Product Owner
+    validations:
+      required: true
   - type: textarea
     id: aws-access
     attributes:

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -84,7 +84,17 @@ body:
     attributes:
       value: |
         ---
+        All done! 
         For SOCKS access, open a [SOCKS Access Request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2Coperations%2Cops-access-request&template=socks-access-request.yml&title=SOCKS+access+for+%5Bindividual%5D).
         If you need additional infrastructure, please open a separate [Ops request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=operations%2C+devops%2C+needs-grooming&template=ops_issue_template.md&title=) to create that infrastructure.
-
-        CC: @department-of-veterans-affairs/vsp-operations , @department-of-veterans-affairs/operations-aws-approvers.
+        :x: Don't fill out anything below here :x:
+  - type: checkboxes
+    attributes:
+      label: User must exist in a roster before AWS access can be granted
+      description: Don't fill this part out, please
+      options:
+      - label: "Search for user on the VFS Team Roster: https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665"
+      - label: "Or search for user on the Platform Team Roster: https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster"
+      - label: "If user is on a VFS team but not in the VFS Team Roster, add the 'NOT YET' label and instruct them to start the Platform orientation process https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html"
+      - label: "If a user is on a Platform team but not on the Platform Team Roster in Confluence, add the 'NOT YET' label and instruct them to reach out to their Product Manager to be added."
+      - label: "Comment in this issue saying which roster the user is listed in."

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -6,11 +6,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        1. Change the **Title** to include your name
-        2. Add the label used by your team (eg: `BAH-526`)
-        3. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
-        4. Add additional info as a comment after GitHub issue is created if you select 'Other' for any of the form inputs.
-        5. When the issue is closed you will be notified and can continue with on-boarding setup
+        :wave: **_Instructions_**
+        1. Before being granted access, you will need to either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        2. Change the **Title** to include your name
+        3. Add the label used by your team (eg: `BAH-526`)
+        4. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
+        5. Add additional info as a comment after GitHub issue is created if you select 'Other' for any of the form inputs.
+        6. When the issue is closed you will be notified and can continue with on-boarding setup
   - type: dropdown
     id: cor-name
     attributes:
@@ -68,13 +70,13 @@ body:
       required: true
   - type: input
     attributes:
-      label: Your Product Manager (PM)
+      label: Product Manager (PM) name and email
       description: Provide the name and email of your Product Manager
     validations:
       required: true
   - type: input
     attributes:
-      label: Your Product Owner (PO)
+      label: Product Owner (PO) name and email
       description: Provide the name and email of your Product Owner
     validations:
       required: true
@@ -96,7 +98,7 @@ body:
     attributes:
       value: |
         ---
-        All done! 
+        :heavy_minus_sign::heavy_minus_sign::heavy_minus_sign::heavy_minus_sign: All done! :heavy_minus_sign::heavy_minus_sign::heavy_minus_sign::heavy_minus_sign:
         For SOCKS access, open a [SOCKS Access Request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2Coperations%2Cops-access-request&template=socks-access-request.yml&title=SOCKS+access+for+%5Bindividual%5D).
         If you need additional infrastructure, please open a separate [Ops request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=operations%2C+devops%2C+needs-grooming&template=ops_issue_template.md&title=) to create that infrastructure.
         :x: Don't fill out anything below here :x:

--- a/.github/ISSUE_TEMPLATE/socks-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/socks-access-request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       value: |
         :wave: **_Instructions_**
-        1. Before being granted access, you will need to have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and either be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665) or the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)
+        1. Before being granted access, you will need to either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
         2. Change the **Title** to include your name
         3. Add the label used by your team (eg: `BAH-526`)
         4. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
@@ -38,13 +38,13 @@ body:
       required: true
   - type: input
     attributes:
-      label: Your Product Manager (PM)
+      label: Product Manager (PM) name and email
       description: Provide the name and email of your Product Manager
     validations:
       required: true
   - type: input
     attributes:
-      label: Your Product Owner (PO)
+      label: Product Owner (PO) name and email
       description: Provide the name and email of your Product Owner
     validations:
       required: true
@@ -60,7 +60,7 @@ body:
     attributes:
       value: |
         ---
-        All done!
+        :heavy_minus_sign::heavy_minus_sign::heavy_minus_sign::heavy_minus_sign: All done! :heavy_minus_sign::heavy_minus_sign::heavy_minus_sign::heavy_minus_sign:
         For AWS access, open an [AWS Access Request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2Coperations%2Cops-access-request&template=aws-access-request.yml&title=AWS+access+for+%5Bindividual%5D).
         :x: Don't fill out anything below here :x:
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/socks-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/socks-access-request.yml
@@ -6,10 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        1. Change the **Title** to include your name
-        2. Add the label used by your team (eg: `BAH-526`)
-        3. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
-        4. When the issue is closed you will be notified and can continue with on-boarding setup
+        :wave: **_Instructions_**
+        1. Before being granted access, you will need to have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and either be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665) or the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)
+        2. Change the **Title** to include your name
+        3. Add the label used by your team (eg: `BAH-526`)
+        4. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
+        5. When the issue is closed you will be notified and can continue with on-boarding setup
   - type: input
     id: requestor-name
     attributes:
@@ -29,9 +31,9 @@ body:
   - type: input
     id: role
     attributes:
-      label: Your Role
-      description: Please provide your role on your team
-      placeholder: e.g. Backend Engineer
+      label: Your Role and Team
+      description: Please provide your role and your team name
+      placeholder: e.g. Backend Engineer on VA Mobile
     validations:
       required: true
   - type: textarea
@@ -46,7 +48,16 @@ body:
     attributes:
       value: |
         ---
+        All done!
         For AWS access, open an [AWS Access Request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2Coperations%2Cops-access-request&template=aws-access-request.yml&title=AWS+access+for+%5Bindividual%5D).
-        If you need additional infrastructure, please open a separate [Ops request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=operations%2C+devops%2C+needs-grooming&template=ops_issue_template.md&title=) to create that infrastructure.
-
-        CC: @department-of-veterans-affairs/vsp-operations
+        :x: Don't fill out anything below here :x:
+  - type: checkboxes
+    attributes:
+      label: User must exist in a roster before SOCKS access can be granted
+      description: Don't fill this part out, please
+      options:
+      - label: "Search for user on the VFS Team Roster: https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665"
+      - label: "Or search for user on the Platform Team Roster: https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster"
+      - label: "If user is on a VFS team but not in the VFS Team Roster, add the 'NOT YET' label and instruct them to start the Platform orientation process https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html"
+      - label: "If a user is on a Platform team but not on the Platform Team Roster in Confluence, add the 'NOT YET' label and instruct them to reach out to their Product Manager to be added."
+      - label: "Comment in this issue saying which roster the user is listed in."

--- a/.github/ISSUE_TEMPLATE/socks-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/socks-access-request.yml
@@ -36,6 +36,18 @@ body:
       placeholder: e.g. Backend Engineer on VA Mobile
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Your Product Manager (PM)
+      description: Provide the name and email of your Product Manager
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Your Product Owner (PO)
+      description: Provide the name and email of your Product Owner
+    validations:
+      required: true
   - type: textarea
     id: ssh-key
     attributes:


### PR DESCRIPTION
This PR will take care of two issues.
1. https://github.com/department-of-veterans-affairs/va.gov-team/issues/40654: Require PM and PO names and emails to easier track a user. This can be useful during offboarding (or if we think a person has left the org and needs to be offboarded and we need to reach out to a manager). 
2. #40655: Add links to the Platform and VFS rosters so we can easily check them for the name of the person requesting access. This is a new requirement. See Slack thread linked in issue for more info. 

### Testing
See what these would look like on my branch.
AWS access request:
https://github.com/department-of-veterans-affairs/va.gov-team/blob/br_40655_rt/.github/ISSUE_TEMPLATE/aws-access-request.yml
SOCKS access request:
https://github.com/department-of-veterans-affairs/va.gov-team/blob/br_40655_rt/.github/ISSUE_TEMPLATE/socks-access-request.yml