### PR TITLE
Add identity user_account creation documentation

### DIFF
--- a/products/identity/Design Documents/UserAccount_Attributes.md
+++ b/products/identity/Design Documents/UserAccount_Attributes.md
@@ -41,5 +41,3 @@
 | `mhv_uuid` | A users UUID from My HealtheVet | Retreived from the user attributes that is queried from My HealtheVet. |
 | `dslogon_uuid` | A users UUID from DS Logon | Retreived from the user attributes that is queried from DS Logon. |
 | `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon | Retreived from the user attributes that is queried from My HealtheVet or DS Logon. |
-
-

--- a/products/identity/Design Documents/UserAccount_Attributes.md
+++ b/products/identity/Design Documents/UserAccount_Attributes.md
@@ -1,0 +1,45 @@
+# UserAccount & UserVerification Attributes
+
+## Summary
+`UserAccount` and `UserVerification` objects are created and maintained from two different methods, Single Sign-On (SSOe) and Sign in Service (SiS) authentication workflows.
+
+## Single Sign-On (SSOe)
+
+### UserAccount
+
+| Attribute | Description | Notes |
+| --- | --- | --- |
+| `icn` | Integration Control Number, this is used as a primary identifier for MPI queries. | The `icn` is retreived from the Eauth SAML headers during the authentication flow. |
+
+### UserVerification
+
+| Attribute | Description | Notes |
+| --- | --- | --- |
+| `user_account_id` | Associated UserAccount | A `UserAccount` can have many `UserVerifications`. There will be one `UserVerification` per IDP UUID.  |
+| `idme_uuid` | A users UUID from ID.me | Retreived from the Eauth SAML headers during the authentication flow. |
+| `logingov_uuid` | A users UUID from Login.gov | Retreived from the Eauth SAML headers during the authentication flow. |
+| `mhv_uuid` | A users UUID from My HealtheVet | Retreived from the Eauth SAML headers during the authentication flow. |
+| `dslogon_uuid` | A users UUID from DS Logon | Retreived from the Eauth SAML headers during the authentication flow. |
+| `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon | Retreived from the Eauth SAML headers during the authentication flow. |
+
+
+## Sign in Service (SiS)
+
+### UserAccount
+
+| Attribute | Description | Notes |
+| --- | --- | --- |
+| `icn` | Integration Control Number, this is used as a primary identifier for MPI queries. | The `icn` is retreived from querying MPI with the `idme_uuid`, `logingov_uuid`, or `mhv_icn` (depending on authentication method). If an MPI record does not exist, a new MPI record with the user's credential information is created. |
+
+### UserVerification
+
+| Attribute | Description | Notes |
+| --- | --- | --- |
+| `user_account_id` | Associated UserAccount | A `UserAccount` can have many `UserVerifications`. There will be one `UserVerification` per IDP UUID. |
+| `idme_uuid` | A users UUID from ID.me | Retreived from the user attributes that is queried from ID.me. |
+| `logingov_uuid` | A users UUID from Login.gov | Retreived from the user attributes that is queried from Logon.gov .|
+| `mhv_uuid` | A users UUID from My HealtheVet | Retreived from the user attributes that is queried from My HealtheVet. |
+| `dslogon_uuid` | A users UUID from DS Logon | Retreived from the user attributes that is queried from DS Logon. |
+| `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon | Retreived from the user attributes that is queried from My HealtheVet or DS Logon. |
+
+

--- a/products/identity/Design Documents/UserAccount_Attributes.md
+++ b/products/identity/Design Documents/UserAccount_Attributes.md
@@ -3,41 +3,20 @@
 ## Summary
 `UserAccount` and `UserVerification` objects are created and maintained from two different methods, Single Sign-On (SSOe) and Sign in Service (SiS) authentication workflows.
 
-## Single Sign-On (SSOe)
+## UserAccount
 
-### UserAccount
+| Attribute | Description | Single Sign-On (SSOe) | Sign in Service (SiS) |
+| --- | --- | --- | --- |
+| `icn` | Integration Control Number, this is used as a primary identifier for MPI queries. | The `icn` is retreived from the Eauth SAML headers during the authentication flow. | The `icn` is retreived from querying MPI with the `idme_uuid`, `logingov_uuid`, or `mhv_icn` (depending on authentication method). If an MPI record does not exist, a new MPI record with the user's credential information is created. |
 
-| Attribute | Description | Notes |
-| --- | --- | --- |
-| `icn` | Integration Control Number, this is used as a primary identifier for MPI queries. | The `icn` is retreived from the Eauth SAML headers during the authentication flow. |
+## UserVerification
+A `UserAccount` can have many `UserVerifications`. There will be one `UserVerification` per IDP UUID.
 
-### UserVerification
-
-| Attribute | Description | Notes |
-| --- | --- | --- |
-| `user_account_id` | Associated UserAccount | A `UserAccount` can have many `UserVerifications`. There will be one `UserVerification` per IDP UUID.  |
-| `idme_uuid` | A users UUID from ID.me | Retreived from the Eauth SAML headers during the authentication flow. |
-| `logingov_uuid` | A users UUID from Login.gov | Retreived from the Eauth SAML headers during the authentication flow. |
-| `mhv_uuid` | A users UUID from My HealtheVet | Retreived from the Eauth SAML headers during the authentication flow. |
-| `dslogon_uuid` | A users UUID from DS Logon | Retreived from the Eauth SAML headers during the authentication flow. |
-| `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon | Retreived from the Eauth SAML headers during the authentication flow. |
-
-
-## Sign in Service (SiS)
-
-### UserAccount
-
-| Attribute | Description | Notes |
-| --- | --- | --- |
-| `icn` | Integration Control Number, this is used as a primary identifier for MPI queries. | The `icn` is retreived from querying MPI with the `idme_uuid`, `logingov_uuid`, or `mhv_icn` (depending on authentication method). If an MPI record does not exist, a new MPI record with the user's credential information is created. |
-
-### UserVerification
-
-| Attribute | Description | Notes |
-| --- | --- | --- |
-| `user_account_id` | Associated UserAccount | A `UserAccount` can have many `UserVerifications`. There will be one `UserVerification` per IDP UUID. |
-| `idme_uuid` | A users UUID from ID.me | Retreived from the user attributes that is queried from ID.me. |
-| `logingov_uuid` | A users UUID from Login.gov | Retreived from the user attributes that is queried from Logon.gov .|
-| `mhv_uuid` | A users UUID from My HealtheVet | Retreived from the user attributes that is queried from My HealtheVet. |
-| `dslogon_uuid` | A users UUID from DS Logon | Retreived from the user attributes that is queried from DS Logon. |
-| `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon | Retreived from the user attributes that is queried from My HealtheVet or DS Logon. |
+| Attribute | Description | Single Sign-On (SSOe) | Sign in Service (SiS) |
+| --- | --- | --- | --- |
+| `user_account_id` | Associated UserAccount | | |
+| `idme_uuid` | A users UUID from ID.me | Retreived from the Eauth SAML headers during the authentication flow. | Retreived from the user attributes that is queried from ID.me |
+| `logingov_uuid` | A users UUID from Login.gov | Retreived from the Eauth SAML headers during the authentication flow. | Retreived from the user attributes queried from Logon.gov |
+| `mhv_uuid` | A users UUID from My HealtheVet | Retreived from the Eauth SAML headers during the authentication flow. | Retreived from the user attributes queried from My HealtheVet. |
+| `dslogon_uuid` | A users UUID from DS Logon | Retreived from the Eauth SAML headers during the authentication flow. |  Retreived from the user attributes queried from DS Logon. |
+| `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon | Retreived from the Eauth SAML headers during the authentication flow. | Retreived from the user attributes queried from My HealtheVet or DS Logon. |

