### PR TITLE
Chore: Grab vsp-bot token

### DIFF
--- a/.github/workflows/infra-stale-issues.yml
+++ b/.github/workflows/infra-stale-issues.yml
@@ -8,23 +8,10 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: "us-gov-west-1"
-
-      - name: Obtain GitHub Token
-        uses: marvinpinto/action-inject-ssm-secrets@latest
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
-
       - name: Checks for stale pr
         uses: actions/stale@v6
         with:
-          repo-token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
+          repo-token: ${{ secrets.VA_VSP_BOT_GITHUB_TOKEN }}
           days-before-issue-stale: 90
           days-before-issue-close: -1
           any-of-issue-labels: devops, operations


### PR DESCRIPTION
## Description

Looks like AWS secrets not in repo. That being said, va-vsp-token are. Calling them directly rather than providing AWS secrets and pulling from param store

https://github.com/department-of-veterans-affairs/va.gov-team/issues/46436
