### PR TITLE
57968 validate public key for socks requests

### DIFF
--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -39,6 +39,14 @@ jobs:
         shell: bash
         run: |
           echo "::error:: You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY"
+      - name: Comment issue
+        if: ${{ failure() }}
+        uses: KeisukeYamashita/create-comment@v1
+        with:
+          token: ${{ secrets.VA_VSP_BOT_GITHUB_TOKEN }}
+          number: 61366
+          comment: |
+            ::error:: The attached ssh key failed to validate
 
   start_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -41,6 +41,7 @@ jobs:
 
   start_workflow:
     runs-on: ubuntu-latest
+    needs: validate_ssh_key
     name: Start workflow in devops repo
     if: contains(github.event.issue.title, 'SOCKS access')
     steps:

--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -35,9 +35,9 @@ jobs:
         run: ssh-keygen -lf /dev/stdin <<< "$PUBLIC_KEY"
       - name: Notify failure
         id: ssh_key_invalid
-        shell: bash
-        run: "echo \"You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY\""
         if: ${{ failure() }}
+        shell: bash
+        run: "echo \"::error::You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY\""
 
   start_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ failure() }}
         shell: bash
         run: |
-          echo "You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY"
+          echo "::error:: You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY"
 
   start_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -37,7 +37,8 @@ jobs:
         id: ssh_key_invalid
         if: ${{ failure() }}
         shell: bash
-        run: "echo \"::error::You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY\""
+        run: |
+          echo "You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY"
 
   start_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/pst-amt-sock-kickoff.yml
+++ b/.github/workflows/pst-amt-sock-kickoff.yml
@@ -2,11 +2,43 @@ name: SOCKS Issue creation kickoff Workflow
 on:
   issues:
     types: [opened, edited, reopened]
-    
+
 env:
   ISSUE_ID: ${{ github.event.issue.number }}
 
 jobs:
+  parse_ssh_key:
+    runs-on: ubuntu-latest
+    outputs:
+      ssh_key: ${{ fromJSON(steps.parse.outputs.payload)[' Public SSH Key'] }}
+    steps:
+      - name: Run Issue form parser
+        id: parse
+        uses: department-of-veterans-affairs/issue-forms-body-parser@main
+        with:
+          issue_id: ${{ github.event.inputs.issue_number }}
+          repository: ${{ env.GH_REPO_FOR_ISSUES }}
+          separator: '###'
+          label_marker_start: " "
+          label_marker_end: "\n"
+  validate_ssh_key:
+    runs-on: ubuntu-latest
+    needs: parse_ssh_key
+    env:
+      PUBLIC_KEY: "${{ needs.parse_ssh_key.outputs.ssh_key }}"
+    if: |
+      needs.parse_ssh_key.outputs.ssh_key != ''
+    steps:
+      - name: Run ssh public key validation
+        id: fingerprint
+        shell: bash
+        run: ssh-keygen -lf /dev/stdin <<< "$PUBLIC_KEY"
+      - name: Notify failure
+        id: ssh_key_invalid
+        shell: bash
+        run: "echo \"You seem to have uploaded an invalid ssh public key: $PUBLIC_KEY\""
+        if: ${{ failure() }}
+
   start_workflow:
     runs-on: ubuntu-latest
     name: Start workflow in devops repo


### PR DESCRIPTION
## Description

This PR adds ssh-key validation to the gh-action `pst-amt-sock-kickoff`. It runs before the socks workflow is kicked off in the devops repo and prevents it from being kicked off if the ssh-key isn't valid.

## Related Issue

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/57968

## Testing

### Locally
For testing on your local machine [act](https://github.com/nektos/act) is required:

```
brew install act
```

Once act is installed create the following `event.json`, which provides the event payload:
```
cd va.gov-team 
echo '{"inputs":{"issue_number":61366}}' > event.json
```
⚠️ The issue number above is an actual issue number for an old SOCKS access request issue

Create an env variable for a github personal access token:

```
export GH_ACCESS_TOKEN=ghp_YOUR_GH_ACCESS_TOKEN_HERE
```

Now the action can be tested as follows:
```
$ act -j validate_ssh_key -W .github/workflows/pst-amt-sock-kickoff.yml \
> --container-architecture 'linux/amd64' -e input.json \
> -s GITHUB_TOKEN=$GH_ACCESS_TOKEN \
> --env GH_REPO_FOR_ISSUES=department-of-veterans-affairs/va.gov-team
```
### Integration

Please test this by creating first, a SOCKS request with an invalid ssh key, but valid in all other regards, then edit the issue and add a valid ssh key.

Don't forget to close the issue afterwards.
