### PR TITLE
Change Domo and GA in Offboarding Issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboarding-request.md
+++ b/.github/ISSUE_TEMPLATE/offboarding-request.md
@@ -31,29 +31,25 @@ Please provide the following information about the individual being offboarded:
   > 
 - additional access they may have: _(First line formatted with access titles only. Additional notes may be added on second line after the list.)_
   > ex: SOCKS, Pagerduty, Google analytics, etc.
-  
-  > Notes, etc...
  
  
 ## Acceptance Criteria
-*Performed by Platform team. Detailed instructions found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/2097545323/Offboard+Team+Member)*
+*The following steps are performed by the Platform Support team. Detailed instructions found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/2097545323/Offboard+Team+Member)*
  - [ ] Requested removal from DSVA Slack (if applicable. Search for them in Slack)
    > A comment on this ticket prefixed with `/request` (i.e. `/request FirstName LastName`) will send a message to the Slack admins automatically!
  - [ ] Requested removal from Confluence (if applicable. Check [confluence members](https://vfs.atlassian.net/wiki/people/search?q=))
  - [ ] Remove from [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=0) (if applicable)
  - [ ] Remove from global/config.yml / SOCKS Access removed (if applicable. Search their email in [config.yml](https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/global/config.yml))
-   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to create a PR to update the `global/config.yml` file and remove the public SSH key. You'll need the user's email address associated with their public key.
+   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to create a PR to update the `global/config.yml` file and remove the public SSH key. You'll need the user's email address associated with their public key (found in `config.yml`).
  - [ ] AWS Access removed  (if applicable. Search their name in [AWS IAM](https://console.amazonaws-us-gov.com/iamv2/home#/home))
-   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to remove user's entry from DSVA AWS. You'll need the user's AWS user name (typically FIRST_NAME.LAST_NAME).
+   > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to remove user's entry from DSVA AWS. You'll need the user's AWS username (typically `First.Last`).
  - [ ] User removed from the VA GitHub Org (if applicable. Check [department-of-veterans-affairs/people](https://github.com/orgs/department-of-veterans-affairs/people))
    > Fill out request found [here](https://github.com/department-of-veterans-affairs/github-user-requests/issues/new?assignees=&labels=remove-user&template=user-remove.yml&title=Remove+User+from+Org%3A+%5Busername%5D). 
  - [ ] Pagerduty access removed (if applicable. Check [pd users](https://dsva.pagerduty.com/users-new))
  - [ ] Datadog account disabled (if applicable. Check [Datadog users](https://vagov.ddog-gov.com/organization-settings/users))
  - [ ] Sentry access removed (if applicable. Check [Sentry members](http://sentry.vfs.va.gov/settings/vsp/members/))
- - [ ] Requested removal from Google analytics and Domo by checking that the `analytics-insights` label is on this Issue. 
- - [ ] Bot user GitHub account(s) YubiKey(s) removed
-   > Typically only applies to Infrastructure team members.  
-   > Refers to the `va-bot`, `va-vfs-bot`, and `va-vsp-bot` users.  
-   > Documentation for this process can be found [here](https://vfs.atlassian.net/wiki/spaces/OT/pages/1908932642/Remove+YubiKeys+of+Offboarded+Operations+Team+Members).
+ - [ ] Google analytics and Domo access removed (if applicable. Make sure the `analytics-insights` label is on this Issue)
+ - [ ] Bot (`va-bot`, `va-vfs-bot`, and `va-vsp-bot`) user GitHub account(s) YubiKey(s) removed
+   > This is rare. See [documentation](https://vfs.atlassian.net/wiki/spaces/OT/pages/1908932642/Remove+YubiKeys+of+Offboarded+Operations+Team+Members) for current users and removal process.
 
  CC: @department-of-veterans-affairs/vsp-operations ,  @department-of-veterans-affairs/platform-analytics-insights-team , @department-of-veterans-affairs/confluence-admins


### PR DESCRIPTION
Don't close the Offboarding issue until Google Analytics and Domo access has been checked by Analytics and Insights team. I talked to Michelle Dooley on the Analytics and Insights team and their team only looks in the "New" column for offboarding requests. If Support closes a request before they get to it, the issue moves out of the "New" column and the offboarding request is effectively lost to them. 

We (infrastructure/support) had hoped that we could just make sure the analytics and insights label was on the issue and then move on, but we'll need to keep the issue open until someone from Analytics and Insights checks for access.

Here is the markdown-rendered document on my branch for your viewing pleasure:
https://github.com/department-of-veterans-affairs/va.gov-team/blob/update_offboarding/.github/ISSUE_TEMPLATE/offboarding-request.md

[Rich diff](https://github.com/department-of-veterans-affairs/va.gov-team/commit/72d35c0897c2770df5720ee0ee1bc611baf9b001?short_path=ee4316a#diff-ee4316a1ba4a1c4c3d3ff678fa703ed8731da8033565578103490d9a740c1d21)