### PR TITLE
Update health-appointments.md

### DIFF
--- a/products/information-architecture/ia-design-docs/health-appointments.md
+++ b/products/information-architecture/ia-design-docs/health-appointments.md
@@ -24,16 +24,14 @@ Note: the URL for the after-visit summary is still TBD. It could be just an ID b
 Page | URL | Breadcrumb | Notes
 --- | --- | --- | ---
 |1. Appointments landing page | https://va.gov/my-health/appointments | VA.gov home > My HealtheVet > Appointments |
-|2. Past appointments list | https://va.gov/my-health/appointments/past | VA.gov home > My HealtheVet > Appointments > Past |
-|3. Requested appointments list | https://va.gov/my-health/appointments/requests | VA.gov home > My HealtheVet > Appointments > Requests  | 
-|4. Upcoming and cancelled appointments detail pages | https://va.gov/my-health/appointments/[ID] | < Back to appointments  | 
-|5. Past appointments detail pages | https://va.gov/my-health/appointments/past/[ID] | < Back to past appointments |
-|6. Requested appointments detail pages | https://va.gov/my-health/appointments/requests/[Request-ID] | < Back to requests |
-|7. Root scheduling URL | https://va.gov/my-health/appointments/schedule/[H1-related-title] | VA.gov home > My HealtheVet > Appointments > [H1 Page Title] |
-
-Additional URLs can be found on Sharepoint in this [excel file](https://dvagov.sharepoint.com/:x:/r/sites/HealthApartment/Shared%20Documents/Appointments/Projects/2023%20Appointments%20move%20to%20MHV%20on%20VA.gov/MVP%20-%20Appointments-FE%20IA%20update.xlsx?d=w069ea28fa90140bd9a0dbca85f8c9cf1&csf=1&web=1&e=dFUVgE).
-Reach out to Peter Russo for access.
-
+|2. Past appointments list | https://va.gov/my-health/appointments/past | VA.gov home > My HealtheVet > Appointments > Past appointments |
+|3. Pending appointments list | https://va.gov/my-health/appointments/pending | VA.gov home > My HealtheVet > Appointments > Pending appointments  | 
+|4. Confirmed appointment details page | https://va.gov/my-health/appointments/[ID]?confirmMsg=true | < Back to appointments |
+|5. Confirmed request details page | https://va.gov/my-health/appointments/pending/[ID]?confirmMsg=true | < Back to pending appointments |
+|6. Upcoming and canceled appointments detail pages | https://va.gov/my-health/appointments/[ID] | < Back to appointments  | 
+|7. Past appointments detail pages | https://va.gov/my-health/appointments/past/[ID] | < Back to past appointments |
+|8. Pending appointments detail pages | https://va.gov/my-health/appointments/pending/[Request-ID] | < Back to pending appointments |
+|9. Root scheduling URL | https://va.gov/my-health/appointments/schedule/[H1-related-title] | VA.gov home > My HealtheVet > Appointments > [H1 Page Title] |
 
 ## <a name="nav"></a>Entry points <br>
 These will be documented and updated according to the Phased Rollout Plan.
@@ -49,6 +47,7 @@ We will need to redirect all of the existing appointments and scheduling URLs to
 | VA direct schedule<br><br>VA request<br><br>CC request | Choose category of care                 | Choose where you want to receive your care     | https://staging.va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/choose-facility-type            | https://va.gov/my-health/appointments/schedule/facility-type                  |
 | CC request                                             | Choose audiology care                   | Choose the type of audiology care you need     | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/audiology                               | https://va.gov/my-health/appointments/schedule/audiology-care                 |
 | VA direct schedule<br><br>VA request                   | Choose a location                       | Choose a VA location                           | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/va-facility-2                           | https://va.gov/my-health/appointments/schedule/location                       |
+| VA direct schedule<br><br>VA request                   | Cerner location redirect                | How to schedule                                | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/how-to-schedule                         | https://va.gov/my-health/appointments/schedule/how-to-schedule                |
 | VA direct schedule                                     | Choose a clinic                         | Choose a VA clinic                             | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/clinics                                 | https://va.gov/my-health/appointments/schedule/clinic                         |
 | VA direct schedule                                     | Patient-indicated date                  | When do you want to schedule this appointment? | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/preferred-date                          | https://va.gov/my-health/appointments/schedule/preferred-date                 |
 | VA direct schedule                                     | Choose a date                           | Choose a date and time                         | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-appointment/select-date                             | https://va.gov/my-health/appointments/schedule/date-time                      |
@@ -59,6 +58,7 @@ We will need to redirect all of the existing appointments and scheduling URLs to
 | COVID vaccine                                          | COVID vaccine screener                  | Have you received a COVID-19 vaccine?          | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/confirm-doses-received | https://va.gov/my-health/appointments/schedule/confirm-covid-doses-received   |
 | COVID vaccine                                          | COVID doses received - contact facility | We can’t schedule your second dose online      | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/contact-facility       | https://va.gov/my-health/appointments/schedule/covid-contact-facility         |
 | COVID vaccine                                          | Choose a location                       | Choose a location                              | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/choose-facility        | https://va.gov/my-health/appointments/schedule/covid-location                 |
+| COVID vaccine                                          | End point: No Facilities Online         | Contact a facility                             | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/contact-facility       | https://va.gov/my-health/appointments/schedule/covid-contact-facility         |
 | COVID vaccine                                          | Choose a clinic                         | Choose a clinic                                | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/choose-clinic          | https://va.gov/my-health/appointments/schedule/covid-clinic                   |
 | COVID vaccine                                          | Choose a date                           | Choose a date                                  | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/select-date            | https://va.gov/my-health/appointments/schedule/covid-date-time                |
 | COVID vaccine                                          | Second dose info                        | When to plan for a second dose                 | https://va.gov/health-care/schedule-view-va-appointments/appointments/new-covid-19-vaccine-appointment/second-dose-info       | https://va.gov/my-health/appointments/schedule/second-dose-info               |


### PR DESCRIPTION
- Changed name of "requests" list back to "pending". Context: In the SME sync last week we decided to keep the "pending" language for the list, since we'll be looking at adding other types of pending appts like recall letters and referrals. A request for appointment made by a veteran for an appt will still be called a request.
- Added two dead-ends that have their own URLs
- Added details confirmation pages.
- Removed note to refer to working Excel file. We'll use this and the VAOS copy docs as the sources of truth