--- a/products/identity/Design Documents/UserAccount_Creation.md
+++ b/products/identity/Design Documents/UserAccount_Creation.md
@@ -1,0 +1,52 @@
+# UserAccount & UserVerification Creation
+
+## Summary
+`UserAccount` and `UserVerification` objects are created from two different methods, SSOe and SiS workflows.
+
+## UserAccount
+
+| Attribute | Description |
+| --- | --- |
+| `icn` | MPI Integration Control Number |
+
+### SSOe
+The `icn` is retreived from the `SAML` that is returned from IAM during the authentication flow. `UserAccount` objects are then found or created in after login actions.
+
+1. `V1::SessionsController#user_login` sets the `current_user` attributes (including `icn`) from the SAML and calls `V1::SessionsController#after_login_actions`.
+2. `V1::SessionsController#after_login_actions` creates and runs a new `Login::UserVerifier` service object with the current_user's `icn`.
+3. `Login::UserVerifier` service finds or creates a `UserAccount` with the current_user's `icn`.
+
+### SiS
+The `icn` is retreived from querying MPI. If an MPI record does not exist, one is created. The `icn` is then used to find or create a `UserAccount`.
+
+1. `V0::SignInController#callback` calls `V0::SignInController#create_login_code`.
+2. `V0::SignInController#create_login_code` gets `verified_icn` from `SignIn::AttributeValidator` service object.
+3. `V0::SignInController#create_login_code` then creates and runs a new `SignIn::UserCreator` service object with the `verified_icn`.
+4. `SignIn::UserCreator` service creates and runs a new `Login::UserVerifier` service object with a `user_verifier_object` containing the `verified_icn`.
+5. `Login::UserVerifier` service finds or creates a `UserAccount` with the `verified_icn`.
+
+## UserVerification
+A `UserAccount` can have many `UserVerifications`. There will be one `UserVerification` per IDP UUID.
+| Attribute | Description |
+| --- | --- |
+| `user_account_id` | Associated UserAccount |
+| `idme_uuid` | A users UUID from IDme |
+| `logingov_uuid` | A users UUID from LoginGov |
+| `mhv_uuid` | A users UUID from MHV |
+| `dslogon_uuid` | A users UUID from DSLogon |
+
+### SSOe
+The UUID is retreived from the SAML returned from IAM during the authentication flow. `UserVerification` objects are then created or updated in after login actions.
+
+1. `V1::SessionsController#user_login` sets the current_user from the SAML and calls `V1::SessionsController#after_login_actions`.
+2. `V1::SessionsController#after_login_actions` creates and runs new `Login::UserVerifier` service object with current user's IDP UUID.
+3. `Login::UserVerifier` service updates or creates a `UserVerification` with the corresponding IDP UUID.
+
+### SiS
+The UUID is retreived from the IDP's user info and is used to create or update `UserVerification` objects in callbacks.
+
+1. `V0::SignInController#callback` retreives user_info from the IDP and calls `V0::SignInController#create_login_code`.
+2. `V0::SignInController#create_login_code` normalizes `user_attributes` (which contains the IDP UUID) then creates and runs a new `SignIn::UserCreator` service object with those attributes.
+3. `SignIn::UserCreator` service creates and runs a new `Login::UserVerifier` service object with a `user_verifier_object` containing the IDP UUID.
+4. `Login::UserVerifier` service updates or creates a `UserVerification` with the corresponding IDP UUID.
+

