### PR TITLE
55037 set output deprecation

### DIFF
--- a/.github/ISSUE_TEMPLATE/offboarding-request.md
+++ b/.github/ISSUE_TEMPLATE/offboarding-request.md
@@ -49,7 +49,7 @@ _The following steps are performed by the **Platform Support** team. Detailed in
  - [ ] AWS Access removed  (if applicable. Search their name in [AWS IAM](https://console.amazonaws-us-gov.com/iamv2/home#/home))
    > Use the [Remove SOCKS and AWS access Github Workflow](https://github.com/department-of-veterans-affairs/devops/actions/workflows/offboarding.yml) to remove user's entry from DSVA AWS. You'll need the user's AWS username (typically `First.Last`).
  - [ ] User removed from the VA GitHub Org (if applicable. Check [department-of-veterans-affairs/people](https://github.com/orgs/department-of-veterans-affairs/people))
-   > Fill out request found [here](https://github.com/department-of-veterans-affairs/github-user-requests/issues/new?assignees=&labels=remove-user&template=user-remove.yml&title=Remove+User+from+Org%3A+%5Busername%5D). 
+   > Fill out request found [here](https://github.com/department-of-veterans-affairs/github-user-requests/issues/new?assignees=&labels=remove-user&template=user-remove.yml&title=Remove+User+from+Org%3A+%5Busername%5D).
  - [ ] Pagerduty access removed (if applicable. Check [pd users](https://dsva.pagerduty.com/users-new))
  - [ ] [Okta account](https://vfs.atlassian.net/wiki/spaces/OT/pages/2532508159/Offboarding+users+from+Okta) disabled (if applicable)
  - [ ] [Datadog account](https://vfs.atlassian.net/wiki/spaces/OT/pages/2526282894/Offboarding+Users+from+Datadog) disabled (if applicable. Check [Datadog users](https://vagov.ddog-gov.com/organization-settings/users))

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/products/facilities/mapbox/README.md
+++ b/products/facilities/mapbox/README.md
@@ -21,7 +21,7 @@ So, the process by which the keys are fetched from AWS Parameter Store and ultim
 1. Fetch from AWS Parameter Store in required workflows (e.g. [continuous-integration](https://github.com/department-of-veterans-affairs/vets-website/blob/8de1ed2fa5b6a462323c2c482e6e2115ac666556/.github/workflows/continuous-integration.yml#L61), [e2e-tests](https://github.com/department-of-veterans-affairs/vets-website/blob/8de1ed2fa5b6a462323c2c482e6e2115ac666556/.github/workflows/e2e-tests.yml#L104))
 ```
       - name: Get Mapbox Token
-        uses: marvinpinto/action-inject-ssm-secrets@v1.2.1
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
         with:
           ssm_parameter: /dsva-vagov/vets-website/dev/mapbox_token
           env_variable_name: MAPBOX_TOKEN

--- a/products/identity/Mocked Authentication/Mockdata/sync.md
+++ b/products/identity/Mocked Authentication/Mockdata/sync.md
@@ -14,7 +14,7 @@ The key is stored in parameter store -  `/dsva-vagov/vets-api/staging/mockdata_s
 
 #### Inject the api_key into the workflow:
 ```yml
-- uses: marvinpinto/action-inject-ssm-secrets@v1.1.1
+- uses: department-of-veterans-affairs/action-inject-ssm-secrets@d8e6de3bde4dd728c9d732baef58b3c854b8c4bb # latest
   with:
     ssm_parameter: /dsva-vagov/vets-api/staging/mockdata_sync_api_key
     env_variable_name: MOCKDATA_API_KEY


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.


## Summary

1. [ ]  ~~[`aws-actions/configure-aws-credentials@v1`](https://github.com/aws-actions/configure-aws-credentials) - Can be replaced with `@v2`; see https://github.com/aws-actions/configure-aws-credentials/issues/489~~
    NA
3. [ ] ~~[`marvinpinto/action-inject-ssm-secrets`](https://github.com/marvinpinto/action-inject-ssm-secrets) - [No apparent updates forthcoming](https://github.com/marvinpinto/actions/issues/543); the maintainer appears to be absent. This is **widely** used: https://github.com/search?q=org%3Adepartment-of-veterans-affairs+action-inject-ssm-secrets&type=code~~
    NA
5. [ ] ~~[`slackapi/slack-github-action`](https://github.com/slackapi/slack-github-action) - Fixable by moving to version 1.23.0~~
    NA
6. [ ] ~~[`EndBug/add-and-commit`](https://github.com/EndBug/add-and-commit/issues/448#issuecomment-1297742564) - Fixable by moving to `v9`~~
    NA
8. [x] Add entry to dependabot.yml for gh-actions updates
9. [x] Update gh-actions references in documentation


## Related issue(s)
- department-of-veterans-affairs/va.gov-team/issues/55037

## Testing done

## Screenshots
_Note: Optional_
