### PR TITLE
Update pst-amt-sock-kickoff.yml

### DIFF
--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -4,7 +4,7 @@ on:
     types:
       - opened
 env:
-  ISSUE_ID: ${{ github.event.issue.id }}
+  ISSUE_ID: ${{ github.event.number }}
   # ISSUE_ID: 42533
 
 jobs:


### PR DESCRIPTION
github.event.issue.id is apparently an internal UUID/ID and not the number associated with the issue for some reason. Trying to get it a different way.