--- a/products/identity/Design Documents/UserAccount_Creation.md
+++ b/products/identity/Design Documents/UserAccount_Creation.md
@@ -1,7 +1,7 @@
 # UserAccount & UserVerification Creation
 
 ## Summary
-`UserAccount` and `UserVerification` objects are created from two different methods, SSOe and SiS workflows.
+`UserAccount` and `UserVerification` objects are created and maintained from two different methods, Single Sign-On (SSOe) and Sign in Service (SiS) authentication workflows.
 
 ## UserAccount
 
@@ -9,14 +9,14 @@
 | --- | --- |
 | `icn` | MPI Integration Control Number |
 
-### SSOe
+### Single Sign-On (SSOe)
 The `icn` is retreived from the `SAML` that is returned from IAM during the authentication flow. `UserAccount` objects are then found or created in after login actions.
 
 1. `V1::SessionsController#user_login` sets the `current_user` attributes (including `icn`) from the SAML and calls `V1::SessionsController#after_login_actions`.
 2. `V1::SessionsController#after_login_actions` creates and runs a new `Login::UserVerifier` service object with the current_user's `icn`.
 3. `Login::UserVerifier` service finds or creates a `UserAccount` with the current_user's `icn`.
 
-### SiS
+### Sign in Service (SiS)
 The `icn` is retreived from querying MPI. If an MPI record does not exist, one is created. The `icn` is then used to find or create a `UserAccount`.
 
 1. `V0::SignInController#callback` calls `V0::SignInController#create_login_code`.
