### PR TITLE
59700 Update terminal access template

### DIFF
--- a/.github/ISSUE_TEMPLATE/vetsapi-argo-terminal-access.yaml
+++ b/.github/ISSUE_TEMPLATE/vetsapi-argo-terminal-access.yaml
@@ -8,7 +8,7 @@ body:
       value: |
         :warning: **_Prerequisites_**
         1. Before being granted access, the individual for whom access is requested (the "target individual") must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started their [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
-        1. The target individual MUST be able to provide proof that E-QIP questionaire has either been transmitted or been adjudicated with a favorable decision. You'll be required to submit proof below. If you have not started your E-QIP process, do NOT submit this ticket. Ask your Vendor Onboarding Representative to confirm (listed below in a dropdown).
+        1. The target individual MUST be able to provide proof that their E-QIP questionaire has either been transmitted or been adjudicated with a favorable decision. You'll be required to submit proof below. If you have not started your E-QIP process, do NOT submit this ticket. Ask your Vendor Onboarding Representative to confirm (listed below in a dropdown).
         -
         :wave: **_Instructions_**
         1. Change the **Title** to include target individual
@@ -99,7 +99,7 @@ body:
         - label: "[Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)"
   - type: checkboxes
     attributes:
-      label: Please confirm E-QIP Transmittal/Adjudication. This could be a screenshot of your Transmittal/Adjudication email, a link to another request where you've submitted this proof, etc.
+      label: Please confirm E-QIP Transmittal/Adjudication. This could be a screenshot of your Transmittal/Adjudication email, a link to another request where you've submitted this proof (i.e. AWS/SOCKS), etc.
       description: If you have not submitted your survey, do not submit this ticket. Ask your Vendor Onboarding Representative to confirm
       options:
         - label: I have attached proof that I have either transmitted my E-QIP survey or previously received a favorable decision (by including in "Additional Notes" section below)

--- a/.github/ISSUE_TEMPLATE/vetsapi-argo-terminal-access.yaml
+++ b/.github/ISSUE_TEMPLATE/vetsapi-argo-terminal-access.yaml
@@ -6,21 +6,17 @@ body:
   - type: markdown
     attributes:
       value: |
+        :warning: **_Prerequisites_**
+        1. Before being granted access, the individual for whom access is requested (the "target individual") must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started their [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        1. The target individual MUST be able to provide proof that E-QIP questionaire has either been transmitted or been adjudicated with a favorable decision. You'll be required to submit proof below. If you have not started your E-QIP process, do NOT submit this ticket. Ask your Vendor Onboarding Representative to confirm (listed below in a dropdown).
+        -
         :wave: **_Instructions_**
-        1. Before being granted access, the individual for whom access is requested (the 'target individual') must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
-        2. Change the **Title** to include target individual
-        3. Add the label used by the target individual's team (eg: `BAH-526`)
-        4. Do not remove any of the existing labels.
-        5. Prod access is highly restricted. If you need prod access, add an explanation in "Additional Notes" section.
-        6. Validate that your E-QIP process has been started with your Vendor Onboarding Representative (listed below in a dropdown). If you have not started your E-QIP process, do NOT put in a request.
-  - type: checkboxes
-    attributes:
-      label: E-QIP Transmittal Date
-      description: Have you started your E-QIP process? If not, do not submit this ticket. Ask your Vendor Onboarding Representative to confirm
-      options:
-      - label: Check this box if you have an E-QIP transmittal date.
-    validations:
-      required: true
+        1. Change the **Title** to include target individual
+        1. Add the label used by the target individual's team (eg: `BAH-526`)
+        1. Do not remove any of the existing labels.
+        1. Complete required fields and select environments you need access to.
+        1. Use the "Additional Notes" section to provide proof of E-QIP transmittal/adjudication.
+        1. Prod access is highly restricted. If you need prod access, add an explanation in "Additional Notes" section.
   - type: input
     id: requestor-name
     attributes:
@@ -37,6 +33,12 @@ body:
       placeholder: "@username"
     validations:
       required: true
+  - type: input
+    id: aws-username
+    attributes:
+      label: Your dsvagovcloud AWS user name (if applicable)
+      description: If you have previously been granted AWS access, list your dsvagovcloud AWS user name
+      placeholder: First.Last
   - type: input
     id: team-name
     attributes:
@@ -57,20 +59,6 @@ body:
       description: Provide the name and email of the Product Owner for the target individual
     validations:
       required: true
-  - type: input
-    attributes:
-      label: Your dsvagovcloud AWS user name (if applicable)
-      description: If you have previously been granted AWS access, list your dsvagovcloud AWS user name
-      placeholder: First.Last
-  - type: checkboxes
-    attributes:
-      label: ArgoCD terminal access requested for the following environments
-      description: Only choose the environments you NEED. 
-      options:
-      - label: dev
-      - label: staging
-      - label: sandbox
-      - label: production (if requesting, justify prod access in 'Additional Notes' section)
   - type: dropdown
     id: cor-name
     attributes:
@@ -84,6 +72,9 @@ body:
         - Vilay Senthep
         - Eunice Garcia
         - Delano McVay
+        - Jennifer O'Day
+        - Laurene "Reney" Cook
+        - Rolanda Copeland
         - Other - please specify in 'Additional Notes'
   - type: dropdown
     id: vendor
@@ -99,14 +90,28 @@ body:
         - Liberty IT -  Michael G. Lovejoy
         - Accenture Federal Services - Alexa Elliot
         - Other - please specify in 'Additional Notes'
-  - type: input
-    id: expiration-date
+  - type: checkboxes
     attributes:
-      label: Access Expiration
-      description: The requested access will be revoked at the start of this date. Enter a date (and time if applicable) or 'ongoing' for non-expiring access. If ongoing is selected, add a justification for this to the 'Additional Notes' field.
-      placeholder: DD-MM-YY
-    validations:
-      required: true
+      label: Please confirm if you are on the VFS Team Roster or Platform Team Roster
+      description: If you are on neither, please refer to the first step in the instructions at the top, and close this request until complete
+      options:
+        - label: "[VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)"
+        - label: "[Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)"
+  - type: checkboxes
+    attributes:
+      label: Please confirm E-QIP Transmittal/Adjudication. This could be a screenshot of your Transmittal/Adjudication email, a link to another request where you've submitted this proof, etc.
+      description: If you have not submitted your survey, do not submit this ticket. Ask your Vendor Onboarding Representative to confirm
+      options:
+        - label: I have attached proof that I have either transmitted my E-QIP survey or previously received a favorable decision (by including in "Additional Notes" section below)
+  - type: checkboxes
+    attributes:
+      label: ArgoCD terminal access requested for the following environments
+      description: Only choose the environments you NEED. 
+      options:
+        - label: dev
+        - label: staging
+        - label: sandbox
+        - label: production (if requesting, justify prod access in 'Additional Notes' section)
   - type: textarea
     id: additional-notes
     attributes:
@@ -118,15 +123,10 @@ body:
       value: |
         ---
         :heavy_minus_sign::heavy_minus_sign::heavy_minus_sign::heavy_minus_sign: All done! :heavy_minus_sign::heavy_minus_sign::heavy_minus_sign::heavy_minus_sign:
-        :x: Don't fill out anything below here :x:
   - type: checkboxes
     attributes:
-      label: User must exist in a roster before vets-api terminal access can be granted
+      label: Additional resources for Support Engineer
       description: Don't fill this part out, please
       options:
-      - label: "Search for user on the [VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)"
-      - label: "Or search for user on the [Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)"
-      - label: "If user is on a VFS team but not in the VFS Team Roster, add the 'NOT YET' label and instruct them to start the [Platform orientation process](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html)"
-      - label: "If user is on a Platform team but not on the Platform Team Roster in Confluence, add the 'NOT YET' label and instruct them to reach out to their Product Manager to be added"
-      - label: "If they included an AWS user name, check to see if their user name is listed in [iam_users.tf](https://github.com/department-of-veterans-affairs/devops/blob/master/terraform/environments/global/iam_users.tf)"
-      - label: "Comment in this issue saying which roster the user is listed in and confirming their AWS user name (if applicable)"
+      - label: "For users on a VFS team but not in the VFS Team Roster, they must start the [Platform orientation process](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html)"
+      - label: "Instructions for handling requests [here](https://vfs.atlassian.net/wiki/spaces/PTST/pages/2183037084/Backend+Support+Responsibilities#Handle-vets-api-ArgoCD-terminal-access) - Support Only"

--- a/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
+++ b/.github/ISSUE_TEMPLATE/vetsapi-sidekiq-ui-access.yaml
@@ -6,14 +6,16 @@ body:
   - type: markdown
     attributes:
       value: |
+        :warning: **_Prerequisites_**
+        Before being granted access, the individual for whom access is requested (the "target individual") must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started their [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
+        -
         :wave: **_Instructions_**
-        1. Before being granted access, the individual for whom access is requested (the 'target individual') must either be listed on the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) or have started your [Platform Orientation](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html) and be listed on the [VFS Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)
-        2. Change the **Title** to include target individual
-        3. Add the label used by the target individual's team (eg: `BAH-526`)
-        4. Do not remove any of the existing labels.
-        5. Enter required fields and select environments you need access to.
-        6. If Production access is required, please use the respective section to provide proof of E-QIP transmittal. If you have not started the E-QIP process, do not submit this ticket. Ask your Vendor Onboarding Representative to confirm.
-        7. Fill in "Additional Notes" with any information requested by the other steps.
+        1. Change the **Title** to include target individual
+        1. Add the label used by the target individual's team (eg: `BAH-526`)
+        1. Do not remove any of the existing labels.
+        1. Complete required fields and select environments you need access to.
+        1. If Production access is required, please  If you have not started the E-QIP process, do NOT submit this ticket. 
+        1. Fill in "Additional Notes" with any information requested by the other steps.
   - type: input
     id: requestor-name
     attributes:
@@ -66,12 +68,10 @@ body:
   - type: checkboxes
     attributes:
       label: Please confirm if you are on the VFS Team Roster or Platform Team Roster
-      description: If you are on neither, close this request and reach out to your Product Manager to be added
+      description: If you are on neither, please refer to the first step in the instructions at the top, and close this request until complete
       options:
         - label: "[VFS Team Roster](https://docs.google.com/spreadsheets/d/11dpCJjhs007uC6CWJI6djy3OAvjB8rHB65m0Yj8HXIw/edit?folder=0ALlyxurHpUilUk9PVA#gid=2042046665)"
         - label: "[Platform Team Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)"
-    validations:
-      required: true
   - type: checkboxes
     attributes:
       label: Sidekiq UI Access requested for the following environments


### PR DESCRIPTION
## Summary 

As an intermediate step to fully removing the pre-req of E-QIP for terminal access (and instead using SOCKS as the implicit guardian see [this ticket](https://app.zenhub.com/workspaces/platform-tech-team-support-634ebbcc35e2bc0015b382fd/issues/gh/department-of-veterans-affairs/va.gov-team/59700)) , this PR iterates on the Terminal access requests, adjusting the format and updating requirements a bit. I've also updated the Sidekiq template a bit for consistency.

Notes:
* Added explicit requirement for E-QIP proof, which is always required by Bill, vs having a checkbox that didn't suggest proof was actually required
* Removed Access Expiration section, as 3 months is all Bill will approve at this time
* Updated instructions with "Prerequisites" (and added redundancies), hoping that requesters will have met criteria before opening ticket
* Replaced checkboxes at the end of the ticket with requester-facing checkboxes (similar to Sidekiq template), that still provides links to the appropriate places, but forces user to select which one they belong to (and points them to the appropriate place if they are not on them)
* Simplified Support Engineer instructions at the bottom to just be a "reference" to related documentation.