### PR TITLE
update references to platform-release-tools to va-platform-cop-frontend

### DIFF
--- a/platform/engineering/codeowners.md
+++ b/platform/engineering/codeowners.md
@@ -17,12 +17,12 @@ This document covers how code owners are used to enforce required reviews. The i
 
 VSP uses GitHub's [code owners](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) feature to trigger required reviews. A code owner is a GitHub [team](https://help.github.com/en/github/setting-up-and-managing-organizations-and-teams/about-teams) that must approve a change before it can be merged.
 
-By default, [`platform-release-tools`](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools) is the code owner of `vets-website` and [`backend-review-group`](https://github.com/orgs/department-of-veterans-affairs/teams/backend-review-group) is the code owner of `vets-api`.
+By default, [`va-platform-cop-frontend`](https://github.com/orgs/department-of-veterans-affairs/teams/va-platform-cop-frontend) is the code owner of `vets-website` and [`backend-review-group`](https://github.com/orgs/department-of-veterans-affairs/teams/backend-review-group) is the code owner of `vets-api`.
 
 ## Other Code Owners
 VSA and VFS teams can optionally [create a GitHub team](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/vsp_user_managment_process.md#creating-a-github-team) under the [Department of Veteran Affairs GitHub organization](https://github.com/orgs/department-of-veterans-affairs/teams) by clicking on the **New team** button. This must be done for the team to become a code owner.
 
-In `vets-website`, a team can be assigned as a code owner of [application folders](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/applications). **This will remove `platform-release-tools` as a required reviewer when changes are made to those folders.** Follow the conventions in the [`CODEOWNERS` configuration file](https://github.com/department-of-veterans-affairs/vets-website/blob/master/.github/CODEOWNERS) to assign your team to an application folder.
+In `vets-website`, a team can be assigned as a code owner of [application folders](https://github.com/department-of-veterans-affairs/vets-website/tree/master/src/applications). **This will remove `va-platform-cop-frontend` as a required reviewer when changes are made to those folders.** Follow the conventions in the [`CODEOWNERS` configuration file](https://github.com/department-of-veterans-affairs/vets-website/blob/master/.github/CODEOWNERS) to assign your team to an application folder.
 
 In `vets-api`, a team can be assigned as a code owner of [module folders](https://github.com/department-of-veterans-affairs/vets-api/tree/master/modules). **This will remove `backend-review-group` as a required reviewer when changes are made to those folders.** Follow the conventions in the [`CODEOWNERS` configuration file](https://github.com/department-of-veterans-affairs/vets-api/blob/master/.github/CODEOWNERS) to assign your team to an application folder.
 

--- a/platform/engineering/content-security-policy.md
+++ b/platform/engineering/content-security-policy.md
@@ -32,7 +32,7 @@ _Reports are throttled by the reverse proxy by setting the `report-url` in the C
 
 The following applies when editing the CSP: 
 
-- Updates to the CSP **must be approved** by the [platform release tools team](https://github.com/orgs/department-of-veterans-affairs/teams/platform-release-tools)
+- Updates to the CSP **must be approved** by the [platform release tools team](https://github.com/orgs/department-of-veterans-affairs/teams/va-platform-cop-frontend)
 - Updates to the CSP must be tested on staging before releasing into production 
   - The only way to test the CSP is to add it to an environment and monitor the logger for violations 
 - Updates to the CSP must be in pull requests without other changes to enable easy rollback 

--- a/platform/engineering/frontend/eslint/adding-new-rules.md
+++ b/platform/engineering/frontend/eslint/adding-new-rules.md
@@ -72,7 +72,7 @@ All rules under review will always be considered to become enforced. However, ba
 
 ## Feedback
 
-VFS are encouraged to provide feedback from any rule that is under review. To do so, please use the tag `@platform-release-tools` or message any of the release tools team members in Slack and provide us with your feedback.
+VFS are encouraged to provide feedback from any rule that is under review. To do so, please use the tag `@va-platform-cop-frontend` or message any of the release tools team members in Slack and provide us with your feedback.
 
 ## Revision History
 

--- a/platform/engineering/frontend/eslint/new-rule-release-notes.md
+++ b/platform/engineering/frontend/eslint/new-rule-release-notes.md
@@ -29,7 +29,7 @@ Sprint 26 & 27 - May 14, 2020
   - no-collapsible-if
   - prefer-immediate-return
 - These rules will be under review for 4 weeks (Sprint 26 & 27) and enforced starting Sprint 28
-- Feedback from VFS teams will be collected during this period. Please use the tag `@platform-release-tools` or message any of the front-end tools team members in Slack and provide us with your feedback.
+- Feedback from VFS teams will be collected during this period. Please use the tag `@va-platform-cop-frontend` or message any of the front-end tools team members in Slack and provide us with your feedback.
 - Other ESLint rules that will be added:
   - va/use-resolved-path
   - react/prefer-stateless-function
@@ -62,7 +62,7 @@ Sprint 23 & 24 - April 2, 2020
   - no-small-switch
   - no-unused-collection
 - These rules will be under review for 4 weeks (Sprint 23 & 24) and enforced starting Sprint 25
-- Feedback from VFS teams will be collected during this period. Please use the tag `@platform-release-tools` or message any of the release tools team members in Slack and provide us with your feedback.
+- Feedback from VFS teams will be collected during this period. Please use the tag `@va-platform-cop-frontend` or message any of the release tools team members in Slack and provide us with your feedback.
 
 ## SonarJS deployed rules
 
@@ -100,7 +100,7 @@ Sprint 21 - March 4, 2020
   - prefer-single-boolean-return
   - prefer-while
 - These rules will be under review for 2 weeks (Sprint 21) and enforced starting Sprint 22
-- Feedback from VFS teams will be collected during this period. Please use the tag `@platform-release-tools` or message any of the release tools team members in Slack and provide us with your feedback.
+- Feedback from VFS teams will be collected during this period. Please use the tag `@va-platform-cop-frontend` or message any of the release tools team members in Slack and provide us with your feedback.
 
 ## SonarJS new rules
 

--- a/platform/engineering/manual-review-triggers.md
+++ b/platform/engineering/manual-review-triggers.md
@@ -11,7 +11,7 @@
 
 Each PR on `vets-website` will run through an automated process which looks for code additions/modifications
 which could be considered bad for the platform.  If a potential issue is found, a bot will leave an
-automated comment and request a review from the **platform-release-tools**.
+automated comment and request a review from the **va-platform-cop-frontend**.
 
 ## Triggers
 

--- a/platform/service-design/newsletter-mvp-outline.md
+++ b/platform/service-design/newsletter-mvp-outline.md
@@ -16,7 +16,7 @@ VSP is starting a periodic newsletter communicating important updates to the pla
 - *Solution:* We are now providing automated tooling to improve code quality with explicit and enforced standards to help reduce the burden of code reviews
 - *Supporting Documentation:* [Learn more](https://docs.google.com/document/d/1jgXFkDF25hPJLYHiyN3_js09dDyyGSWXyXIGITEpsUU/edit)
 - *Supporting Documentation:* [Get started](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/front-end-standards/manual-reviews/)
-- *Feedback or Questions:* Please use the tag `@platform-release-tools` or message any of the release tools team members in Slack.
+- *Feedback or Questions:* Please use the tag `@va-platform-cop-frontend` or message any of the release tools team members in Slack.
 
 ------
 

--- a/platform/service-design/product-brochure-automated-frontend-code-reviews.md
+++ b/platform/service-design/product-brochure-automated-frontend-code-reviews.md
@@ -8,7 +8,7 @@ Automated code quality checks allowing you to move faster and bypass reviews fro
 
 **ESLint:** A standard set of rules for analyzing code that run during every build and report any warnings or errors to VFS Teams.
 
-**Manual review triggers:** Each PR runs through an automated process that looks for code additions and modifications that could negatively impact the platform. If a potential issue is found, a bot leaves a comment and requests a review from `platform-release-tools`.
+**Manual review triggers:** Each PR runs through an automated process that looks for code additions and modifications that could negatively impact the platform. If a potential issue is found, a bot leaves a comment and requests a review from `va-platform-cop-frontend`.
 
 ------
 

--- a/products/platform/README.md
+++ b/products/platform/README.md
@@ -29,7 +29,7 @@
 
 ### Sprint 23 (04-02-2020 - 4-14-2020)
 - [Automated Code Quality](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/platform/automated_code_quality) - v1.2
-  - ESLint - Publish and setup the second set of standard linting rules for [trial](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/new-rule-release-notes.md) for the next 4 weeks. Feedback from VFS teams will be collected during this period. Please use the tag `@platform-release-tools` or message any of the release tools team members in Slack and provide us with your feedback.
+  - ESLint - Publish and setup the second set of standard linting rules for [trial](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/new-rule-release-notes.md) for the next 4 weeks. Feedback from VFS teams will be collected during this period. Please use the tag `@va-platform-cop-frontend` or message any of the release tools team members in Slack and provide us with your feedback.
 
 ### Sprint 22 (04-01-2020)
 - [Feature Toggles](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/platform/feature-toggles) - v0.3

--- a/products/platform/automated_code_quality/readme.md
+++ b/products/platform/automated_code_quality/readme.md
@@ -14,7 +14,7 @@ Provide automated tooling to automate to improve code quality with explicit and 
 ## Tools Implemented:
 **ESLint** - Establish a standard set of linting rules using 'eslint' that will be run during every build and report any warnings or errors to VFS Teams 
 
-**Manual Review Triggers** - Each PR on vets-website will run through an automated process which looks for code additions/modifications which could be considered bad for the platform. If a potential issue is found, a bot will leave an automated comment and request a review from  `platform-release-tools`.
+**Manual Review Triggers** - Each PR on vets-website will run through an automated process which looks for code additions/modifications which could be considered bad for the platform. If a potential issue is found, a bot will leave an automated comment and request a review from  `va-platform-cop-frontend`.
 
 ## Product Guides\Documentation:
 
@@ -38,7 +38,7 @@ Provide automated tooling to automate to improve code quality with explicit and 
 ## Version Notes:
 ### Release v1.2 Sprint 20 (04-02-20)
 
-- ESLint - Publish and setup the second set of standard linting rules for [trial](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/new-rule-release-notes.md) for the next 4 weeks. Feedback from VFS teams will be collected during this period. Please use the tag @platform-release-tools or message any of the release tools team members in Slack and provide us with your feedback.
+- ESLint - Publish and setup the second set of standard linting rules for [trial](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/new-rule-release-notes.md) for the next 4 weeks. Feedback from VFS teams will be collected during this period. Please use the tag @va-platform-cop-frontend or message any of the release tools team members in Slack and provide us with your feedback.
 ---
 ### Release v1.1 Sprint 21 (03-30-20)
 - ESLint - First set of standard linting rules are [enforced](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/new-rule-release-notes.md#SonarJS-deployed-rules) 

--- a/teams/vsp/teams/tools/frontend/support-and-triage.md
+++ b/teams/vsp/teams/tools/frontend/support-and-triage.md
@@ -51,7 +51,7 @@ Support requests include every interaction you have with a VSF team member. Even
 
 ### Pull requests 
 
-Ensure that no pull requests have been waiting on the @department-of-veterans-affairs/platform-release-tools more than 24 hours for a response. This includes follow-ups to reviews. 
+Ensure that no pull requests have been waiting on the @department-of-veterans-affairs/va-platform-cop-frontend more than 24 hours for a response. This includes follow-ups to reviews. 
 
 ### Oncall support
 


### PR DESCRIPTION
This PR updates references to platform-release-tools to va-platform-cop-frontend to account for the change of teams following the vsp reorg.