### PR TITLE
Chore: Add stale label to infrastructure issue

### DIFF
--- a/.github/workflows/infra-stale-issues.yml
+++ b/.github/workflows/infra-stale-issues.yml
@@ -1,0 +1,32 @@
+name: Infrastructure stale issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "us-gov-west-1"
+
+      - name: Obtain GitHub Token
+        uses: marvinpinto/action-inject-ssm-secrets@latest
+        with:
+          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+
+      - name: Checks for stale pr
+        uses: actions/stale@v6
+        with:
+          repo-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          days-before-issue-stale: 90
+          days-before-issue-close: -1
+          any-of-issue-labels: devops, operations
+          stale-issue-label: stale
+          stale-issue-message: This issue is stale. If it is no longer valid, please close issue. Otherwise please update


### PR DESCRIPTION
### Description

This PR addresses the following:

- Adds a stale label to issues older than 90 days
  - Checks at the start of every day or can manually trigger workflow
- If a issues gets commented then it will not get marked as stale

### Relations

https://github.com/department-of-veterans-affairs/va.gov-team/issues/46436

