### PR TITLE
Update templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/kubernetes-onboarding-template.md
+++ b/.github/ISSUE_TEMPLATE/kubernetes-onboarding-template.md
@@ -68,13 +68,15 @@ _Requesting team; Infrastructure Team can assist_
 - [ ] **Automation to push the app's container to ECR with a semantic version number** | [Example](https://github.com/department-of-veterans-affairs/vsp-infra-calico/blob/main/.github/workflows/mirror-images.yaml)    
 Note: Don't use default "latest" tag. The release system uses modified container image tags to synchronize automation. 
 _Requesting team; Infrastructure Team can assist_  
-- [ ] **Kubernetes manifest in YAML, Jsonnet, or Helm Chart** in `vsp-infra-application-manifests` | [Example](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/tree/main/apps) | [Docs](https://argo-cd.readthedocs.io/en/stable/)  
-Note: must be compatible with ArgoCD  
+- [ ] **Kubernetes manifest using Helm charts** in `vsp-infra-application-manifests` | [Example](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/tree/main/apps/vsp-amt/grafana) | [Argo CD Docs](https://argo-cd.readthedocs.io/en/stable/)  
+Note: Manifests _can_ be specified in several formats, however, we are standardizing around [Helm charts](https://helm.sh/docs/topics/charts/).  
 _Requesting team; Infrastructure Team can assist_  
 - [ ] **Kubernetes detect and update application** in `vsp-infra-applications-manifests` | [Environments](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/tree/main/apps/vsp-operations/argocd-apps)  
 _Requesting team; Infrastructure Team can assist_  
 - [ ] **Automation to update the Kubernetes manifest** when a new version of the app's container is pushed to ECR | [Example](https://github.com/department-of-veterans-affairs/vsp-infra-calico/blob/main/.github/workflows/update-manifests.yaml)  
 _Requesting team; Infrastructure Team can assist_
+- [ ] **Argo CD project permissions defined** Add project (or include appropriate namespaces and clusters to existing project) https://github.com/department-of-veterans-affairs/vsp-infra-argocd/tree/main/chart/templates
+_Infrastructure Team_
 
 ### Application secrets and parameters
 - [ ] **AWS SSM Parameter Store path created for your team or app,** ie `/dsva-vagov/team-name/` | [Request here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=operations%2C+devops%2C+needs-grooming&template=ops_issue_template.md&title=)  

--- a/.github/ISSUE_TEMPLATE/offboarding-request.md
+++ b/.github/ISSUE_TEMPLATE/offboarding-request.md
@@ -33,9 +33,9 @@ Please provide the following information about the individual being offboarded:
  
 ## Acceptance Criteria
 *Performed by Platform team. Detailed instructions found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/2097545323/Offboard+Team+Member)*
- - [ ] DSVA Slack (if applicable. Search for them in Slack)
+ - [ ] Requested removal from DSVA Slack (if applicable. Search for them in Slack)
    > A comment on this ticket prefixed with `/request` (i.e. `/request FirstName LastName`) will send a message to the Slack admins automatically!
- - [ ] Remove from Confluence (if applicable. Check [confluence members](https://vfs.atlassian.net/wiki/people/search?q=))
+ - [ ] Requested removal from Confluence (if applicable. Check [confluence members](https://vfs.atlassian.net/wiki/people/search?q=))
  - [ ] Remove from [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=0) (if applicable)
  - [ ] Remove from global/config.yml / SOCKS Access removed (if applicable. Search their email in [config.yml](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/global/config.yml))
    > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to create a PR to update the `global/config.yml` file and remove the public SSH key. You'll need the user's email address associated with their public key.
@@ -46,12 +46,10 @@ Please provide the following information about the individual being offboarded:
  - [ ] Pagerduty access removed (if applicable. Check [pd users](https://dsva.pagerduty.com/users-new))
  - [ ] Datadog account disabled (if applicable. Check [Datadog users](https://vagov.ddog-gov.com/organization-settings/users))
  - [ ] Sentry access removed (if applicable. Check [Sentry members](http://sentry.vfs.va.gov/settings/vsp/members/))
- - [ ] Google analytics, and Domo access removed (if applicable) 
+ - [ ] Requested removal from Google analytics and Domo by checking that the `analytics-insights` label is on this Issue. 
  - [ ] Bot user GitHub account(s) YubiKey(s) removed
-   > Typically only applies to Operations team members
-   
-   > Refers to the `va-bot`, `va-vfs-bot`, and `va-vsp-bot` users
-   
-   > Documentation for this process can be found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/1908932642/Remove+YubiKeys+of+Offboarded+Operations+Team+Members)
+   > Typically only applies to Infrastructure team members.  
+   > Refers to the `va-bot`, `va-vfs-bot`, and `va-vsp-bot` users.  
+   > Documentation for this process can be found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/1908932642/Remove+YubiKeys+of+Offboarded+Operations+Team+Members).
 
  CC: @department-of-veterans-affairs/vsp-operations ,  @department-of-veterans-affairs/platform-analytics-insights-team , @department-of-veterans-affairs/confluence-admins


### PR DESCRIPTION
**Kubernetes template:**
I had these changes on an old branch and figured I'd include them in this PR!

**Offboarding template:**
The offboarding request is currently owned by the Infrastructure team, but not all items are the responsibility of the Infra team. Changing the wording makes it so the Infra team can check off items ✅ after _requesting_ removal. This means that the ticket can be closed after Infra is done, but remaining offboarding tasks might be required by other teams. 

Fixes the problem brought up in https://github.com/department-of-veterans-affairs/va.gov-team/issues/40919