### PR TITLE
AWS Access Request Template Refinement

### DIFF
--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -90,7 +90,7 @@ body:
     id: expiration-date
     attributes:
       label: Access Expiration
-      description: The requested access will be revoked at the start of this date. Enter a date (and time if applicable) or 'ongoing' for non-expiring access. If ongoing is selected, add a comment to this request after filing to justify the ongoing access.
+      description: The requested access will be revoked at the start of this date. Enter a date (and time if applicable) or 'ongoing' for non-expiring access. If ongoing is selected, add a justification for this to the 'Additional Notes' field.
       placeholder: timestamp
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -98,7 +98,7 @@ body:
     id: additional-notes
     attributes:
       label: Additional Notes
-      description: Use this section to add notes, such as justification for the access request, COR information when 'Other' was selected, etc.
+      description: Use this section to add notes, such as justification for the access request, COR/VOR information when 'Other' was selected, etc.
       placeholder: I need this access because of <reason>
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -25,7 +25,7 @@ body:
         - Doris Lin
         - Vilay Senthep
         - Eunice Garcia
-        - Other
+        - Other - please specify in 'Additional Notes'
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -7,9 +7,9 @@ body:
     attributes:
       value: |
         :wave: **_Instructions_**
-        1. Before being granted access, you will need to either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
-        2. Change the **Title** to include your name
-        3. Add the label used by your team (eg: `BAH-526`)
+        1. Before being granted access, the principal for whom access is requested (the 'target principal') must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        2. Change the **Title** to include target principal
+        3. Add the label used by the target principal's team (eg: `BAH-526`)
         4. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
         5. Add additional info as a comment after GitHub issue is created if you select 'Other' for any of the form inputs.
         6. When the issue is closed you will be notified and can continue with on-boarding setup
@@ -17,7 +17,7 @@ body:
     id: cor-name
     attributes:
       label: COR Name
-      description: Your Contracting Officer's Representative (COR) name.
+      description: The name of Contracting Officer's Representative (COR) covering the target principal
       options:
         - Cecila Lee
         - Courtney Bethea
@@ -32,7 +32,7 @@ body:
     id: vendor
     attributes:
       label: Vendor Onboarding Representative Name
-      description: This is the person from the contracting company responsible for your onboarding process.
+      description: This is the person from the contracting company responsible for the onboarding process of the target principal.
       options:
         - Oddball - Amber Malcolm
         - Insignia - Kimberly S. Cole
@@ -41,14 +41,14 @@ body:
         - Magnum Opus - Paula G. Mendoza
         - Liberty IT -  Michael G. Lovejoy
         - Accenture Federal Services - Alexa Elliot
-        - Other
+        - Other - please specify in comment after filing if known
     validations:
       required: true
   - type: input
     id: requestor-name
     attributes:
       label: Your Name
-      description: Please provide your name
+      description: Please provide the name of the target principal
       placeholder: e.g. Jane Doe
     validations:
       required: true
@@ -56,41 +56,41 @@ body:
     id: email
     attributes:
       label: Your Email
-      description: Please provide your work email
+      description: Please provide the work email for the target principal
       placeholder: e.g. jane.doe@company.com
     validations:
       required: true
   - type: input
     id: team-name
     attributes:
-      label: Your Team, Role, and Company
-      description: Please provide the name of your team, your role on that team, and the name of the company you work for
+      label: Team, Role, and Company of the target principal
+      description: Please provide the name of the team, their role on that team, and the name of the company the target principal works for
       placeholder: e.g. Platform Security, Backend Engineer, Ad Hoc
     validations:
       required: true
   - type: input
     attributes:
       label: Product Manager (PM) name and email
-      description: Provide the name and email of your Product Manager
+      description: Provide the name and email of the Product Manager working with the target principal
     validations:
       required: true
   - type: input
     attributes:
       label: Product Owner (PO) name and email
-      description: Provide the name and email of your Product Owner
+      description: Provide the name and email of the Product Owner for the target principal
     validations:
       required: true
   - type: textarea
     id: aws-access
     attributes:
       label: Desired AWS Access
-      description: Please list which resources (bucket names, parameter store paths, EC2 instance name, etc.) would you like to access. Also list what type of access will you need (read, read-write, etc.). If there is a teammate whose permissions you'd like to copy, please list their name.
-      placeholder: I need access to S3 to read uploaded files from the /tools-team/uploads bucket.
+      description: Please list which resources (bucket names, parameter store paths, EC2 instance name, etc.) would you like to access and why you need this access. Also list what type of access will you need (read, read-write, etc.). If there is a teammate whose permissions should be copied, please list their name.
+      placeholder: I need access to S3 to read uploaded files from the /tools-team/uploads bucket because <reason>.
   - type: input
     id: expiration-date
     attributes:
       label: Access Expiration
-      description: The requested access will be revoked at the start of this date. Enter a date (and time if applicable) or 'ongoing' for non-expiring access.
+      description: The requested access will be revoked at the start of this date. Enter a date (and time if applicable) or 'ongoing' for non-expiring access. If ongoing is selected, add a comment to this request after filing to justify the ongoing access.
       placeholder: timestamp
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -7,9 +7,9 @@ body:
     attributes:
       value: |
         :wave: **_Instructions_**
