### PR TITLE
Facilities VBA Naming Schema updates

### DIFF
--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -52,7 +52,7 @@ Update from October 1, 2020:
 
 Facility type  |  Owned by  |  Official name | Name pattern | URL 
  -- | -- | -- | -- | -- 
-_Source:_<br>VAST |   | _Source:_<br>VAST |   | _Source:_<br>Facilities API
+_Source:_ VAST |   | _Source:_ VAST |   | _Source:_ Facilities API
 Regional office | Standalone | [Winston-Salem VA Regional Benefit Office](https://www.va.gov/find-locations/facility/vba_318) | [Region name] [Facility type]
 Regional office | VHA or non-VA | [Anchorage VA Regional Benefit Office at Anchorage VA Medical Center](https://www.va.gov/find-locations/facility/vba_463) | [Region name] [Facility type] at [shared location name]
 ~~Outbased office~~ | ~~VHA or non-VA~~ | ~~Regional Benefit Office at New Bedford VA Clinic (If not regional, then Benefit Office at Rochester Calkins VA Clinic.)~~ | ~~[Facility type] at [shared location name]~~

--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -46,7 +46,10 @@ Some VBA benefits facilities are standalone. Regional benefit offices are an exa
 Update from October 1, 2020:
 * VBA and OFO, the Office of Field Operations, just approved [this naming scheme](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/naming-schema/VBA-facilties-name_DRAFT-%20v9.docx). 
 * First we are updating the [names of facilities inside VA facilities](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/naming-schema/VBA%20Facility%20Names_v4.xlsx). See column E "Inside other official VA Location."
-* Next we will update the names of facilities not located inside VA facilities. 
+* Next we will update the names of facilities not located inside VA facilities.
+
+Update from September 22, 2023:
+* Updated the chart to reflect current naming schema. [See full changelog](https://github.com/department-of-veterans-affairs/va.gov-team/pull/66167)
 
 **For every example below, "at" is followed by the official location name. Official location names come from legislation, so we may not be able to change things that don't follow VA.gov style.** Example: Veterans' (should not have an apostrophe). 
 

--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -50,19 +50,19 @@ Update from October 1, 2020:
 
 **For every example below, "at" is followed by the official location name. Official location names come from legislation, so we may not be able to change things that don't follow VA.gov style.** Example: Veterans' (should not have an apostrophe). 
 
-Facility type  |  Owned by  |  Official name | URL 
- -- | -- | -- | -- 
-_Source:_<br>VAST |   | _Source:_<br>VAST | _Source:_<br>Facilities API
-Regional benefit office | Standalone | Winston-Salem Regional Benefit Office | 
-VR&E office | Standalone | Harrisburg Veteran Readiness and Employment Office |   
-VR&E office | VHA or non-VA | Veteran Readiness and Employment Office at Grand Junction VA Medical Center | 
-Regional office | VHA or non-VA | Regional Office at Samuel S. Stratton Department of Veterans Affairs Medical Center | 
-Outbased office | VHA or non-VA | Regional Benefit Office at New Bedford VA Clinic (If not regional, then Benefit Office at Rochester Calkins VA Clinic.)
-Satellite office | VHA or non-VA | Regional Benefit Office at William S. Middleton Memorial Veterans' Hospital
-Integrated Disability Evaluation System (IDES) Site | VHA or non-VA | Integrated Disability Evaluation System (IDES) Site at Fort Drum
-Intake site | VHA or non-VA | Intake Site at Twentynine Palms
-Seamless Transition Integrated Care Clinic (STICC) | VHA or non-VA | Seamless Transition Integrated Care Clinic (STICC) at Richard L. Roudebush Veterans' Administration Medical Center
-VetSuccess on Campus | non-VA | VetSuccess on Campus at Saint Leo University
+Facility type  |  Owned by  |  Official name | Name pattern | URL 
+ -- | -- | -- | -- | -- 
+_Source:_<br>VAST |   | _Source:_<br>VAST |   | _Source:_<br>Facilities API
+Regional office | Standalone | [Winston-Salem VA Regional Benefit Office](https://www.va.gov/find-locations/facility/vba_318) | [Region name] [Facility type]
+Regional office | VHA or non-VA | [Anchorage VA Regional Benefit Office at Anchorage VA Medical Center](https://www.va.gov/find-locations/facility/vba_463) | [Region name] [Facility type] at [shared location name]
+~~Outbased office~~ | ~~VHA or non-VA~~ | ~~Regional Benefit Office at New Bedford VA Clinic (If not regional, then Benefit Office at Rochester Calkins VA Clinic.)~~ | ~~[Facility type] at [shared location name]~~
+Satellite office | VHA or non-VA | [VA Regional Benefit Satellite Office at New Bedford VA Clinic](https://www.va.gov/find-locations/facility/vba_304n) | [Facility type] at [shared location name]
+VR&E office | Standalone | [Harrisburg Veteran Readiness and Employment Office](https://www.va.gov/find-locations/facility/vba_310g) | [Region name] [Facility type]
+VR&E office | VHA or non-VA | [Veteran Readiness and Employment Office at Peoria Vet Center](https://www.va.gov/find-locations/facility/vba_328c) | [Facility type] at [shared location name]
+Integrated Disability Evaluation System (IDES) Site | VHA or non-VA | [Integrated Disability Evaluation System (IDES) Site at Fort Drum](https://www.va.gov/find-locations/facility/vba_307f) | [Facility type] at [shared location name]
+Pre-Discharge Site | VHA or non-VA | [Pre-Discharge Site at Twentynine Palms Marine Corps Air Ground Combat Center](https://www.va.gov/find-locations/facility/vba_344x) | [Facility type] at [shared location name]
+Seamless Transition Integrated Care Clinic (STICC) | VHA or non-VA | [Seamless Transition Integrated Care Clinic (STICC) at Richard L. Roudebush VA Medical Center](https://www.va.gov/find-locations/facility/vba_326g) | [Facility type] at [shared location name]
+VetSuccess on Campus | non-VA | [VetSuccess On Campus at University of Nevada, Las Vegas (UNLV)](https://www.va.gov/find-locations/facility/vba_354b) | [Facility type] at [shared location name]
 
 
 

--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -53,7 +53,7 @@ Update from September 22, 2023:
 
 **For every example below, "at" is followed by the official location name. Official location names come from legislation, so we may not be able to change things that don't follow VA.gov style.** Example: Veterans' (should not have an apostrophe). 
 
-Facility type  |  Owned by  |  Official name | Name pattern | URL 
+Facility type  |  Shared location?  |  Official name | Name pattern | URL 
  -- | -- | -- | -- | -- 
 _Source:_ Sandy's Database |   | _Source:_ Sandy's Database |   | _Source:_
 Regional office | Standalone | [Winston-Salem VA Regional Benefit Office](https://www.va.gov/find-locations/facility/vba_318) | [Region name] [Facility type]

--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -52,7 +52,7 @@ Update from October 1, 2020:
 
 Facility type  |  Owned by  |  Official name | Name pattern | URL 
  -- | -- | -- | -- | -- 
-_Source:_ VAST |   | _Source:_ VAST |   | _Source:_ Facilities API
+_Source:_ Sandy's Database |   | _Source:_ Sandy's Database |   | _Source:_
 Regional office | Standalone | [Winston-Salem VA Regional Benefit Office](https://www.va.gov/find-locations/facility/vba_318) | [Region name] [Facility type]
 Regional office | VHA or non-VA | [Anchorage VA Regional Benefit Office at Anchorage VA Medical Center](https://www.va.gov/find-locations/facility/vba_463) | [Region name] [Facility type] at [shared location name]
 Satellite office | VHA or non-VA | [VA Regional Benefit Satellite Office at New Bedford VA Clinic](https://www.va.gov/find-locations/facility/vba_304n) | [Facility type] at [shared location name]

--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -50,9 +50,9 @@ Update from October 1, 2020:
 
 **For every example below, "at" is followed by the official location name. Official location names come from legislation, so we may not be able to change things that don't follow VA.gov style.** Example: Veterans' (should not have an apostrophe). 
 
-Facility type  |  Owned by  |  Official name  | Plain-language name | URL 
- -- | -- | -- | -- | -- 
-_Source:_<br>VAST |   | _Source:_<br>VAST | _Source:_<br>Drupal  | _Source:_<br>Facilities API
+Facility type  |  Owned by  |  Official name | URL 
+ -- | -- | -- | -- 
+_Source:_<br>VAST |   | _Source:_<br>VAST | _Source:_<br>Facilities API
 Regional benefit office | Standalone | Winston-Salem Regional Benefit Office | 
 VR&E office | Standalone | Harrisburg Veteran Readiness and Employment Office |   
 VR&E office | VHA or non-VA | Veteran Readiness and Employment Office at Grand Junction VA Medical Center | 

--- a/products/facilities/naming-schema/README.md
+++ b/products/facilities/naming-schema/README.md
@@ -55,7 +55,6 @@ Facility type  |  Owned by  |  Official name | Name pattern | URL
 _Source:_ VAST |   | _Source:_ VAST |   | _Source:_ Facilities API
 Regional office | Standalone | [Winston-Salem VA Regional Benefit Office](https://www.va.gov/find-locations/facility/vba_318) | [Region name] [Facility type]
 Regional office | VHA or non-VA | [Anchorage VA Regional Benefit Office at Anchorage VA Medical Center](https://www.va.gov/find-locations/facility/vba_463) | [Region name] [Facility type] at [shared location name]
-~~Outbased office~~ | ~~VHA or non-VA~~ | ~~Regional Benefit Office at New Bedford VA Clinic (If not regional, then Benefit Office at Rochester Calkins VA Clinic.)~~ | ~~[Facility type] at [shared location name]~~
 Satellite office | VHA or non-VA | [VA Regional Benefit Satellite Office at New Bedford VA Clinic](https://www.va.gov/find-locations/facility/vba_304n) | [Facility type] at [shared location name]
 VR&E office | Standalone | [Harrisburg Veteran Readiness and Employment Office](https://www.va.gov/find-locations/facility/vba_310g) | [Region name] [Facility type]
 VR&E office | VHA or non-VA | [Veteran Readiness and Employment Office at Peoria Vet Center](https://www.va.gov/find-locations/facility/vba_328c) | [Facility type] at [shared location name]


### PR DESCRIPTION
**The actual change**
- [Current VBA naming schema documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/facilities/naming-schema/README.md#vba-benefits-facilities-naming-schema)
- [Proposed revision](https://github.com/department-of-veterans-affairs/va.gov-team/blob/742ebd9dd707069d3d958d688ca32e58d09c581d/products/facilities/naming-schema/README.md#vba-benefits-facilities-naming-schema)
  - All changes are to the big table
  - ⛔ Removed "Plain-language name" column (it was empty)
  - ⛔ Removed "Outbased office" row (these are all Regional Offices or Satellite Offices now)
  - ➕ Added "Name pattern" column and populated it to generalize the patterns
  - ➕Added links to Facility Locator detail pages to every example in "Official name" column
  - ♻️ Renamed "Owned by" column to "Shared location?"
  - ♻️ Renamed "Intake site" row to "Pre-discharge site"
  - ♻️ Updated some examples in the "Official name" column to reflect current state
  - ♻️ Reordered rows so Regional Office and Satellite Offices are at the top
  - ♻️ Updated "Source:" row

**Why is this change happening?**
- I had a discussion with @kristinoletmuskat about #64934
- Prepping for [VBA Regional Office MVP](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/10514)

**Stress cases to consider:**

Some current example of official names of Regional Offices and Satellite Offices that may cause issues when converting to URLs / H1s /breadcrumbs
- [Honolulu VA Regional Benefit Office and Spark M. Matsunaga Department of Veterans Affairs Medical Center](https://www.va.gov/find-locations/facility/vba_459)
  - Long names are long
- [VA Regional Benefit Office at U.S. Embassy in Manila](https://www.va.gov/find-locations/facility/vba_358)
  - This is the only Regional Office that doesn't start have a [region name] before the [facility type]
- [Fort Harrison VA Regional Benefit Office and Fort Harrison VA Medical Center](https://www.va.gov/find-locations/facility/vba_436)
  - When a Regional Office is at a shared location, sometimes the [region name] is repeated in the [shared location name] 
  - See also: Anchorage VA Regional Benefit Office at Anchorage VA Medical Center
- [VA Regional Benefit Satellite Office at Gerald W. Heaney Federal Building & U.S. Courthouse](https://www.va.gov/find-locations/facility/vba_335d)
  - Punctuation in the shared location name
- [VA Regional Benefit Satellite Office at Samuel S. Stratton Department of Veterans Affairs Medical Center](https://www.va.gov/find-locations/facility/vba_306b)
  -  Long names are long (satellite office edition)

**Possible errors:**
- [Milwaukee Regional Benefit Office](https://www.va.gov/find-locations/facility/vba_330) 
  - "Milwaukee **VA** Regional Benefit Office" would be consistent with all other ROs