@@ -30,19 +30,19 @@ A `UserAccount` can have many `UserVerifications`. There will be one `UserVerifi
 | Attribute | Description |
 | --- | --- |
 | `user_account_id` | Associated UserAccount |
-| `idme_uuid` | A users UUID from IDme |
-| `logingov_uuid` | A users UUID from LoginGov |
-| `mhv_uuid` | A users UUID from MHV |
-| `dslogon_uuid` | A users UUID from DSLogon |
+| `idme_uuid` | A users UUID from ID.me |
+| `logingov_uuid` | A users UUID from Login.gov |
+| `mhv_uuid` | A users UUID from My HealtheVet |
+| `dslogon_uuid` | A users UUID from DS Logon |
 
-### SSOe
+### Single Sign-On (SSOe)
 The UUID is retreived from the SAML returned from IAM during the authentication flow. `UserVerification` objects are then created or updated in after login actions.
 
 1. `V1::SessionsController#user_login` sets the current_user from the SAML and calls `V1::SessionsController#after_login_actions`.
 2. `V1::SessionsController#after_login_actions` creates and runs new `Login::UserVerifier` service object with current user's IDP UUID.
 3. `Login::UserVerifier` service updates or creates a `UserVerification` with the corresponding IDP UUID.
 
-### SiS
+### Sign in Service (SiS)
 The UUID is retreived from the IDP's user info and is used to create or update `UserVerification` objects in callbacks.
 
 1. `V0::SignInController#callback` retreives user_info from the IDP and calls `V0::SignInController#create_login_code`.

--- a/products/identity/Design Documents/UserAccount_Creation_Flow.md
+++ b/products/identity/Design Documents/UserAccount_Creation_Flow.md
@@ -51,4 +51,3 @@ The UUID is retreived from the IDP's user info and is used to create or update `
 2. `V0::SignInController#create_login_code` normalizes `user_attributes` (which contains the IDP UUID) then creates and runs a new `SignIn::UserCreator` service object with those attributes.
 3. `SignIn::UserCreator` service creates and runs a new `Login::UserVerifier` service object with a `user_verifier_object` containing the IDP UUID.
 4. `Login::UserVerifier` service updates or creates a `UserVerification` with the corresponding IDP UUID.
-

--- a/products/identity/Design Documents/UserAccount_Creation_Flow.md
+++ b/products/identity/Design Documents/UserAccount_Creation_Flow.md
@@ -1,4 +1,4 @@
-# UserAccount & UserVerification Creation
+# UserAccount & UserVerification Creation Flow
 
 ## Summary
 `UserAccount` and `UserVerification` objects are created and maintained from two different methods, Single Sign-On (SSOe) and Sign in Service (SiS) authentication workflows.
