### PR TITLE
Update column name for documentation project board

### DIFF
--- a/.github/workflows/assign-to-one-project.yml
+++ b/.github/workflows/assign-to-one-project.yml
@@ -30,7 +30,7 @@ jobs:
         contains(github.event.issue.labels.*.name, 'documentation-support')
       with:
         project: 'https://github.com/department-of-veterans-affairs/va.gov-team/projects/16'
-        column_name: 'New'
+        column_name: 'New - Incoming'
     - name: Add issues with `platform-architecture-working-group` label to Platform Architecture Working Group project
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: |


### PR DESCRIPTION
The column name for this project board is no longer "New" it is now "New - Incoming".

The project is: https://github.com/department-of-veterans-affairs/va.gov-team/projects/16