### PR TITLE
Adding CODEOWNERS file to help protect .github/workflows/ directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Ensure added automation gets scrutiny from platform engineering leadership
+.github/workflows/*     @department-of-veterans-affairs/platform-leadership-engineering

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,3 @@
+# Github Actions
+
+This directory is used for running [Github Actions](https://docs.github.com/en/actions) on the `va.gov-team` repository. Anyone may contribute or modify these workflows and they will be reviewed by [Platform Engineering Leadership](https://github.com/orgs/department-of-veterans-affairs/teams/platform-leadership-engineering).


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file with protection for the `.github/workflows` directory.

NOTE: I made a change to the va.gov-team repository and added the `@department-of-veterans-affairs/platform-leadership-engineering` team to that repo with `write` permissions. This is needed for this `CODEOWNERS` file to be legal and accepted.