@@ -7,21 +7,22 @@
 
 | Attribute | Description |
 | --- | --- |
-| `icn` | MPI Integration Control Number |
+| `icn` | Integration Control Number, this is used as a primary identifier for MPI queries |
 
 ### Single Sign-On (SSOe)
-The `icn` is retreived from the `SAML` that is returned from IAM during the authentication flow. `UserAccount` objects are then found or created in after login actions.
+The `icn` is retreived from the Eauth SAML headers during the authentication flow. `UserAccount` objects are then found or created in after login actions.
 
-1. `V1::SessionsController#user_login` sets the `current_user` attributes (including `icn`) from the SAML and calls `V1::SessionsController#after_login_actions`.
+1. `V1::SessionsController#user_login` sets the `current_user` attributes (including `icn`) from the Eauth SAML headers and calls `V1::SessionsController#after_login_actions`.
 2. `V1::SessionsController#after_login_actions` creates and runs a new `Login::UserVerifier` service object with the current_user's `icn`.
 3. `Login::UserVerifier` service finds or creates a `UserAccount` with the current_user's `icn`.
 
 ### Sign in Service (SiS)
 The `icn` is retreived from querying MPI. If an MPI record does not exist, one is created. The `icn` is then used to find or create a `UserAccount`.
 
-1. `V0::SignInController#callback` calls `V0::SignInController#create_login_code`.
-2. `V0::SignInController#create_login_code` gets `verified_icn` from `SignIn::AttributeValidator` service object.
-3. `V0::SignInController#create_login_code` then creates and runs a new `SignIn::UserCreator` service object with the `verified_icn`.
+1. `V0::SignInController#callback` gets `verified_icn` from `SignIn::AttributeValidator` service object.
+2. `SignIn::AttributeValidator` attempts to query MPI based off the `idme_uuid`, `logingov_uuid`, or `mhv_icn` (depending on what the user has authenticated with).
+    1. If MPI record does not exist, `SignIn::AttributeValidator` creates a new MPI record with the user's credential information.
+3. A new `SignIn::UserCreator` service object is created and run with the `verified_icn`.
 4. `SignIn::UserCreator` service creates and runs a new `Login::UserVerifier` service object with a `user_verifier_object` containing the `verified_icn`.
 5. `Login::UserVerifier` service finds or creates a `UserAccount` with the `verified_icn`.
 
@@ -34,9 +35,10 @@ A `UserAccount` can have many `UserVerifications`. There will be one `UserVerifi
 | `logingov_uuid` | A users UUID from Login.gov |
 | `mhv_uuid` | A users UUID from My HealtheVet |
 | `dslogon_uuid` | A users UUID from DS Logon |
+| `backing_idme_uuid` | A users ID.me UUID when they authenticate with My HealtheVet or DS Logon |
 
 ### Single Sign-On (SSOe)
-The UUID is retreived from the SAML returned from IAM during the authentication flow. `UserVerification` objects are then created or updated in after login actions.
+The UUID is retreived from the Eauth SAML headers during the authentication flow. `UserVerification` objects are then created or updated in after login actions.
 
 1. `V1::SessionsController#user_login` sets the current_user from the SAML and calls `V1::SessionsController#after_login_actions`.
 2. `V1::SessionsController#after_login_actions` creates and runs new `Login::UserVerifier` service object with current user's IDP UUID.


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/50827

[UserAccount_Creation_Flow.md](https://github.com/department-of-veterans-affairs/va.gov-team/blob/identity/user-accounts-documentation/products/identity/Design%20Documents/UserAccount_Creation_Flow.md)

[UserAccount_Attributes.md](https://github.com/department-of-veterans-affairs/va.gov-team/blob/identity/user-accounts-documentation/products/identity/Design%20Documents/UserAccount_Attributes.md)

@joeniquette is this what you were looking for? I wasn't sure how deep into the weeds I should go.