-        1. Before being granted access, the principal for whom access is requested (the 'target principal') must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
-        2. Change the **Title** to include target principal
-        3. Add the label used by the target principal's team (eg: `BAH-526`)
+        1. Before being granted access, the individual for whom access is requested (the 'target individual') must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        2. Change the **Title** to include target individual
+        3. Add the label used by the target individual's team (eg: `BAH-526`)
         4. Do not remove `operations` label or the `ops-access-request` label; this will notify the VSP Operations team of your request
         5. Add additional info as a comment after GitHub issue is created if you select 'Other' for any of the form inputs.
         6. When the issue is closed you will be notified and can continue with on-boarding setup
@@ -17,7 +17,7 @@ body:
     id: cor-name
     attributes:
       label: COR Name
-      description: The name of the Contracting Officer's Representative (COR) covering the target principal.
+      description: The name of the Contracting Officer's Representative (COR) covering the target individual.
       options:
         - Cecila Lee
         - Courtney Bethea
@@ -32,7 +32,7 @@ body:
     id: vendor
     attributes:
       label: Vendor Onboarding Representative Name
-      description: This is the person from the contracting company responsible for the onboarding process of the target principal.
+      description: This is the person from the contracting company responsible for the onboarding process of the target individual.
       options:
         - Oddball - Amber Malcolm
         - Insignia - Kimberly S. Cole
@@ -48,7 +48,7 @@ body:
     id: requestor-name
     attributes:
       label: Your Name
-      description: Please provide the name of the target principal
+      description: Please provide the name of the target individual
       placeholder: Jane Doe
     validations:
       required: true
@@ -56,28 +56,28 @@ body:
     id: email
     attributes:
       label: Your Email
-      description: Please provide the work email for the target principal
+      description: Please provide the work email for the target individual
       placeholder: jane.doe@company.com
     validations:
       required: true
   - type: input
     id: team-name
     attributes:
-      label: Team, Role, and Company of the target principal
-      description: Please provide the name of the team, their role on that team, and the name of the company the target principal works for
+      label: Team, Role, and Company of the target individual
+      description: Please provide the name of the team, their role on that team, and the name of the company the target individual works for
       placeholder: Team Moose, Antler Development, Alces LLC
     validations:
       required: true
   - type: input
     attributes:
       label: Product Manager (PM) name and email
-      description: Provide the name and email of the Product Manager working with the target principal
+      description: Provide the name and email of the Product Manager working with the target individual
     validations:
       required: true
   - type: input
     attributes:
       label: Product Owner (PO) name and email
-      description: Provide the name and email of the Product Owner for the target principal
+      description: Provide the name and email of the Product Owner for the target individual
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -17,7 +17,7 @@ body:
     id: cor-name
     attributes:
       label: COR Name
-      description: The name of Contracting Officer's Representative (COR) covering the target principal
+      description: The name of the Contracting Officer's Representative (COR) covering the target principal.
       options:
         - Cecila Lee
         - Courtney Bethea
@@ -49,7 +49,7 @@ body:
     attributes:
       label: Your Name
       description: Please provide the name of the target principal
-      placeholder: e.g. Jane Doe
+      placeholder: Jane Doe
     validations:
       required: true
   - type: input
@@ -57,7 +57,7 @@ body:
     attributes:
       label: Your Email
       description: Please provide the work email for the target principal
-      placeholder: e.g. jane.doe@company.com
+      placeholder: jane.doe@company.com
     validations:
       required: true
   - type: input
@@ -65,7 +65,7 @@ body:
     attributes:
       label: Team, Role, and Company of the target principal
       description: Please provide the name of the team, their role on that team, and the name of the company the target principal works for
-      placeholder: e.g. Platform Security, Backend Engineer, Ad Hoc
+      placeholder: Team Moose, Antler Development, Alces LLC
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -41,7 +41,7 @@ body:
         - Magnum Opus - Paula G. Mendoza
         - Liberty IT -  Michael G. Lovejoy
         - Accenture Federal Services - Alexa Elliot
-        - Other - please specify in comment after filing if known
+        - Other - please specify in 'Additional Notes'
     validations:
       required: true
   - type: input
@@ -84,8 +84,8 @@ body:
     id: aws-access
     attributes:
       label: Desired AWS Access
-      description: Please list which resources (bucket names, parameter store paths, EC2 instance name, etc.) would you like to access and why you need this access. Also list what type of access will you need (read, read-write, etc.). If there is a teammate whose permissions should be copied, please list their name.
-      placeholder: I need access to S3 to read uploaded files from the /tools-team/uploads bucket because <reason>.
+      description: Please list which resources (bucket names, parameter store paths, EC2 instance name, etc.) and which type of access is requested. Explicitly list which type(s) of access are needed for which resources and keep these scopes as small/tight as possible. If there is a teammate whose permissions should be copied, please list their name.
+      placeholder: I need access to S3 to read uploaded files from the /tools-team/uploads bucket.
   - type: input
     id: expiration-date
     attributes:
@@ -94,6 +94,12 @@ body:
       placeholder: timestamp
     validations:
       required: true
+  - type: textarea
+    id: additional-notes
+    attributes:
+      label: Additional Notes
+      description: Use this section to add notes, such as justification for the access request, COR information when 'Other' was selected, etc.
+      placeholder: I need this access because of <reason>
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
This PR updates the AWS Access Request issue template. The wording was ambiguous and not totally clear in requesting information about the target principal (i.e. the principal for whom access is being requested). Third party filers can be mistaken in thinking that the requested information is about them (i.e. the filer) and not the target principal.
This PR addresses this confusion by making it clear that the requested information should cover the target principal.

This PR also adds an extra field '`additional-notes`' with instructions to use this to specify a VOR that is not listed in the dropdown, as well as to use this to justify the requested access.