### PR TITLE
Add Sidekiq Admin UI Request yaml file

### DIFF
--- a/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
+++ b/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
@@ -1,0 +1,99 @@
+name: Vets-api Sidekiq Admin UI Access Request
+description: For requesting access to the Sidekiq Admin UI
+title: Sidekiq Admin UI access for [individual]
+labels: ['external-request', 'platform-tech-team-support', 'ops-access-request', 'sidekiq-access-request']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        :wave: **_Instructions_**
+        1. Before being granted access, the individual for whom access is requested (the 'target individual') must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        2. Change the **Title** to include target individual
+        3. Add the label used by the target individual's team (eg: `BAH-526`)
+        4. Do not remove any of the existing labels.
+        5. Enter required fields and select environments you need access to.
+        6. If Production access is required, please use the respective section to provide proof of E-QIP transmittal. If you have not started the E-QIP process, do not submit this ticket. Ask your Vendor Onboarding Representative to confirm.
+        7. Fill in "Additional Notes" with any information requested by the other steps.
+  - type: input
+    id: requestor-name
+    attributes:
+      label: Your Name
+      description: Please provide the name of the target individual
+      placeholder: Jane Doe
+    validations:
+      required: true
+  - type: input
+    id: email
+    attributes:
+      label: Your GitHub handle (Sidekiq Admin UI access is managed through GitHub)
+      description: Please provide the work GitHub handle of the target individual
+      placeholder: "@username"
+    validations:
+      required: true
+  - type: input
+    id: aws-username
+    attributes:
+      label: Your dsvagovcloud AWS user name (if applicable)
+      description: If you have previously been granted AWS access, list your dsvagovcloud AWS user name
+      placeholder: First.Last
+  - type: input
+    id: team-name
+    attributes:
+      label: Team, Role, and Company of the target individual
+      description: Please provide the name of the team, their role on that team, and the name of the company the target individual works for
+      placeholder: Team Moose, Antler Development, Alces LLC
+    validations:
+      required: true
+  - type: dropdown
+    id: cor-name
+    attributes:
+      label: COR Name
+      description: The name of the Contracting Officer's Representative (COR) covering the target individual.
+      options:
+        - Cecila Lee
+        - Courtney Bethea
+        - Crystal Moultrie
+        - Doris Lin
+        - Vilay Senthep
+        - Eunice Garcia
+        - Delano McVay
+        - Jennifer O'Day
+        - Laurene "Reney" Cook
+        - Rolanda Copeland
+        - Other - please specify in 'Additional Notes'
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Please confirm if you are on the VFS Team Roster or Platform Team Roster
+      description: If you are on neither, close this request and reach out to your Product Manager to be added
+      options:
+        - label: [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        - label: [Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Sidekiq UI Access requested for the following environments
+      description: Only choose the environments you NEED. Additional requirements for Prod are listed below
+      options:
+        - label: dev
+        - label: staging
+        - label: sandbox
+        - label: production (if requesting, justify prod access in 'Additional Notes' section)
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: If PRODUCTION ACCESS is required, confirm/complete ONE of the following
+      description: If you have not submitted your E-QIP questionaire, Production access will not be provided.
+      options:
+        - label: I have an AWS Username and it is listed in "[here](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/environments/global/iam_users.tf)"
+        - label: I currently have access to vets-api Production Terminal via ArgoCD
+        - label: I've attached a screenshot of my E-QIP Transmittal Notice E-mail (Drag or Copy/Paste in Additional Notes Section below)
+  - type: textarea
+    id: additional-notes
+    attributes:
+      label: Additional Notes
+      description: Use this section to add notes, such as justification for the access request, COR information when 'Other' was selected, E-QIP screenshot, etc.
+      placeholder: I need this access because of <reason>

--- a/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
+++ b/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
@@ -88,7 +88,7 @@ body:
       label: If PRODUCTION ACCESS is required, confirm/complete ONE of the following
       description: If you have not submitted your E-QIP questionaire, Production access will not be provided.
       options:
-        - label: "I have an AWS Username and it is listed in "[here](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/environments/global/iam_users.tf)""
+        - label: "I have an AWS Username and it is listed in [here](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/environments/global/iam_users.tf)"
         - label: "I currently have access to vets-api Production Terminal via ArgoCD"
         - label: "I've attached a screenshot of my E-QIP Transmittal Notice E-mail (Drag or Copy/Paste in Additional Notes Section below)"
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
+++ b/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
@@ -68,8 +68,8 @@ body:
       label: Please confirm if you are on the VFS Team Roster or Platform Team Roster
       description: If you are on neither, close this request and reach out to your Product Manager to be added
       options:
-        - label: [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
-        - label: [Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)
+        - label: "[VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)"
+        - label: "[Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)"
     validations:
       required: true
   - type: checkboxes
@@ -88,9 +88,9 @@ body:
       label: If PRODUCTION ACCESS is required, confirm/complete ONE of the following
       description: If you have not submitted your E-QIP questionaire, Production access will not be provided.
       options:
-        - label: I have an AWS Username and it is listed in "[here](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/environments/global/iam_users.tf)"
-        - label: I currently have access to vets-api Production Terminal via ArgoCD
-        - label: I've attached a screenshot of my E-QIP Transmittal Notice E-mail (Drag or Copy/Paste in Additional Notes Section below)
+        - label: "I have an AWS Username and it is listed in "[here](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/environments/global/iam_users.tf)""
+        - label: "I currently have access to vets-api Production Terminal via ArgoCD"
+        - label: "I've attached a screenshot of my E-QIP Transmittal Notice E-mail (Drag or Copy/Paste in Additional Notes Section below)"
   - type: textarea
     id: additional-notes
     attributes:


### PR DESCRIPTION
Added a form comparable to those that we use for the AWS and Terminal Access Requests, among many others.

You'll notice I've put the responsibility into the hands of the requester to:
* Indicate which Roster they're on
* Indicate which "method" they'd like us to confirm their EQIP status.

It also indicates they should not continue creating the issue until they've done the required steps, so that we don't have unfinished tickets that hang for weeks.

NOTE that I've used the COR values that Rebecca recently added to the WAS request. Let me know if you think we should change the Dropdown to an Input

After comments are received/implemented and I've merged, I'll likely be applying similar changes to the Terminal Access Request as well.