### PR TITLE
Delete claimant-experience-crew/team-rosters, 

### DIFF
--- a/teams/benefits-portfolio/claimant-experience-crew/team-rosters/readme.md
+++ b/teams/benefits-portfolio/claimant-experience-crew/team-rosters/readme.md
@@ -1,8 +1,0 @@
-| Name  | Project(s) | Role | DSVA Slack | GitHub | 
-| ------------- | ------------- | ------------- | ------------- | ------------- |
-| Steve Albers  | Benefits Portfolio-VA Enabling Team  | Engineer | @Steve Albers | va-albers |
-| Julie Strothman  | Claimant Experience VA Enabling Team (Benefits Management, Decision Reviews, Non-disability Benefits, Dependents Experience) | Designer / Researcher | @Julie Strothman | @jstrothman |
-| Shannon Ford  | Benefits Portfolio-VA Enabling Team (supporting Disability Benefits Experience team 1 and team 2) |  Design and Research Lead  | @Shannon Ford | shannonkford |
-| name  | project  | role | slack id | github id |
-| name  | project  | role | slack id | github id |
-| name  | project  | role | slack id | github id |


### PR DESCRIPTION
...since we are using a GitHub Project instead.