### PR TITLE
adding basic issue template for platform tech team 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-tech-team-2.md
+++ b/.github/ISSUE_TEMPLATE/platform-tech-team-2.md
@@ -21,4 +21,4 @@ _What details are necessary to understand the work that this issue is tracking?_
 - [ ] _Epic assigned_
 - [ ] _Estimated (points assigned)_
 - [ ] _Sprint assigned (once planned)_
-- [ ] _Team member(s) assigned 
+- [ ] _Team member(s) assigned_ 

--- a/.github/ISSUE_TEMPLATE/platform-tech-team-2.md
+++ b/.github/ISSUE_TEMPLATE/platform-tech-team-2.md
@@ -16,9 +16,9 @@ _What details are necessary to understand the work that this issue is tracking?_
 ## Acceptance Criteria
 - [ ] _What will be created or happen as a result of this issue?_
 
-## How to configure this issue
-- [ ] _Team label assigned_
-- [ ] _Epic assigned_
+## Refinement Guidance - Check the following before working on this issue: 
+- [ ] _Team label assigned ("platform-tech-team-2")_
+- [ ] _Epic assigned (if needed)_ 
 - [ ] _Estimated (points assigned)_
 - [ ] _Sprint assigned (once planned)_
 - [ ] _Team member(s) assigned_ 

--- a/.github/ISSUE_TEMPLATE/platform-tech-team-2.md
+++ b/.github/ISSUE_TEMPLATE/platform-tech-team-2.md
@@ -1,0 +1,24 @@
+---
+name: Platform Tech Team 2 Issue
+about: For VA.gov Platform Tech Team 2
+title: '[Product] Thing to be done'
+labels: platform-tech-team-2
+assignees: ''
+
+---
+
+## Description
+_What details are necessary to understand the work that this issue is tracking?_
+
+## Resources 
+- Artifacts - i.e., issues, documentation, code, etc. - that help explain what's needed to work on this issue
+
+## Acceptance Criteria
+- [ ] _What will be created or happen as a result of this issue?_
+
+## How to configure this issue
+- [ ] _Team label assigned_
+- [ ] _Epic assigned_
+- [ ] _Estimated (points assigned)_
+- [ ] _Sprint assigned (once planned)_
+- [ ] _Team member(s) assigned 


### PR DESCRIPTION
relates to #48756 

I’m adding a template that Platform Tech Team 2 can use to create issues. 