### PR TITLE
Add labels to ops_issue_template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/ops_issue_template.md
@@ -2,7 +2,7 @@
 name: Ops Issue Template
 about: For filing standard issues with the Platform Operations Team.
 title: ''
-labels: devops, needs-grooming, operations
+labels: devops, needs-grooming, operations, platform-cop, platform-cop-devops
 assignees: ''
 
 ---


### PR DESCRIPTION
Add `platform-cop` and `platform-cop-devops` as default labels as discussed in the Platform CoP meeting 12/16.