### PR TITLE
60662 Update 526 flow diagrams for paper sync

### DIFF
--- a/products/disability/526ez/526-overall-flow.md
+++ b/products/disability/526ez/526-overall-flow.md
@@ -1,4 +1,4 @@
-## This flow is no longer up to date as of 6/12/23, up to date flow can be viewed [in VA MURAL space here](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1686768383603/3f4415dd2ddb71bbd104ebefd92a2c7b553ad792?invited=true&sender=u2905941a69b3083a009c9997).
+## Additional documentation can be viewed in the [526 Form Flow Mural](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1686768383603/3f4415dd2ddb71bbd104ebefd92a2c7b553ad792?invited=true&sender=u2905941a69b3083a009c9997).
 
 ## Legend
 
@@ -88,11 +88,14 @@ graph TD
     subgraph ChapterDetails [Chapter: Veteran Details]
 
     VetInfo --> ContactInfo[Contact Inforation]
-    ContactInfo -. BDD/OC .-> AltNames[Alternative Names]
-    ContactInfo -. 526 .-> MilitaryHx
-
+    ContactInfo --> Homeless[Homeless or at risk]
+    Homeless --> TerminallyIll[Are you terminally ill]
+    TerminallyIll -. OC .-> AltNames[Alternative Names]
+    ContactInfo -. BDD .-> AltNames
+    TerminallyIll .-> MilitaryHx
     AltNames --> MilitaryHx[Military History]
-
+    
+    
     MilitaryHx -. RNG .-> ReserveNG[Reserve National Guard Info]
     MilitaryHx -. OC, not RNG .-> PaySep
     ReserveNG --> FedOrders[Federal Orders]
@@ -475,25 +478,20 @@ graph TD
 
     PaymentInfo[Payment/bank information]
 
-    PaymentInfo -. BDD .-> VaEmployee
-    PaymentInfo --> Homeless[Homeless or at risk]
-    Homeless --> TerminallyIll[Are you terminally ill]
-    TerminallyIll --> VaEmployee[Are you a VA employee]
+    PaymentInfo --> VaEmployee[Are you a VA employee]
 
     VaEmployee -. OC & has retired pay .-> RetiredPayWaiver[Waiving retirement pay]
     RetiredPayWaiver -. has training pay .-> TrainingPayWaiver
-    RetiredPayWaiver --> FDC
+    
 
     VaEmployee -. OC & has training pay .-> TrainingPayWaiver[Waiving training pay]
-    TrainingPayWaiver --> FDC
-
-    VaEmployee --> FDC[Fully developed claim]
-
+    
     end
 
-    VaEmployee -. BDD .-> RS
-    FDC --> RS[Review & Submit]
-    RS --> Confirmation[Confirmation]
+    TrainingPayWaiver --> RS 
+    VaEmployee --> RS
+    RetiredPayWaiver --> RS
+    RS[Review & Submit] --> Confirmation[Confirmation]
 
 ```
 


### PR DESCRIPTION
Includes the following 3 changes:

1) Updated the initial description to still link to the 526 Form Flow Mural, but removed out of date note. The DBEX team intends to keep both docs up to date.

2) Updated the Veteran Details chapter diagram to move the Homeless and Terminally Ill pages (Note: the mermaid preview tool doesn't have the same colors in the dev env, but the colors should remain the same once published on gh)
![image](https://github.com/department-of-veterans-affairs/va.gov-team/assets/127446042/99a654ef-02a4-43da-ab8a-7003efc07b0b)

3) Updated the Additional Information chapter to move the Homeless and Terminally Ill pages. Also removed the Fully Developed Claim page
![image](https://github.com/department-of-veterans-affairs/va.gov-team/assets/127446042/a28f4bb0-6130-4c79-9601-fd876ed6297f)

