### PR TITLE
WIP: transfer first pass error handing doc (no images)

### DIFF
--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/01_overview_of_error_and_logging.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/01_overview_of_error_and_logging.md
@@ -20,13 +20,13 @@ Identify how we are currently handling errors in the 526ez applications, with a 
 ### FE (vets-website)
 Our front-end error handling is apparently simple.  We have a Sentry module that exposes methods for setting tags and logging.  
 
-wipn-image
-<!-- ![alt text](https://github.com/[username]/[reponame]/blob/[branch]/image.jpg?raw=true) -->
+<img width="809" alt="Screen Shot 2023-07-06 at 3 19 25 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/758095ed-d644-47b1-ba7a-fc4350e7425e">
+
 
 To make it even easier, at the top level of the what appears to be our FE app, we have some catch all sentry logging:
 `src/applications/disability-benefits/all-claims/Form526EZApp.jsx`
   
-wipn-image
+<img width="719" alt="Screen Shot 2023-07-06 at 3 19 54 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/42e2f634-df77-4efa-b5ca-73d8e44b4ed5">
 
 Further thought / research / need will likely determine if this is sufficient, but given the severity of our BE issue where submissions are dropped, this data feels sufficient for now.  TL;DR - looks fine, not too worried about it.
 
@@ -41,7 +41,8 @@ Logging is a bit more convoluted on the backend. There are a few different parad
   * `Rails.logger` is our preferred method of logging.  It’s a clear API that provides `.error`, and `.info`, and `.debug` logging levels.  
     * Here is an example of how we can (and should) pass additional context into `Rails.logger`
       * app/workers/decision_review/submit_upload.rb:47
-      * wipn-image 
+      <img width="758" alt="Screen Shot 2023-07-06 at 3 20 41 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/01f11b28-43f2-4219-bb6d-8b241f5aba6e">
+
 
   * Our error logging uses a temporary log file as a middle man between our application and our various Dev facing dashboards.  Exactly how it works and why it’s done this way is the domain of DevOps, and for now should be considered out of scope. 
   * More is More.  Log anything important.  Job completion, Job offloading, 3rd party API calls and payloads, suppressed errors, etc.  
@@ -86,16 +87,17 @@ In either failure case, we attempt to run the following **Failover** logic:
 
 
   1. Generate support documentation PDFs.  [Our API owns this PDF generation, and this is the most relevant section of that code.](https://github.com/department-of-veterans-affairs/vets-api/blob/16e68a67c69df4c280ec1c5523d96cd25f74301b/lib/sidekiq/form526_backup_submission_process/processor.rb#L75)
-    * wipn-image
+    * <img width="594" alt="Screen Shot 2023-07-06 at 3 21 00 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/9451b95c-2acb-41b4-9669-4f6b97d2ef2d">
 
   2. We also need to submit the actual 526 form itself. EVSS already has logic to PDF-ify this, so in the event of a failure we will request this PDF from them.  [This is documented along with other 3rd party communications here.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
-    * wipn-image
+    * <img width="630" alt="Screen Shot 2023-07-06 at 3 21 47 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/5a23df9a-9e4c-425e-b27c-5b8694ebd7f2">
   
   3. Once we have these PDFS, we send them to Lighthouse, specifically the Benefits Claims Intake API, [via this a new worker](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/sidekiq/form526_backup_submission_process/submit.rb)
-    * wipn-image
-  
+    * <img width="701" alt="Screen Shot 2023-07-06 at 3 22 08 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/198b0248-3cb4-473b-a664-71a1af7b656e">
+
   4. If the Backup worker fails, we log the failure, [as seen here](https://vagov.ddog-gov.com/logs?query=%22FORM526%20BACKUP%20SUMBISSION%20FAILURE.%20In[…]=stream&from_ts=1684334801686&to_ts=1686926801686&live=true)
-    * wipn-image
+    * <img width="713" alt="Screen Shot 2023-07-06 at 3 22 31 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/7f950e82-9aea-412d-a192-be0be9bcc8cc">
+    * <img width="714" alt="Screen Shot 2023-07-06 at 3 23 01 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/dd8d547e-81f3-4c6d-92b4-d5ddb7ed724f">
 
 In the event of the last case, where all submission has failed, there is no immediate alerting.  However, we do include this information in a weekly report to the VA.  These failures are not differentiated from other, historical failures, and they will simply and in line, like the other 40,000 or so claims that have failed over the years, to be batch/bulk re-established, via whatever method the VA decides upon.
 

--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/01_overview_of_error_and_logging.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/01_overview_of_error_and_logging.md
@@ -1,0 +1,148 @@
+# State of 526 Error Handling and Fallback Summary (June 2023)
+## Purpose
+Identify how we are currently handling errors in the 526ez applications, with a specific focus on silent form submission failures.  Offer high level best-practices for error handling in our applications and identify loose ends.  This document is for discovery and should not be considered exhaustive.
+
+
+## TL;DR
+### Takeaways:
+  * Conventions for new in-code error handling are; FE == use Sentry, BE == use Rails.logger.
+  * Datadog is most likely going to be the future, and it tends to be easier to grok than Sentry.
+  * Our biggest problem is that sometimes Vet form submissions get lost.  We now have a failover solution that manually delivers the PDFs if electronic submissions fail.  
+  * These are the known [bugs](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board) and [KPIs](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489) that we have inherited.
+### Recommended next steps:
+  * [Notate this flow with visual groupings by error handling solution(s)](https://app.mural.co/t/coforma8350/m/coforma8350/1686317911061/2ff3d4b4c2d9d84eaa61e9eda95a533041f137da?sender=uf9a509d178428eccea215628)
+  * [Investigate these bugs](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board), e.g. commonly returned EVSS API errors
+  * Adding automatic retries to Manual PDF delivery failover worker is very low hanging fruit with a potentially huge payoff.
+  * Add the ability to manually retry our failover solution.
+
+
+## What we have
+### FE (vets-website)
+Our front-end error handling is apparently simple.  We have a Sentry module that exposes methods for setting tags and logging.  
+
+wipn-image
+<!-- ![alt text](https://github.com/[username]/[reponame]/blob/[branch]/image.jpg?raw=true) -->
+
+To make it even easier, at the top level of the what appears to be our FE app, we have some catch all sentry logging:
+`src/applications/disability-benefits/all-claims/Form526EZApp.jsx`
+  
+wipn-image
+
+Further thought / research / need will likely determine if this is sufficient, but given the severity of our BE issue where submissions are dropped, this data feels sufficient for now.  TL;DR - looks fine, not too worried about it.
+
+EVSS API validation errors are an api issue, and the FE data is transformed before being sent. 
+
+[UPDATE: this document outlines the EVSS validations run on form submissions](https://drive.google.com/drive/folders/1Vjkle-URBLGTJtXQb8ZVsbIiCpagy1GD)
+
+
+### BE (vets-api)
+Logging is a bit more convoluted on the backend. There are a few different paradigms, as well as the aforementioned ‘big bug’, which is lost submissions.  However, we do have a few current best practices that we can follow as we iterate.
+  * We catch errors, log relevant info, and report only salient information to the front end.
+  * `Rails.logger` is our preferred method of logging.  It’s a clear API that provides `.error`, and `.info`, and `.debug` logging levels.  
+    * Here is an example of how we can (and should) pass additional context into `Rails.logger`
+      * app/workers/decision_review/submit_upload.rb:47
+      * wipn-image 
+
+  * Our error logging uses a temporary log file as a middle man between our application and our various Dev facing dashboards.  Exactly how it works and why it’s done this way is the domain of DevOps, and for now should be considered out of scope. 
+  * More is More.  Log anything important.  Job completion, Job offloading, 3rd party API calls and payloads, suppressed errors, etc.  
+  * We have middleware in place that automatically logs errors from the EVSS API. This should be kept in mind when generating logs around EVSS API communication, however developers should not assume that this middleware is sufficient for their use case.
+
+#### Ways we Log on the BE
+
+We have four apparent paradigms, which is actually all logging to the same place, a temp log file on the server instance.  That logfile is then scrapped and the data is propagated to Sentry, Datadog, Grafana, and who knows what else.  However, that is happening under the hood.  Here is what you will actually see in the code:
+  * `Rails.logger`… vs `SentryLogging`
+  * `SentryLogging` uses rails_logger under the hood, so just skip the middleman and use `Rails.logger`…
+  * Raven Gem
+  * This appears to just be a wrapper for Sentry.  More investigation is required, but don’t use it unless you have a good reason.  This also appears to logging directly to sentry, skipping the logs, which would break our preferred convention, however I’m not sure of this.  Since we are deprecating Raven, it seems out of scope to dig further.
+  * EVSS Middleware
+  * This requires a bit more investigation, but seems primarily responsible for logging error responses from the EVSS API.  This also writes to our temp log file under the hood.
+  * Submission Failover logging
+  * `vets-api/app/models/form526_submission.rb` is the entry point for all of our submission and failover code.  
+  * TODO: This is the place to start for gaining a deeper understanding of how our submission / failover works.
+  * Our failover has logging peppered throughout it, which again writes to the temp log file for scraping.
+
+#### The difference between logging and error raising
+
+**LOGGING**: We log bits of context that we explicitly want to track.  This can include the beginning and end of 3rd party interactions, successful actions, job queuing and more.  We Log data to our local rails logs which are in turn reported to Datadog, Sentry, and Grafana.  (possibly more)
+
+**ERROR RAISING**:  If an error occurs in the rails application (BE) it will be caught in Sentry.  Sentry receives log data, but its primary value (relative to datadog) is as a catch-all for errors. Ideally, in user facing interactions we catch errors, log relevant information, and then report back to the front end without raising an error.  However, if an error occurs in a non-user facing interaction, e.g. a 526 form submission to EVSS, then we can log the failure, but we should also raise that error.  There is forthcoming work to improve the way we raise errors, e.g. using Sentry tags.
+
+
+#### How we handle 526 form submission failures
+
+These were previously silent failures.  We now have a stopgap (aka our failover solution)  in place that is far better (~600 failures per week to ~1 per week), however our goal is a 100% success rate.  
+
+The failover will kick in once the submission delivery worker (encapsulated here) fails.  We have two distinct failure states, defined as `retryable` and `non_retryable`.  
+  * `retryable` are ones that, if you keep trying, may have a chance at succeeding. Such as network issues (timeout errors, downstream services temporarily down or unreachable, etc).
+    * If the error we get back is retryable, we retry (up to 14 times, or until it is successful). If we exhaust all 14, then backup path.
+  * `non_retryable` errors are errors that we know, no matter how many times we retry the submission, it will never succeed (without direct human interaction or changes in further downstream services).  Examples of this would be a "fraud-lock" on the veterans account, or the further backend systems having a mismatching SSN, or file number for the veteran vs what we are providing.
+    * If we get a `non_retryable` error, we just bail right away, stop trying, and go the backup path right away. We know it will not succeed, so instead of wasting a day trying, just send it now, essentially.
+
+
+**NOTE:**
+We never generate our own 526 form. We either submit the DATA from the submission, to EVSS, who turns that data into a call to downstream systems to establish the claim directly in the backend system (the normal regular functionality), or we use that same data to ask EVSS to generate a 526 PDF for us. **Unlike the other forms, we do not ever generate a 526 paper form ourselves (vets-api)**
+
+In either failure case, we attempt to run the following **Failover** logic:
+
+
+  1. Generate support documentation PDFs.  [Our API owns this PDF generation, and this is the most relevant section of that code.](https://github.com/department-of-veterans-affairs/vets-api/blob/16e68a67c69df4c280ec1c5523d96cd25f74301b/lib/sidekiq/form526_backup_submission_process/processor.rb#L75)
+    * wipn-image
+
+  2. We also need to submit the actual 526 form itself. EVSS already has logic to PDF-ify this, so in the event of a failure we will request this PDF from them.  [This is documented along with other 3rd party communications here.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
+    * wipn-image
+  
+  3. Once we have these PDFS, we send them to Lighthouse, specifically the Benefits Claims Intake API, [via this a new worker](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/sidekiq/form526_backup_submission_process/submit.rb)
+    * wipn-image
+  
+  4. If the Backup worker fails, we log the failure, [as seen here](https://vagov.ddog-gov.com/logs?query=%22FORM526%20BACKUP%20SUMBISSION%20FAILURE.%20In[…]=stream&from_ts=1684334801686&to_ts=1686926801686&live=true)
+    * wipn-image
+
+In the event of the last case, where all submission has failed, there is no immediate alerting.  However, we do include this information in a weekly report to the VA.  These failures are not differentiated from other, historical failures, and they will simply and in line, like the other 40,000 or so claims that have failed over the years, to be batch/bulk re-established, via whatever method the VA decides upon.
+
+A potential area of improvement would be allowing us to reprocess these manually via our submission logic (basically reattempt the BACKUP submission)... and adding a retry to the backup job may resolve some of these. This has not been added yet.
+
+### Action items for ongoing error handling
+    * Use good form for logging.  Follow the convention of using `Sentry` with tags on the front end and `Rails.logger` on the back end.
+    * We should have a standard (style guide?) for what we log, how we log it, tag it, etc.  Right now it’s up to the developer to decide how much or how little context to pass to the `Rails.logger`
+    * Syntactic anomalies aside, we are using two drastically different approaches to error logging in our BE, i.e. Feature level logging vs Middleware level logging.  We might consider moving in one direction or the other for external API calls.
+
+### Action items for ongoing Failover improvement
+Improving on submission failover is a high priority.  Previously we had an issue where submissions were failing on a Sidekiq worker with no retrying, and little or no logging.  We currently have a failover solution that needs documentation, however it could be summarized as  **“If we fail X retries of this job fail, then make a PDF out of this information and email it to the appropriate entity.”**
+Action Items:
+  * Identify systemic issues e.g. some services are not available at certain times of day.
+    * These are mostly subsystems of EVSS and beyond our control.
+    * This may correspond to some of the contemporaneous failure spikes [documented here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152).  
+  * Document our current failover solution. [This will require digging through some code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/form526_submission.rb).
+  * Investigate EVSS validation failures that could be prevented by FE validations.
+    * [This thread in Slack](https://dsva.slack.com/archives/C1VBAHWQL/p1686785454385369) provides some relevant context on EVSS form validations and specifically how / where we can go about asking what validations exist and possibly getting them changed.
+  * Synthesize the following smattering of existing issues into actionable ticket work.
+    * Happy path failures (Sidekiq retries / pre-failover)
+      * [DataDog 1](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation?from_ts=1685984856415&to_ts=1686589656415&live=true)
+      * [DataDog 2](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20%22Form526%20Exhausted%22%2[…]c3%3A56&from_ts=1685985062267&to_ts=1686589862267&live=true)
+    * Sad path messages (Manual PDF creation)
+      * [DataDog 3](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation?from_ts=1685984856415&to_ts=1686589656415&live=true)
+  * [Investigate documented bugs, primarily from the EVSS Error Middleware](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board)
+    * TODO: This is the place to start for debugging lost form submissions.
+    * [This document is potentially relevant, as we are seeing grouping of failures](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152)
+    * Look at common bugs e.g. “the 15001 error” and see if there could be a dummy simple solution 
+
+## Misc Tips
+  * To see the full lifecycle of a form submission, search DataDog by the forms submission_id
+    * E.G. `service:vets-api @named_tags.dd.env:eks-prod @payload.submission_id:1982049`
+    * TODO: Where does `submission_id` come from?
+  * The classname `Sidekiq/EVSS::DisabilityCompensationForm::SubmitForm526AllClaim` can be searched in sentry to see all of the relevant logs
+  * Most of the new error reporting we do will be manually added to code in the application layer.  Keep in mind that we also have middleware logging responses from EVSS.
+
+
+## Resources
+### Slack threads:
+   * [Thomas -> Kyle: “how do we look up 526EZ errors in logs?”](https://dsva.slack.com/archives/C053U7BUT27/p1686588415725609)
+   * [Sam (via Kyle) -> Carbs: “some additional locations in the code for KPI consideration”](https://dsva.slack.com/archives/C053U7BUT27/p1686836358577259)
+   * [Seth -> Team: “I have some questions about EVSS API validations”](https://dsva.slack.com/archives/C1VBAHWQL/p1686785454385369)
+
+
+### Documentation:
+   * [Our Bug Board with errors related EVSS API failures](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board)
+   * [Git issue describing contemporaneous groupings of form submission failures](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152)
+   * [Kyles KPIs for 526 error handling](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
+   * [Most relevant code for 526 submissions and failover](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/form526_submission.rb)

--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/01_overview_of_error_and_logging.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/01_overview_of_error_and_logging.md
@@ -5,15 +5,15 @@ Identify how we are currently handling errors in the 526ez applications, with a 
 
 ## TL;DR
 ### Takeaways:
-  * Conventions for new in-code error handling are; FE == use Sentry, BE == use Rails.logger.
-  * Datadog is most likely going to be the future, and it tends to be easier to grok than Sentry.
-  * Our biggest problem is that sometimes Vet form submissions get lost.  We now have a failover solution that manually delivers the PDFs if electronic submissions fail.  
-  * These are the known [bugs](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board) and [KPIs](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489) that we have inherited.
+ - Conventions for new in-code error handling are; FE == use Sentry, BE == use Rails.logger.
+ - Datadog is most likely going to be the future, and it tends to be easier to grok than Sentry.
+ - Our biggest problem is that sometimes Vet form submissions get lost.  We now have a failover solution that manually delivers the PDFs if electronic submissions fail.  
+ - These are the known [bugs](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board) and [KPIs](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489) that we have inherited.
 ### Recommended next steps:
-  * [Notate this flow with visual groupings by error handling solution(s)](https://app.mural.co/t/coforma8350/m/coforma8350/1686317911061/2ff3d4b4c2d9d84eaa61e9eda95a533041f137da?sender=uf9a509d178428eccea215628)
-  * [Investigate these bugs](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board), e.g. commonly returned EVSS API errors
-  * Adding automatic retries to Manual PDF delivery failover worker is very low hanging fruit with a potentially huge payoff.
-  * Add the ability to manually retry our failover solution.
+ - [Notate this flow with visual groupings by error handling solution(s)](https://app.mural.co/t/coforma8350/m/coforma8350/1686317911061/2ff3d4b4c2d9d84eaa61e9eda95a533041f137da?sender=uf9a509d178428eccea215628)
+ - [Investigate these bugs](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board), e.g. commonly returned EVSS API errors
+ - Adding automatic retries to Manual PDF delivery failover worker is very low hanging fruit with a potentially huge payoff.
+ - Add the ability to manually retry our failover solution.
 
 
 ## What we have
@@ -35,29 +35,29 @@ EVSS API validation errors are an api issue, and the FE data is transformed befo
 
 ### BE (vets-api)
 Logging is a bit more convoluted on the backend. There are a few different paradigms, as well as the aforementioned ‘big bug’, which is lost submissions.  However, we do have a few current best practices that we can follow as we iterate.
-  * We catch errors, log relevant info, and report only salient information to the front end.
-  * `Rails.logger` is our preferred method of logging.  It’s a clear API that provides `.error`, and `.info`, and `.debug` logging levels.  
-    * Here is an example of how we can (and should) pass additional context into `Rails.logger`
-      * app/workers/decision_review/submit_upload.rb:47
-      * <img width="758" alt="Screen Shot 2023-07-06 at 3 20 41 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/01f11b28-43f2-4219-bb6d-8b241f5aba6e">
+ - We catch errors, log relevant info, and report only salient information to the front end.
+ - `Rails.logger` is our preferred method of logging.  It’s a clear API that provides `.error`, and `.info`, and `.debug` logging levels.  
+   - Here is an example of how we can (and should) pass additional context into `Rails.logger`
+     - app/workers/decision_review/submit_upload.rb:47
+     - <img width="758" alt="Screen Shot 2023-07-06 at 3 20 41 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/01f11b28-43f2-4219-bb6d-8b241f5aba6e">
 
-  * Our error logging uses a temporary log file as a middle man between our application and our various Dev facing dashboards.  Exactly how it works and why it’s done this way is the domain of DevOps, and for now should be considered out of scope. 
-  * More is More.  Log anything important.  Job completion, Job offloading, 3rd party API calls and payloads, suppressed errors, etc.  
-  * We have middleware in place that automatically logs errors from the EVSS API. This should be kept in mind when generating logs around EVSS API communication, however developers should not assume that this middleware is sufficient for their use case.
+ - Our error logging uses a temporary log file as a middle man between our application and our various Dev facing dashboards.  Exactly how it works and why it’s done this way is the domain of DevOps, and for now should be considered out of scope. 
+ - More is More.  Log anything important.  Job completion, Job offloading, 3rd party API calls and payloads, suppressed errors, etc.  
+ - We have middleware in place that automatically logs errors from the EVSS API. This should be kept in mind when generating logs around EVSS API communication, however developers should not assume that this middleware is sufficient for their use case.
 
 #### Ways we Log on the BE
 
 We have four apparent paradigms, which is actually all logging to the same place, a temp log file on the server instance.  That logfile is then scrapped and the data is propagated to Sentry, Datadog, Grafana, and who knows what else.  However, that is happening under the hood.  Here is what you will actually see in the code:
-  * `Rails.logger`… vs `SentryLogging`
-  * `SentryLogging` uses rails_logger under the hood, so just skip the middleman and use `Rails.logger`…
-  * Raven Gem
-  * This appears to just be a wrapper for Sentry.  More investigation is required, but don’t use it unless you have a good reason.  This also appears to logging directly to sentry, skipping the logs, which would break our preferred convention, however I’m not sure of this.  Since we are deprecating Raven, it seems out of scope to dig further.
-  * EVSS Middleware
-  * This requires a bit more investigation, but seems primarily responsible for logging error responses from the EVSS API.  This also writes to our temp log file under the hood.
-  * Submission Failover logging
-  * `vets-api/app/models/form526_submission.rb` is the entry point for all of our submission and failover code.  
-  * TODO: This is the place to start for gaining a deeper understanding of how our submission / failover works.
-  * Our failover has logging peppered throughout it, which again writes to the temp log file for scraping.
+ - `Rails.logger`… vs `SentryLogging`
+ - `SentryLogging` uses rails_logger under the hood, so just skip the middleman and use `Rails.logger`…
+ - Raven Gem
+ - This appears to just be a wrapper for Sentry.  More investigation is required, but don’t use it unless you have a good reason.  This also appears to logging directly to sentry, skipping the logs, which would break our preferred convention, however I’m not sure of this.  Since we are deprecating Raven, it seems out of scope to dig further.
+ - EVSS Middleware
+ - This requires a bit more investigation, but seems primarily responsible for logging error responses from the EVSS API.  This also writes to our temp log file under the hood.
+ - Submission Failover logging
+ - `vets-api/app/models/form526_submission.rb` is the entry point for all of our submission and failover code.  
+ - TODO: This is the place to start for gaining a deeper understanding of how our submission / failover works.
+ - Our failover has logging peppered throughout it, which again writes to the temp log file for scraping.
 
 #### The difference between logging and error raising
 
@@ -70,73 +70,73 @@ We have four apparent paradigms, which is actually all logging to the same place
 These were previously silent failures.  We now have a stopgap (aka our failover solution)  in place that is far better (~600 failures per week to ~1 per week), however our goal is a 100% success rate.  
 
 The failover will kick in once the submission delivery worker (encapsulated here) fails.  We have two distinct failure states, defined as `retryable` and `non_retryable`.  
-  * `retryable` are ones that, if you keep trying, may have a chance at succeeding. Such as network issues (timeout errors, downstream services temporarily down or unreachable, etc).
-    * If the error we get back is retryable, we retry (up to 14 times, or until it is successful). If we exhaust all 14, then backup path.
-  * `non_retryable` errors are errors that we know, no matter how many times we retry the submission, it will never succeed (without direct human interaction or changes in further downstream services).  Examples of this would be a "fraud-lock" on the veterans account, or the further backend systems having a mismatching SSN, or file number for the veteran vs what we are providing.
-    * If we get a `non_retryable` error, we just bail right away, stop trying, and go the backup path right away. We know it will not succeed, so instead of wasting a day trying, just send it now, essentially.
+ - `retryable` are ones that, if you keep trying, may have a chance at succeeding. Such as network issues (timeout errors, downstream services temporarily down or unreachable, etc).
+   - If the error we get back is retryable, we retry (up to 14 times, or until it is successful). If we exhaust all 14, then backup path.
+ - `non_retryable` errors are errors that we know, no matter how many times we retry the submission, it will never succeed (without direct human interaction or changes in further downstream services).  Examples of this would be a "fraud-lock" on the veterans account, or the further backend systems having a mismatching SSN, or file number for the veteran vs what we are providing.
+   - If we get a `non_retryable` error, we just bail right away, stop trying, and go the backup path right away. We know it will not succeed, so instead of wasting a day trying, just send it now, essentially.
 
 **NOTE:**
-We never generate our own 526 form. We either submit the DATA from the submission, to EVSS, who turns that data into a call to downstream systems to establish the claim directly in the backend system (the normal regular functionality), or we use that same data to ask EVSS to generate a 526 PDF for us. **Unlike the other forms, we do not ever generate a 526 paper form ourselves (vets-api)**
+We never generate our own 526 form. We either submit the DATA from the submission, to EVSS, who turns that data into a call to downstream systems to establish the claim directly in the backend system (the normal regular functionality), or we use that same data to ask EVSS to generate a 526 PDF for us.-*Unlike the other forms, we do not ever generate a 526 paper form ourselves (vets-api)**
 
-In either failure case, we attempt to run the following **Failover** logic:
+In either failure case, we attempt to run the following-*Failover** logic:
 
   1. Generate support documentation PDFs.  [Our API owns this PDF generation, and this is the most relevant section of that code.](https://github.com/department-of-veterans-affairs/vets-api/blob/16e68a67c69df4c280ec1c5523d96cd25f74301b/lib/sidekiq/form526_backup_submission_process/processor.rb#L75)
-    * <img width="594" alt="Screen Shot 2023-07-06 at 3 21 00 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/9451b95c-2acb-41b4-9669-4f6b97d2ef2d">
+   - <img width="594" alt="Screen Shot 2023-07-06 at 3 21 00 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/9451b95c-2acb-41b4-9669-4f6b97d2ef2d">
 
   2. We also need to submit the actual 526 form itself. EVSS already has logic to PDF-ify this, so in the event of a failure we will request this PDF from them.  [This is documented along with other 3rd party communications here.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
-    * <img width="630" alt="Screen Shot 2023-07-06 at 3 21 47 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/5a23df9a-9e4c-425e-b27c-5b8694ebd7f2">
+   - <img width="630" alt="Screen Shot 2023-07-06 at 3 21 47 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/5a23df9a-9e4c-425e-b27c-5b8694ebd7f2">
   
   3. Once we have these PDFS, we send them to Lighthouse, specifically the Benefits Claims Intake API, [via this a new worker](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/sidekiq/form526_backup_submission_process/submit.rb)
-    * <img width="701" alt="Screen Shot 2023-07-06 at 3 22 08 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/198b0248-3cb4-473b-a664-71a1af7b656e">
+   - <img width="701" alt="Screen Shot 2023-07-06 at 3 22 08 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/198b0248-3cb4-473b-a664-71a1af7b656e">
 
   4. If the Backup worker fails, we log the failure, [as seen here](https://vagov.ddog-gov.com/logs?query=%22FORM526%20BACKUP%20SUMBISSION%20FAILURE.%20In[…]=stream&from_ts=1684334801686&to_ts=1686926801686&live=true)
-    * <img width="713" alt="Screen Shot 2023-07-06 at 3 22 31 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/7f950e82-9aea-412d-a192-be0be9bcc8cc">
-    * <img width="714" alt="Screen Shot 2023-07-06 at 3 23 01 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/dd8d547e-81f3-4c6d-92b4-d5ddb7ed724f">
+   - <img width="713" alt="Screen Shot 2023-07-06 at 3 22 31 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/7f950e82-9aea-412d-a192-be0be9bcc8cc">
+   - <img width="714" alt="Screen Shot 2023-07-06 at 3 23 01 PM" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/15328092/dd8d547e-81f3-4c6d-92b4-d5ddb7ed724f">
 
 In the event of the last case, where all submission has failed, there is no immediate alerting.  However, we do include this information in a weekly report to the VA.  These failures are not differentiated from other, historical failures, and they will simply and in line, like the other 40,000 or so claims that have failed over the years, to be batch/bulk re-established, via whatever method the VA decides upon.
 
 A potential area of improvement would be allowing us to reprocess these manually via our submission logic (basically reattempt the BACKUP submission)... and adding a retry to the backup job may resolve some of these. This has not been added yet.
 
 ### Action items for ongoing error handling
-  * Use good form for logging.  Follow the convention of using `Sentry` with tags on the front end and `Rails.logger` on the back end.
-  * We should have a standard (style guide?) for what we log, how we log it, tag it, etc.  Right now it’s up to the developer to decide how much or how little context to pass to the `Rails.logger`
-  * Syntactic anomalies aside, we are using two drastically different approaches to error logging in our BE, i.e. Feature level logging vs Middleware level logging.  We might consider moving in one direction or the other for external API calls.
+ - Use good form for logging.  Follow the convention of using `Sentry` with tags on the front end and `Rails.logger` on the back end.
+ - We should have a standard (style guide?) for what we log, how we log it, tag it, etc.  Right now it’s up to the developer to decide how much or how little context to pass to the `Rails.logger`
+ - Syntactic anomalies aside, we are using two drastically different approaches to error logging in our BE, i.e. Feature level logging vs Middleware level logging.  We might consider moving in one direction or the other for external API calls.
 
 ### Action items for ongoing Failover improvement
-Improving on submission failover is a high priority.  Previously we had an issue where submissions were failing on a Sidekiq worker with no retrying, and little or no logging.  We currently have a failover solution that needs documentation, however it could be summarized as  **“If we fail X retries of this job fail, then make a PDF out of this information and email it to the appropriate entity.”**
+Improving on submission failover is a high priority.  Previously we had an issue where submissions were failing on a Sidekiq worker with no retrying, and little or no logging.  We currently have a failover solution that needs documentation, however it could be summarized as -*“If we fail X retries of this job fail, then make a PDF out of this information and email it to the appropriate entity.”**
 Action Items:
-  * Identify systemic issues e.g. some services are not available at certain times of day.
-    * These are mostly subsystems of EVSS and beyond our control.
-    * This may correspond to some of the contemporaneous failure spikes [documented here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152).  
-  * Document our current failover solution. [This will require digging through some code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/form526_submission.rb).
-  * Investigate EVSS validation failures that could be prevented by FE validations.
-    * [This thread in Slack](https://dsva.slack.com/archives/C1VBAHWQL/p1686785454385369) provides some relevant context on EVSS form validations and specifically how / where we can go about asking what validations exist and possibly getting them changed.
-  * Synthesize the following smattering of existing issues into actionable ticket work.
-    * Happy path failures (Sidekiq retries / pre-failover)
-      * [DataDog 1](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation?from_ts=1685984856415&to_ts=1686589656415&live=true)
-      * [DataDog 2](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20%22Form526%20Exhausted%22%2[…]c3%3A56&from_ts=1685985062267&to_ts=1686589862267&live=true)
-    * Sad path messages (Manual PDF creation)
-      * [DataDog 3](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation?from_ts=1685984856415&to_ts=1686589656415&live=true)
-  * [Investigate documented bugs, primarily from the EVSS Error Middleware](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board)
-    * TODO: This is the place to start for debugging lost form submissions.
-    * [This document is potentially relevant, as we are seeing grouping of failures](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152)
-    * Look at common bugs e.g. “the 15001 error” and see if there could be a dummy simple solution 
+ - Identify systemic issues e.g. some services are not available at certain times of day.
+   - These are mostly subsystems of EVSS and beyond our control.
+   - This may correspond to some of the contemporaneous failure spikes [documented here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152).  
+ - Document our current failover solution. [This will require digging through some code](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/form526_submission.rb).
+ - Investigate EVSS validation failures that could be prevented by FE validations.
+   - [This thread in Slack](https://dsva.slack.com/archives/C1VBAHWQL/p1686785454385369) provides some relevant context on EVSS form validations and specifically how / where we can go about asking what validations exist and possibly getting them changed.
+ - Synthesize the following smattering of existing issues into actionable ticket work.
+   - Happy path failures (Sidekiq retries / pre-failover)
+     - [DataDog 1](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation?from_ts=1685984856415&to_ts=1686589656415&live=true)
+     - [DataDog 2](https://vagov.ddog-gov.com/logs?query=service%3Avets-api%20%22Form526%20Exhausted%22%2[…]c3%3A56&from_ts=1685985062267&to_ts=1686589862267&live=true)
+   - Sad path messages (Manual PDF creation)
+     - [DataDog 3](https://vagov.ddog-gov.com/dashboard/ygg-v6d-nza/form-526-disability-compensation?from_ts=1685984856415&to_ts=1686589656415&live=true)
+ - [Investigate documented bugs, primarily from the EVSS Error Middleware](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board)
+   - TODO: This is the place to start for debugging lost form submissions.
+   - [This document is potentially relevant, as we are seeing grouping of failures](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152)
+   - Look at common bugs e.g. “the 15001 error” and see if there could be a dummy simple solution 
 
 ## Misc Tips
-  * To see the full lifecycle of a form submission, search DataDog by the forms submission_id
-    * E.G. `service:vets-api @named_tags.dd.env:eks-prod @payload.submission_id:1982049`
-    * TODO: Where does `submission_id` come from?
-  * The classname `Sidekiq/EVSS::DisabilityCompensationForm::SubmitForm526AllClaim` can be searched in sentry to see all of the relevant logs
-  * Most of the new error reporting we do will be manually added to code in the application layer.  Keep in mind that we also have middleware logging responses from EVSS.
+ - To see the full lifecycle of a form submission, search DataDog by the forms submission_id
+   - E.G. `service:vets-api @named_tags.dd.env:eks-prod @payload.submission_id:1982049`
+   - TODO: Where does `submission_id` come from?
+ - The classname `Sidekiq/EVSS::DisabilityCompensationForm::SubmitForm526AllClaim` can be searched in sentry to see all of the relevant logs
+ - Most of the new error reporting we do will be manually added to code in the application layer.  Keep in mind that we also have middleware logging responses from EVSS.
 
 ## Resources
 ### Slack threads:
-  * [Thomas -> Kyle: “how do we look up 526EZ errors in logs?”](https://dsva.slack.com/archives/C053U7BUT27/p1686588415725609)
-  * [Sam (via Kyle) -> Carbs: “some additional locations in the code for KPI consideration”](https://dsva.slack.com/archives/C053U7BUT27/p1686836358577259)
-  * [Seth -> Team: “I have some questions about EVSS API validations”](https://dsva.slack.com/archives/C1VBAHWQL/p1686785454385369)
+ - [Thomas -> Kyle: “how do we look up 526EZ errors in logs?”](https://dsva.slack.com/archives/C053U7BUT27/p1686588415725609)
+ - [Sam (via Kyle) -> Carbs: “some additional locations in the code for KPI consideration”](https://dsva.slack.com/archives/C053U7BUT27/p1686836358577259)
+ - [Seth -> Team: “I have some questions about EVSS API validations”](https://dsva.slack.com/archives/C1VBAHWQL/p1686785454385369)
 
 ### Documentation:
-  * [Our Bug Board with errors related EVSS API failures](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board)
-  * [Git issue describing contemporaneous groupings of form submission failures](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152)
-  * [Kyles KPIs for 526 error handling](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
-  * [Most relevant code for 526 submissions and failover](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/form526_submission.rb)
+ - [Our Bug Board with errors related EVSS API failures](https://app.zenhub.com/workspaces/526ez-bugs-and-defects-646e4436ff6787001ac4771a/board)
+ - [Git issue describing contemporaneous groupings of form submission failures](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60152)
+ - [Kyles KPIs for 526 error handling](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
+ - [Most relevant code for 526 submissions and failover](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/models/form526_submission.rb)

--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/02_loose_ends_and_next_steps.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/02_loose_ends_and_next_steps.md
@@ -1,67 +1,70 @@
-# 526 Submission Stabilization Next Steps
+# Loose End round up and Next steps for 526 stabilizing
+[Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/60565)
 
-(Ticket)[https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/60565]
-## Purpose:
-Gather documentation to the effect of 526 submission error handling atm, summarize, and qualify each.
-Synthesize most salient data available to us to date in regards to 526 submission errors, logging, and fixes
-Define clear action items to improve submission success. 
+## Purpose
+- Gather documentation to the effect of 526 submission error handling atm, summarize, and qualify each.
+- Synthesize most salient data available to us to date in regards to 526 submission errors, logging, and fixes.
+- Define clear action items to improve submission success.
 
-## Questions:
-What are the potential pitfalls of our “paper” back up submission?
-[TODO] will this create a longer wait time? Potentially longer time to get the claim established. WIth the backup submission process, the claim is sent to the Centralized Mail Portal, which scans claims to see if they meet automation requirements. Those that don’t will go through manual establishment. (via Sade)  Yes, this will make waits longer.  Additionally we add an unmitigatable point of potential failure when we add humans into the process. (via Kyle)
-[TODO] Will this impact a vets ability to use online services in the future? The backup submission process does not impact the Veteran’s ability to use online services in the future. (via Sade)
-Can we set, as an axiom, that form validations to ensure EVSS acceptance are worthwhile, vs saying “no worries, paper
-TODO: check with product after we find out the above
-What do KPIs mean, specifically, in regards to Kyle’s previous git document?
+## Questions
+- What are the potential pitfalls of our “paper” back up submission?
+  - [TODO] will this create a longer wait time? Potentially longer time to get the claim established. WIth the backup submission process, the claim is sent to the Centralized Mail Portal, which scans claims to see if they meet automation requirements. Those that don’t will go through manual establishment. (via Sade)  Yes, this will make waits longer.  Additionally we add an unmitigatable point of potential failure when we add humans into the process. (via Kyle)
+  - [TODO] Will this impact a vets ability to use online services in the future? The backup submission process does not impact the Veteran’s ability to use online services in the future. (via Sade)
+- Can we set, as an axiom, that form validations to ensure EVSS acceptance are worthwhile, vs saying “no worries, paper
+  - TODO: check with product after we find out the above
+- What do KPIs mean, specifically, in regards to [Kyle's previous git document](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)?
 
-Existing Documentation:
-State of 526 Error Handling and Fallback summary as of June 2023
-takes a high level look at how we are reporting errors and how we should be reporting errors in the current ecosystem
-Highlevel look at our fallback solution
-Defines the following relevant action items:
-Add manual / automatic retries to “paper” submission fallback
-Align our FE validations with EVSS validations
-Create architecture diagram of submission and fallback flow
-Improve error reporting and logging around submission and fallback flow
-Assess code and Identify KPIs (by Kyle Soskin)
-Resultant artifact of this epic
-[TODO] what exactly does “KPIs” mean here? KPIs in this context means “If all is well, these are the things that should happen.”  The work here is to logging that give us clarity into the health of these parts of the app.
-Open Issue
-The ask is to implement logging.  
-[TODO] clarify what that means. The work here is squaring up the identified KPIs (via Kyle) with our logging expectations.  Some stuff will be covered, other stuff needs coverage, and there may be areas for improvement
+## Existing Documentation 
+- [State of 526 Error Handling and Fallback summary as of June 2023](https://docs.google.com/document/d/1IIRz1og52BRLxkAPmowHJRxX8POlBK1zWt3dtWewTHM/edit#heading=h.4pz3vouh89o5)
+  - Takes a high level look at how we are reporting errors and how we should be reporting errors in the current ecosystem
+  - Highlevel look at our fallback solution
+  - Defines the following relevant action items:
+    - Add manual / automatic retries to "paper" submission fallback
+    - Align our FE validations with EVSS validations
+    - Create architecture diagram of submission and fallback flow
+    - Improve error reporting and logging around submission and fallback flow
+- [Assess code and Identify KPIs (by Kyle Soskin)](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
+  - [Resultant artifact of this epic](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57473)
+  - [TODO] what exactly does “KPIs” mean here? KPIs in this context means “If all is well, these are the things that should happen.”  The work here is to logging that give us clarity into the health of these parts of the app.
+- [Open Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57500)
+  - The ask is to implement logging.
+    - [TODO] clarify what that means. The work here is squaring up the identified KPIs (via Kyle) with our logging expectations.  Some stuff will be covered, other stuff needs coverage, and there may be areas for improvement
+## Next Steps: 
+- Add / validate logging, [as described in the open issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57500), to [the places identified by Kyle here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57489)
+  - There is (probably) way more than one sprint worth of work described in this ticket.  If that is the case, break it down.
+- Datadog logging is already good.  Sentry error reporting could be better.  Investigate ways to make Sentry errors, scoped to form submission, more verbose.  This may require getting better errors from EVSS.
+  - This work is blocked by my datadog access.  I need more insight into what information we have before I start trying to improve a siloed portion of it.
+## Follow up: 
+The next step, as recommend here was to engage this ticket [526ez | Implement Logging and Monitoring](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/57500), and start iterating on actual logging.  This lead to a bit of a follow-up discovery with the tickets criteria.  As noted below, the acceptance criteria has been labeled in-scope, out-of scope, and open questions.
+### The acceptance criteria from the original ticket:
+- The log data includes relevant information (example: IP address, timestamp, and form input data).
+  - Need to see what’s in here, but this will probably be configuring Rails logger, or wrapping Rails logger in an object?
+    - This will be answered in [the proof of concept ticket here](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/60944)
+  - Need something to be inscope, so let’s start here by wrapping one of the KPI actions in a log
+- The log data is stored in a secure and scalable manner, and is easily searchable and accessible to authorized personnel.
+  - Datadog pretty much has this covered, so this feels out of scope.
+- The logging system generates alerts for any errors or unexpected behavior, such as user input that exceeds acceptable limits or failed form submissions.
+  - First pass should be getting data into the logs, we can configure alerts later.
+  - We might need to pass extra data into the logs for alerting, but this feels like an edge case.  Also, as a proof of concept it makes more sense to just start logging and iterate.
+- The alerts are sent to relevant team members via email or other appropriate channels, with clear information about the nature of the issue and how to resolve it.
+  - Alerting if V2
+-  A dashboard has been created to display the log data and facilitate analysis and monitoring of user behavior and performance.
+   - V2
+-   The dashboard allows for easy filtering and aggregation of log data to identify patterns and trends over time.
+    - V2
+-   The dashboard includes clear visualizations of the data, such as charts or graphs, to facilitate easy interpretation and analysis.
+    - V2
+-  The dashboard allows for drill-down into the data to identify specific areas for improvement and track progress at the user or form level.
+   -  V2
+-  Regular reports are generated and shared with the relevant stakeholders, summarizing performance and highlighting any areas for improvement or concern
+   - Feels like dev ops work imho
+### Takeaway
+The old ticket is basically obsolete.  It made sense to round up all of the findings from this document and the initial investigation into an epic with actionable sub-tasks.  [This is that epic.](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/60952)
+      
 
 
-Next Steps:
-Add / validate logging, as described in the open issue, to the places identified by Kyle here
-There is (probably) way more than one sprint worth of work described in this ticket.  If that is the case, break it down.
-Datadog logging is already good.  Sentry error reporting could be better.  Investigate ways to make Sentry errors, scoped to form submission, more verbose.  This may require getting better errors from EVSS.  
-This work is blocked by my datadog access.  I need more insight into what information we have before I start trying to improve a siloed portion of it.
 
-Follow up:
-The next step, as recommend here was to engage this ticket 526ez | Implement Logging and Monitoring, and start iterating on actual logging.  This lead to a bit of a follow-up discovery with the tickets criteria.  As noted below, the acceptance criteria has been labeled in-scope, out-of scope, and open questions
-The acceptance criteria from the original ticket:
-The log data includes relevant information (example: IP address, timestamp, and form input data).
-Need to see what’s in here, but this will probably be configuring Rails logger, or wrapping Rails logger in an object?
-This will be answered in the proof of concept ticket here
-Need something to be inscope, so let’s start here by wrapping one of the KPI actions in a log
-The log data is stored in a secure and scalable manner, and is easily searchable and accessible to authorized personnel.
-Datadog pretty much has this covered, so this feels out of scope.
-The logging system generates alerts for any errors or unexpected behavior, such as user input that exceeds acceptable limits or failed form submissions.
-First pass should be getting data into the logs, we can configure alerts later. 
-We might need to pass extra data into the logs for alerting, but this feels like an edge case.  Also, as a proof of concept it makes more sense to just start logging and iterate.
-The alerts are sent to relevant team members via email or other appropriate channels, with clear information about the nature of the issue and how to resolve it.
-Alerting if V2
- A dashboard has been created to display the log data and facilitate analysis and monitoring of user behavior and performance.
-V2
- The dashboard allows for easy filtering and aggregation of log data to identify patterns and trends over time.
-V2
-The dashboard includes clear visualizations of the data, such as charts or graphs, to facilitate easy interpretation and analysis.
-V2
- The dashboard allows for drill-down into the data to identify specific areas for improvement and track progress at the user or form level.
-V2
- Regular reports are generated and shared with the relevant stakeholders, summarizing performance and highlighting any areas for improvement or concern.
-Feels like dev ops work imho
 
-Takeaway
 
-The old ticket is basically obsolete.  It made sense to round up all of the findings from this document and the initial investigation into an epic with actionable sub-tasks.  This is that epic.
+
+

--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/02_loose_ends_and_next_steps.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/02_loose_ends_and_next_steps.md
@@ -1,0 +1,67 @@
+# 526 Submission Stabilization Next Steps
+
+(Ticket)[https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/60565]
+## Purpose:
+Gather documentation to the effect of 526 submission error handling atm, summarize, and qualify each.
+Synthesize most salient data available to us to date in regards to 526 submission errors, logging, and fixes
+Define clear action items to improve submission success. 
+
+## Questions:
+What are the potential pitfalls of our “paper” back up submission?
+[TODO] will this create a longer wait time? Potentially longer time to get the claim established. WIth the backup submission process, the claim is sent to the Centralized Mail Portal, which scans claims to see if they meet automation requirements. Those that don’t will go through manual establishment. (via Sade)  Yes, this will make waits longer.  Additionally we add an unmitigatable point of potential failure when we add humans into the process. (via Kyle)
+[TODO] Will this impact a vets ability to use online services in the future? The backup submission process does not impact the Veteran’s ability to use online services in the future. (via Sade)
+Can we set, as an axiom, that form validations to ensure EVSS acceptance are worthwhile, vs saying “no worries, paper
+TODO: check with product after we find out the above
+What do KPIs mean, specifically, in regards to Kyle’s previous git document?
+
+Existing Documentation:
+State of 526 Error Handling and Fallback summary as of June 2023
+takes a high level look at how we are reporting errors and how we should be reporting errors in the current ecosystem
+Highlevel look at our fallback solution
+Defines the following relevant action items:
+Add manual / automatic retries to “paper” submission fallback
+Align our FE validations with EVSS validations
+Create architecture diagram of submission and fallback flow
+Improve error reporting and logging around submission and fallback flow
+Assess code and Identify KPIs (by Kyle Soskin)
+Resultant artifact of this epic
+[TODO] what exactly does “KPIs” mean here? KPIs in this context means “If all is well, these are the things that should happen.”  The work here is to logging that give us clarity into the health of these parts of the app.
+Open Issue
+The ask is to implement logging.  
+[TODO] clarify what that means. The work here is squaring up the identified KPIs (via Kyle) with our logging expectations.  Some stuff will be covered, other stuff needs coverage, and there may be areas for improvement
+
+
+Next Steps:
+Add / validate logging, as described in the open issue, to the places identified by Kyle here
+There is (probably) way more than one sprint worth of work described in this ticket.  If that is the case, break it down.
+Datadog logging is already good.  Sentry error reporting could be better.  Investigate ways to make Sentry errors, scoped to form submission, more verbose.  This may require getting better errors from EVSS.  
+This work is blocked by my datadog access.  I need more insight into what information we have before I start trying to improve a siloed portion of it.
+
+Follow up:
+The next step, as recommend here was to engage this ticket 526ez | Implement Logging and Monitoring, and start iterating on actual logging.  This lead to a bit of a follow-up discovery with the tickets criteria.  As noted below, the acceptance criteria has been labeled in-scope, out-of scope, and open questions
+The acceptance criteria from the original ticket:
+The log data includes relevant information (example: IP address, timestamp, and form input data).
+Need to see what’s in here, but this will probably be configuring Rails logger, or wrapping Rails logger in an object?
+This will be answered in the proof of concept ticket here
+Need something to be inscope, so let’s start here by wrapping one of the KPI actions in a log
+The log data is stored in a secure and scalable manner, and is easily searchable and accessible to authorized personnel.
+Datadog pretty much has this covered, so this feels out of scope.
+The logging system generates alerts for any errors or unexpected behavior, such as user input that exceeds acceptable limits or failed form submissions.
+First pass should be getting data into the logs, we can configure alerts later. 
+We might need to pass extra data into the logs for alerting, but this feels like an edge case.  Also, as a proof of concept it makes more sense to just start logging and iterate.
+The alerts are sent to relevant team members via email or other appropriate channels, with clear information about the nature of the issue and how to resolve it.
+Alerting if V2
+ A dashboard has been created to display the log data and facilitate analysis and monitoring of user behavior and performance.
+V2
+ The dashboard allows for easy filtering and aggregation of log data to identify patterns and trends over time.
+V2
+The dashboard includes clear visualizations of the data, such as charts or graphs, to facilitate easy interpretation and analysis.
+V2
+ The dashboard allows for drill-down into the data to identify specific areas for improvement and track progress at the user or form level.
+V2
+ Regular reports are generated and shared with the relevant stakeholders, summarizing performance and highlighting any areas for improvement or concern.
+Feels like dev ops work imho
+
+Takeaway
+
+The old ticket is basically obsolete.  It made sense to round up all of the findings from this document and the initial investigation into an epic with actionable sub-tasks.  This is that epic.

--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/03_third_party_action_logging_POC.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/03_third_party_action_logging_POC.md
@@ -1,0 +1,4 @@
+# Third Party Action Logging (Proof Of Concept)
+
+## Purpouse
+Document questions, decisions and considered alternatives in regards to our 

--- a/products/disability/526ez/engineering_research/error_handling_and_submission_failures/03_third_party_action_logging_POC.md
+++ b/products/disability/526ez/engineering_research/error_handling_and_submission_failures/03_third_party_action_logging_POC.md
@@ -1,4 +1,109 @@
-# Third Party Action Logging (Proof Of Concept)
+# Add Logging Around Document Upload & POC
 
-## Purpouse
-Document questions, decisions and considered alternatives in regards to our 
+[Ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/60944)
+
+## Terms
+**3PI** - “3rd party interactions,” describes an interaction between one of our services and a third party API.  
+**SCC** - “Shared Context Complexity”, described below in the “Complexity” section.
+
+## Requirements
+- Wrap our Supporting Document upload in meaningful logging
+  - Logging should be as close to the 3PI as possible to maximize desirable visibility
+    - This happens at the model level
+-  Logging must contain information as defined in the ticket
+  - Most of this is from the request
+    - E.g. ‘current user id’
+- Generate a Proof of concept.  This work will define a reusable pattern for the remaining 14 epic tickets.
+
+## Primary Complexity
+
+We have Model level actions that need logging with Controller level information.  Logging request level information from the model level presents the challenge of maintaining OO encapsulation while working with this shared context.  This complexity will be referred to herein as the “SCC”, or “shared context complexity”, meaning the difficulty around using context from the controller level in model level logging without coupling the two layers.
+
+This is not just an academic concern.  Given our use of inheritance in the affected models and composition in the affected controllers, we will be touching widely reused code in this feature implementation.  Breaking encapsulation principles risks introducing unexpected behavior elsewhere in the application by giving context to an object in one place that does not exist elsewhere.
+
+## Options
+
+### Option 1: The “middle man”
+
+Here we address the SCC by creating an isolated context in which to make the controller level data available to an object that is capable of initiating model level actions. 
+
+wipn-image
+
+#### Pros
+- Shared context without breaking coupling
+- Reusable
+- Relies on established OOD pattern (Service Object)
+#### Cons
+- Would require a wider refactor of how we call the 3PIs from within the model.  In order to call form.upload_method, ‘upload_method needs to be publicly available on the instance of FormClass.  This would be a relatively simple refactor, except that FormClass is part of an inheritance chain that wraps our ‘upload_method’ in other methods.  Breaking out the upload_method would require changing the way all FormObjects (not just in 526) work.  That would be out of scope and dangerous.
+#### Decision
+Ultimately the refactor required on FormClass is too invasive to consider for this work.
+
+### Option 2: The “Context Decorator”
+In this option, we wrap the FormClass in a decorator at instantiation and pass the shared context to the decorator object, thus making it available to model without violating the models encapsulation.
+
+wipn-image
+
+#### Pros
+- Model has no idea what’s changed
+- No Model refactoring
+#### Cons
+- Requires refactoring and monkey patching of controller logic. Minimal but not ideal.  The controller is (like the model) using some shared logic, this time in the form of composition (FormAttachmentCreate module).  Here, in order to wrap the FormClass instantiation we would need to refactor the existing shared logic so the instantiation happened in a helper method.  Then we would need to monkey patch that helper method in the controller that leverages the FormAttachmentCreate logic in order to insert our decorated object.  
+- Requires monkey patching of Model logic.  Once we have successfully wrapped our object in our decorator, we still need the decorator to overwrite the bit of the model logic that actually initializes the 3PI.  In order to do that we would again be refactoring the parent model’s 3PI into a helper method and overwriting that method in the wrapped object in order to insert before and after logging.  This is problematic because  Decorators in Rails (SimpleDelegator) don't support overwriting helper methods, and it would be an anti-pattern to boot. 
+#### Variation
+- I considered making this work with before and after hooks instead of monkey patching.  This would be (arguably) better in that we wouldn’t be rewriting code, but still an anti-pattern in that one object would be attempting to hook into the private workings of another.  Also, rails lifecycle hooks are not intended to work with private methods, which is a whole can of worms.
+#### Decision
+Same problem as before, where I’m getting too invasive, bending / breaking the rules of OOD, with not a ton of pay off.
+
+Option 3: Manual insertion of logging into the FormClass
+In this option, we simply crack open the model an wrap our desired action in some logging.  
+
+
+Pros
+Easy to implement
+Easy to understand
+Cons
+Breaks encapsulation.  We would need to pass controller level logging into the model.
+Would affect all form attachments.  This is a con-light, because really the added logging site wide would be kinda nice.  However, modifying shared code (remember that ‘FormClass’ is a hypothetical representation of a more complex inheritance model) feels dangerous, especially in light of the aforementioned encapsulation concerns.
+Not a reusable pattern.  One of our goals is to have something to point at and say “do this for each 3PI”.  This manual addition of start_logging and stop_logging methods all over the code would be unwieldy to maintain.
+Variation
+One promising solution to the 3rd con above (lack of reusability) would be to create a logging module that will dynamically monkey patch methods with start / stop logging calls.  E.G. 
+
+
+Decision
+There are some good and bad bits here.  This is a decent fallback if we need to ship something ASAP and can’t come up with something better.
+
+Option 4: Break Logging into smaller chunks
+In this option we simply log controller level data from the controller action, then inside the model when we are actually calling the 3PI we add more logs around that more specific action.  We could possibly even skip the model level logging and just log from the controller, however i think the model level logs, even without context could be nice pointers for future debugging when we wonder “did we even make it to the 3PI before this broke?”
+
+
+Pros
+Eliminates SCC!
+More info is… better?
+Easy to understand
+Easy to implement
+Cons
+More info is… worse? Is it Kruft?  Duplication?
+Data separation. 
+DataDog mitigates this by dynamically grouping process IDs (I think).  This means, theoretically if you are looking at one of these 4 logs, you should be able to easy and intuitively navigate to the other 3
+Lot’s of code duplication. 
+Would affect objects and actions beyond the scope of our Form, due to the inheritance / composition in our controller and model levels.
+Variations
+Hybrid this with the composition based shared logging module.
+This may seem to be over engineering for a first pass, except that one of our stated goals with this POC work is to define a reusable pattern.  The subsequent tickets could be as easy as adding 2 - 4 lines of code per 3PI, which would make future proofing and iterating a breeze.
+Would remove code duplication.
+Composition mitigates (in the controller) unintended affectation of out of scope actions.
+Decision
+This feels like the “simple and clear” path, so despite its potential “krufty-ness” it is the path that I am currently pursuing.  Additionally, the variation with a reusable logging architecture, while slower to implement, will massively reduce code duplication, future development time, and possible points of failure.
+
+Option 5: Monkey Patch CarrierWave with Middleware logging
+Including this for completeness. This was my first instinct, but upon further thought it breaks down so completely as to not really warrant much discussion, however, quickly…
+Hard to understand.
+Hard to maintain.
+Hard to debug.
+Hard to implement (context passing would be a nightmare, if even possible.)
+
+Next steps
+Continue POC implementation of option 4, then refactor it into reusable pattern using the plug-and-play logging module pattern.
+
+
+The WIP branch

--- a/products/disability/526ez/engineering_research/proposal_to_remove_raven_gem.md
+++ b/products/disability/526ez/engineering_research/proposal_to_remove_raven_gem.md
@@ -1,0 +1,47 @@
+# Proposal to refactor SentryLogging (remove Raven)
+
+## NOTE!!!
+I’m not proposing getting rid of Sentry logging, this proposal is for the refactoring of a module called SentryLogging.  The naming is confusing, but this is an important distinction to keep in mind.  We are not yet in a position to get rid of Sentry or Grafana, even though word on the street is they will eventually be marginalized in favor of DataDog.
+## What:
+SentryLogging is a module that wraps Raven, a gem which allows us to log directly to sentry.
+## Why is it there:
+According to Kevin Duesing and Kyle Soskin, Sentry was originally the non-platform Dev logging solution.  Once upon a time, Platform wanted to keep DataDog info to themselves, so we sent logs to Grafana and Sentry. More context
+## Why it’s not longer useful:
+- It actually logs to the Rails logs, then to Sentry, and in many cases re-raises the error.  So at best we are polluting Sentry with redundant kruft. (see the code here)
+- Assumptions worth noting, but not deal breakers if they don’t happen:
+  - We are now giving DataDog access to all users. 
+  - Grafana is Deprecated in favor of DataDog. 
+# Why it’s actually harmful:
+- Our current logging best practice is to use Rails.logger, which writes to a log file which is then parsed to both DataDog AND Sentry.  Writing directly to Sentry breaks this convention and creates disparate sources of truth.  
+- Sentry will catch 100% of errors that are raised in our API.  The convention of catching errors and quietly logging them with SentryLogging is an anti-pattern that allows for the following failures
+  - SentryLogging & Raven fail to connect to Sentry and the error is not logged.
+  - The error is logged with the incorrect level, e.g. warn instead of alert
+  - Code gets changed and the SentryLogging call is accidentally subverted, removed, broken, etc. 
+- The fork we are using isn’t actively maintained, possibly out of sync
+  - Sentry-ruby is regularly maintained.  Migrating would probably be a medium lift, but why??
+  - The Nate Berkopec-authored fork we are using, sentry-raven is way deprecated (2013).  It seems likely given that we are on version 2.13 of the gem, that sentry-raven (fork) is actually pulling from sentry-ruby (master)?  Requires more investigation but either way this indirection isn’t rad.
+## How hard would it be to remove completely:
+- Not at all.  If we pulled out every single instance of SentryLogging and replaced it with Rails.logger, the exact same data would still be going to Sentry, but it would also be going to DataDog
+  - This needs hard confirmation, but is apparently correct.
+- Several small, sane PR.s
+  - **Refactor**: Remove Raven.
+    - Refactor Raven tag setting to Rails.logger metadata setting
+    - Remove all references to Raven
+    - This is probably the only real lift of the batch
+  - **Rename**: Second, we go through and update naming conventions 
+    - so the SentryLogger just becomes something like GlobalLogger 
+    - methods like log_to_sentry become something like write_to_global_logs.
+    - This is very easy.
+  - **Encapsulate**: Third, over time, normalize our usage.  If it makes sense to have a proprietary Rails.logger wrapper (which I think it does), then we can slowly refactor explicit calls to Rails.logger into GlobalLogger
+    - Encapsulation makes our logging much more testable.
+    - Encapsulation would make it easy to have a ‘logging health’ dashboard that specifically tests the health of our logging ecosystem!  This may be redundant, but is a cool idea.
+- I would estimate one dev, 3 sprints at most, probably / possibly less.
+## What would the benefits be:
+- Improved error coverage in sentry.  Less chance of “Black Holes”
+- Improved coverage with DataDog.  DataDog is MUCH better at organizing logs than Sentry, because Sentry was not originally intended to be a logs platform.  Sentry requires manual tagging of data dashboard configuration, whereas DataDog dynamically associates like data, making dense logs highly traversable.
+- Less proprietary code / less potential points of failure. 
+- Possibility of “logging health” insights and alerts.
+
+## Outstanding Questions:
+- What is the latency introduced by the log scraper?  Would that be a reason to keep direct-to-sentry logging?
+


### PR DESCRIPTION
Transfer these documents out of Google docs
- [first pass of research on error handling and logging](https://docs.google.com/document/d/1IIRz1og52BRLxkAPmowHJRxX8POlBK1zWt3dtWewTHM/edit)
- [loose ends and action items (second pass)](https://docs.google.com/document/d/1ky3-BDC8Cteq5Cr--2PcaVnBiCavOIzl5feLT4mXXNY/edit)
- [third pass, engineering design doc for proof of concept](https://docs.google.com/document/d/1raA--MtiOrohMXEQb808f3ec4BBlSmT5-vjrlYXONpQ/edit#heading=h.fasg02nqleql)
- [proposal to homogenize our logging by removing the Raven gem from vets API](https://docs.google.com/document/d/1_ukVIZ546n0i8ZPZDr1GycNZMFI09jo1pUOl-kKSdb0/edit)