### PR TITLE
Public Websites updates: Cerner is now Oracle Health

### DIFF
--- a/products/content/cerner-vista-ehr/README.md
+++ b/products/content/cerner-vista-ehr/README.md
@@ -1,6 +1,9 @@
-# Cerner/VistA (Electronic Health Records Systems)
+# Oracle Health (formerly Cerner)/VistA (Electronic Health Records Systems)
+
+Note: As of Nov 2023, Cerner is now called Oracle Health.
+
 ## Overview
-[Here is some documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/how-to-opt-in-to-drupal-as-the-source-of-truth-for#Howtoopt-intoDrupalasthesourceoftruthforCerner-relatedappsandwidgets-Background) that provides a nice overview of the problem space, as well as a guide for app/widget developers looking to integrate with Drupal-managed EHR data points.
+[How to opt-in to Drupal as the source of truth for Oracle Health-related apps and widgets](https://depo-platform-documentation.scrollhelp.site/developer-docs/how-to-opt-in-to-drupal-as-the-source-of-truth-for) that provides a nice overview of the problem space, as well as a guide for app/widget developers looking to integrate with Drupal-managed EHR data points.
 
 ## Audience
 The documentation that follows is aimed at Public Websites engineers. It covers two main topics:
@@ -8,48 +11,15 @@ The documentation that follows is aimed at Public Websites engineers. It covers 
 2) Consuming the API as it specifically relates to Public Websites products.
 
 ## Exposing the API
-There are two ways this is done.
-- The original way, which has been deprecated but has not been removed. Implementing apps and widgets should no longer be using this method, but it's important to understand the code that persists.
+
+The original way has been deprecated and code has been removed. Implementing apps and widgets should no longer be using this method.
 - The new way, which exposes the data points stored in Drupal.
 
 ### The original way
-Originally, tracking which facilities had migrated from VistA to Cerner was tracked via a hard-coded array combined with Flipper feature toggles.
+Originally, tracking which facilities had migrated from VistA to Oracle Health (formerly Cerner) was tracked via a hard-coded array combined with Flipper feature toggles.
 
-Here are the key pieces:
-- `src/platform/utilities/cerner/index.js`
-   - This file has a hard-coded array that indicates which facilities have migrated to Cerner.
-   ```
-   export const CERNER_FACILITY_IDS = [
-    '463', // Alaska VA
-    '531', // Boise, ID
-    '648', // Portland, OR
-    '653', // Roseburg (Roseburg OR)
-    '663', // Puget Sound (Seattle WA)
-    '668', // Mann Grandstaff
-    '687', // Walla Walla, WA
-    '692', // White City, OR
-    '757', // Chalmers P. Wylie Veterans Outpatient Clinic
-  ];
-   ```
-   - Additionally, there are hard-coded arrays for specific pieces of health-care management. It was the case previously (but should not be the case again in the future) that only a _subset_ of a facility's health-care management would initially migrate. This required that we have an array for each piece that should not be considered Cerner when the facility at large was considered to have migrated to Cerner.
-   (Note: these arrays are all empty, as there was only ever one partial cutover, and that facility has now been fully migrated.)
-   ```
-    // Not all Cerner facilities have the same capabilities. These blocklists are
-    // used to determine which facilities lack certain capabilities.
-    // Facilities that are Cerner but do not have Cerner prescription features:
-    export const CERNER_RX_BLOCKLIST = [];
-    // Facilities that are Cerner but do not have Cerner secure messaging features:
-    export const CERNER_MESSAGING_BLOCKLIST = [];
-    // Facilities that are Cerner but do not have Cerner appointment features:
-    export const CERNER_APPOINTMENTS_BLOCKLIST = [];
-    // Facilities that are Cerner but do not have Cerner medical records features:
-    export const CERNER_MEDICAL_RECORDS_BLOCKLIST = [];
-    // Facilities that are Cerner but do not have Cerner test and lab results
-    // features:
-    export const CERNER_TEST_RESULTS_BLOCKLIST = [];
-   ```
-- `src/platform/user/selectors.js`
-   - This file implements selectors related to determining if a facility is a Cerner or VistA facility. The "selector" (i.e. Redux) piece of this rests on the fact that user-specific data, as well as Flipper toggles, are stored in the global Redux store. Nothing specifically related to the Cerner facility IDs is stored in Redux. That is all hard-coded in this original approach.
+Additionally, there were hard-coded arrays for specific pieces of health-care management. It was the case previously (but should not be the case again in the future) that only a _subset_ of a facility's health-care management would initially migrate. This required that we have an array for each piece that should not be considered Oracle Health when the facility at large was considered to have migrated to Oracle Health.
+
 
 ### The new way
 The new way amounts to managing the data points in Drupal rather than hard-coded in the code. The vast majority of the work related to this new way of handling this was completed in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/21393). There were some small additions and refactoring in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/21905), which primarily was work done for the PW-consuming code.
@@ -59,7 +29,7 @@ Here are the key pieces:
    - This is the browser-side piece of the KISS puzzle. The function `connectDrupalStaticDataFile` takes the name of a KISS-generated file as a parameter, then fetches that file and subsequently places the contents in the global Redux state under a property name that is also passed in.
    - **Importantly,** there is no mechanism yet in place to prevent multiple fetches of the same data file. This work should be considered for future implementation. There is now a connection being made from the header code. Since this code runs on all pages, every other app that makes this connection will ultimately be making a redundant call.
 - `src/platform/utilities/cerner/dsot.js`
-   - This file implements an abstraction of the more general `connectDrupalStaticDataFile` specifically for the Cerner/EHR KISS-generated data file `vamc-ehr.json`. As we can see in the code below, this abstraction places the fetched data in the global state under the property `cernerFacilities`.
+   - This file implements an abstraction of the more general `connectDrupalStaticDataFile` specifically for the Oracle Health/EHR KISS-generated data file `vamc-ehr.json`. As we can see in the code below, this abstraction places the fetched data in the global state under the property `cernerFacilities`.
    ```
     export const connectDrupalSourceOfTruthCerner = dispatch => {
       connectDrupalStaticDataFile(dispatch, {
@@ -76,7 +46,7 @@ Here are the key pieces:
    - Once the data is in the Redux store, we need to provide a way for apps to get it out. The selectors in this file provide that mechanism. Unlike the selectors in the original way, these selectors need to grab the EHR data from the Redux store.
 
 ## Consuming the API in PW products
-All Public Website code has been updated to use the new way of integrating with EHR data points. There are five widgets:
+All healthcare widgets have been updated to use the new way of integrating with EHR data points. There are five widgets:
 1. Get Medical Records
 2. Refill and Track Prescriptions
 3. Schedule and View VA Appointments
@@ -100,4 +70,4 @@ All of these widgets are implemented similarly. We'll examine Get Medical Record
     });
    ```
   - `ehrDataByVhaId` represents a data structure that provides additional data for each facility. One benefit of moving to this new approach is that we can access data points that we didn't have hard-coded. One example is that we now have access to a VAMC system name rather than just the name of the main facility within that system. [This PR](https://github.com/department-of-veterans-affairs/vets-website/pull/21905) captures work to utilize that name.
-  - `facilities` represents the facilities with which an authenticated veteran is associated. Each record in the array will have a property that indicates if it is a Cerner or VistA facility.
+  - `facilities` represents the facilities with which an authenticated veteran is associated. Each record in the array will have a property that indicates if it is an Oracle Health or VistA facility.

--- a/products/public-websites/healthcare-widget-support/cms-source-of-truth/initiative-brief.md
+++ b/products/public-websites/healthcare-widget-support/cms-source-of-truth/initiative-brief.md
@@ -1,16 +1,19 @@
-# Initiative: Cerner react widgets consume facility/system data from CMS instead of hard-coded array
+# Initiative: Healthcare react widgets consume facility/system data from CMS instead of hard-coded array
+
+NOTE: As of Nov 2023, Oracle has acquired Cerner, and Cerner is now Oracle Health. 
+
 #### Overview
 
 This is a purely technical change, with no change to the user experience.
 
-The CSWs look at the facilities that a user is associated with and then provide buttons that direct the user to either VistA or Cerner, as appropriate per facility/system. The MVP implementation of the CSWs used a hard-coded array in the `index.js` file to associate specific VA systems/locations with Cerner. In this iteration, the Drupal CMS provides the data object associating medical systems with either Cerner or VistA.
+The CSWs look at the facilities that a user is associated with and then provide buttons that direct the user to either VistA or Oracle Health (formerly Cerner), as appropriate per facility/system. The MVP implementation of the CSWs used a hard-coded array in the `index.js` file to associate specific VA systems/locations with Oracle Health. In this iteration, the Drupal CMS provides the data object associating medical systems with either Oracle Health or VistA.
 
 ## Outcome Summary
 
-When we're successful, across all experiences on VA.gov related to Cerner/VistA, cutting a system/facility over to Cerner will be a matter of configuration (in Drupal) rather than a code change that has to be deployed to reach users. 
+When we're successful, across all experiences on VA.gov related to Oracle Health/VistA, cutting a system/facility over to Oracle Health will be a matter of configuration (in Drupal) rather than a code change that has to be deployed to reach users. 
 
 **Related/Associated product(s)**
-- Cerner React Widgets | [Link to product outline ](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/Cerner-Support/product-outline.md)
+- Healthcare React Widgets | [Link to product outline ](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/healthcare-widget-support/product-outline.md)
 
 
 ## Discovery
@@ -54,7 +57,7 @@ None
 ### Timeline 
 > *Describe any major milestones for this initiative including organizational, legislative, etc. constraints.*
 
-Release date TBD – only constraint is ensuring that we have a window in which to test thoroughly without risking a disruption in production. Ideally we will find a 3-4 week break between new Cerner cutovers.
+Release date TBD – only constraint is ensuring that we have a window in which to test thoroughly without risking a disruption in production. Ideally we will find a 3-4 week break between new Oracle Health cutovers.
 
 * [Link to Release Plan for this Initiative](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/product-management/release-plan-template.md)
 
@@ -68,7 +71,7 @@ Release date TBD – only constraint is ensuring that we have a window in which
    
 ## Screenshots
 
-**There are no user-facing changes to the Cerner React Widget experience.**
+**There are no user-facing changes to the Oracle Health React Widget experience.**
 
 ### Before
 

--- a/products/public-websites/healthcare-widget-support/cms-source-of-truth/opt-in-drupal-source-of-truth.md
+++ b/products/public-websites/healthcare-widget-support/cms-source-of-truth/opt-in-drupal-source-of-truth.md
@@ -1,3 +1,3 @@
-# How to opt in to Drupal as the source of truth for Cerner-related apps and widgets
+# How to opt in to Drupal as the source of truth for Oracle Health-related apps and widgets
 
 https://depo-platform-documentation.scrollhelp.site/developer-docs/how-to-opt-in-to-drupal-as-the-source-of-truth-for

--- a/products/public-websites/healthcare-widget-support/cms-source-of-truth/release-plan.md
+++ b/products/public-websites/healthcare-widget-support/cms-source-of-truth/release-plan.md
@@ -1,11 +1,13 @@
-# Cerner CMS Source of Truth Release Plan - DRAFT
+# Oracle Health (formerly Cerner) CMS Source of Truth Release Plan - DRAFT
+
+As of Nov 2023, Oracle acquired Cerner. Cerner is now Oracle Health.
 
 ## Scope of release
-Initiative brief: [Initiative: Cerner react widgets consume facility/system data from CMS instead of hard-coded array](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/Cerner-Support/cms-source-of-truth/initiative-brief.md)
+Initiative brief: [Initiative: Healthcare react widgets consume facility/system data from CMS instead of hard-coded array](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/Cerner-Support/cms-source-of-truth/initiative-brief.md)
 
 This is a backend data change that should remain invisible to site users. 
 
-Cerner cutover support epic [#7158](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7158) includes a subset of tickets that describe this launch: 
+Oracle Health cutover support epic [#7158](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/7158) includes a subset of tickets that describe this launch: 
 * [Add static data build step to content-build #8199](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8199)
 * [Add Electronic Health Care Record data query/endpoint #8201](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/8201)
 * [Create async JS API (within FE code) to make JSON facility data available to products #9306](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9306)
@@ -15,18 +17,18 @@ Cerner cutover support epic [#7158](https://github.com/department-of-veterans-af
 * [Remove Cerner data source feature toggle and hard coded mechanism #9078](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9078)
 
 
-### Cerner cutover schedule
+### Oracle Health cutover schedule
 During the testing / launch period for this change, additional Systems will cutover to Cerner. Timing for each phase is planned with respect to the following launches: 
-* June 13 - White City, Roseburg
-* June 25 - Boise
-* July 16 - Anchorage
-* August 27 - Puget Sound
+* June 13, 2022 - White City, Roseburg
+* June 25, 2022 - Boise
+* July 16, 2022 - Anchorage
+* August 27, 2022 - Puget Sound
 
 
 ## Phase I: PW validation in Staging
 The Public Websites (PW) team will deliver an API ([#9306](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9306)) that makes Cerner/VistA facility data available to FE components. The API will be independent of the current hard-coded/synchronous approach, so product teams can decide when to integrate and switch from previous hard coded data source to the new API.
 
-PW will integrate against the new API for Cerner React widgets, e.g. Schedule and manage health appointments. 
+PW will integrate against the new API for Healthcare React widgets, e.g. Schedule and manage health appointments. 
 
 PW will place the API behind a feature toggle that controls the Cerner data source:
 * Off = Hard coded data
@@ -102,13 +104,13 @@ A separate funnel needs to be built for each of the five Benefit Detail pages th
 
 #### User flow 1: User can sign in and reach the EHR to finish their task
 Because some users will already be signed in, we need to pick up the flow after login.
-- Flow begins with clicking a CTA button that links to either Cerner or VistA. 
-    - The GA click event on a Cerner link:
+- Flow begins with clicking a CTA button that links to either Oracle Health (Cerner) or VistA. 
+    - The GA click event on a Oracle Health (Cerner) link:
       - ec (category): "Interactions",
       - ea (action): "Default Button CTA - Go to My VA Health - rgb(0, 62, 115)",
       - el (element?): "cta-button-click"
     - The click on a VistA link is the same, except the text on the button is "Go to My HealtheVet" instead (reflected in the `ea` property above).
-- **It doesn't appear that GA can track the user to the new tab that opens up for either Cerner or VistA.** 
+- **It doesn't appear that GA can track the user to the new tab that opens up for either Oracle Health (Cerner) or VistA.** 
 - The only thing we think we can watch for (for site health monitoring) is to see if the user returns to the original widget page for further interaction. 
   - Since the CTA opened another tab, there is not likely to be a new Page View event.
   - Clicking a CTA within the widget (ie, a different button or the same one again) would be an antipattern to monitor (expected but not common)

--- a/products/public-websites/healthcare-widget-support/how_to_set_up_vamc_cerner_within_va_health_care_portals.md
+++ b/products/public-websites/healthcare-widget-support/how_to_set_up_vamc_cerner_within_va_health_care_portals.md
@@ -1,17 +1,19 @@
-# How to set up a VAMC's Cerner integration within the VA.gov health care portals: hard coded data and CMS data
+# How to set up a VAMC's Oracle Health (formerly Cerner) integration within the VA.gov health care portals: hard coded data and CMS data
+
+As of Nov 2023, Oracle has acquired Cerner, and Cerner is now Oracle Health.
 
 ## Purpose
-As healthcare systems migrate to using Cerner for electronic health records, the website will update to point users to Cerner API / UI for tasks like prescription refills, appointment scheduling, viewing lab results, messaging healthcare team, etc. As a result, some of the links that we direct our users to if they belong to that facility need to reflect that change. This document gives examples / steps for a Cerner cutover using hard coded data.
+As healthcare systems migrate to using Oracle Health (formerly Cerner) for electronic health records, the website will update to point users to Oracle Health API / UI for tasks like prescription refills, appointment scheduling, viewing lab results, messaging healthcare team, etc. As a result, some of the links that we direct our users to if they belong to that facility need to reflect that change. This document gives examples / steps for a Oracle Health cutover using hard coded data.
 
 ## A Cerner facility cutover is scheduled
-Your PO will tell the team that a Cerner facility/system is "ready to go live" or "ready to cutover." Exciting! This means the team responsible for migrating a System from VistA to Cerner has completed their testing, the healthcare records system cutover is complete, and the website can be updated to point users to Cerner triggers as well. Now you need some information.
+Your PO will tell the team that a Oracle Health facility/system is "ready to go live" or "ready to cutover." Exciting! This means the team responsible for migrating a System from VistA to Oracle Health has completed their testing, the healthcare records system cutover is complete, and the website can be updated to point users to Oracle Health triggers as well. Now you need some information.
 
-### Step 1: Derive Cerner facility information
+### Step 1: Derive Oracle Health facility information
 
 For the following steps, we will use the __Alaska VA Medical Center__ as an example.
 
 **Task 1: Request / find the facility ID**  
-(should be 3 digits) of the facility that will soon go live as a Cerner facility, e.g.
+(should be 3 digits) of the facility that will soon go live as a Oracle Health facility, e.g.
 
 ```
 463 | Alaska VA
@@ -24,30 +26,30 @@ For the following steps, we will use the __Alaska VA Medical Center__ as an exam
 692 | White City, OR
 757 | Chalmers P. Wylie Veterans Outpatient Clinic
 ```
-  - In our example, we determine from leadership that the facility ID of the Alaska VA Medical Center is __463__. If you aren't sure about the ID, confirm with your PO or the Cerner cutover team.
+  - In our example, we determine from leadership that the facility ID of the Alaska VA Medical Center is __463__. If you aren't sure about the ID, confirm with your PO or the Oracle Health cutover team.
 
 That ID is pivotal for the following tasks:
 
 
 **Task 2: Identify if the Facility has exceptions** 
 
-By default, once you have set up a VAMC's Cerner integration, it is enabled for _all_ health care portals, including prescription refills, secure messaging, appointments, medical records, and test results. There may be cases where a VAMC's Cerner integration is limited to only one or more of these. In this case, you can add the VAMC's facility ID into a health care portal's "blocklist", which will disable the VAMC's Cerner integration for that particular health care portal.
+By default, once you have set up a VAMC's Oracle Health integration, it is enabled for _all_ health care portals, including prescription refills, secure messaging, appointments, medical records, and test results. There may be cases where a VAMC's Oracle Health integration is limited to only one or more of these. In this case, you can add the VAMC's facility ID into a health care portal's "blocklist", which will disable the VAMC's Oracle Health integration for that particular health care portal.
 
 Exceptions:
 
-1. Facility is Cerner but does not have Cerner prescription features. ([View the prescription features page here](https://www.va.gov/health-care/refill-track-prescriptions/))
-1. Facility is Cerner but does not have Cerner secure messaging features. ([View the secure messaging features page here](https://www.va.gov/health-care/secure-messaging/))
-1. Facility is Cerner but does not have Cerner appointment features. ([View the appointment features page here](https://www.va.gov/health-care/schedule-view-va-appointments/))
-1. Facility is Cerner but does not have Cerner medical records features. ([View the medical records features page here](https://www.va.gov/health-care/get-medical-records/))
-1. Facility is Cerner but does not have Cerner test and lab results. ([View the test and lab results page here](https://www.va.gov/health-care/view-test-and-lab-results/))
+1. Facility is Oracle Health but does not have Oracle Health prescription features. ([View the prescription features page here](https://www.va.gov/health-care/refill-track-prescriptions/))
+1. Facility is Oracle Health but does not have Oracle Health secure messaging features. ([View the secure messaging features page here](https://www.va.gov/health-care/secure-messaging/))
+1. Facility is Oracle Health but does not have Oracle Health appointment features. ([View the appointment features page here](https://www.va.gov/health-care/schedule-view-va-appointments/))
+1. Facility is Oracle Health but does not have Oracle Health medical records features. ([View the medical records features page here](https://www.va.gov/health-care/get-medical-records/))
+1. Facility is Oracle Health but does not have Oracle Health test and lab results. ([View the test and lab results page here](https://www.va.gov/health-care/view-test-and-lab-results/))
 
 If you answered yes to any of these, keep that information for code changes in Step 2.4 below.
 
 **Task 3: Schedule** 
 
-Cerner records cutovers typically happen over the weekend, and web tasks happen the Monday after. Confirm the scheduled cutover plan. Engineering tasks should all be completed the week prior, minimum, with only a feature flag update remaining for the day of cutover.
+Oracle Health records cutovers typically happen over the weekend, and web tasks happen the Monday after. Confirm the scheduled cutover plan. Engineering tasks should all be completed the week prior, minimum, with only a feature flag update remaining for the day of cutover.
 
-_All Cerner cutovers after Boise are delayed until 2023._
+_All Oracle Health cutovers after Boise are delayed until 2023._
 
 **Task 4: Identify any available test users** 
 
@@ -56,28 +58,28 @@ The integration testers who are verifying the records integrations typically hav
 Anthony Diaz (Contractor) <Anthony.Diaz@va.gov>
 System Integration Testing (SIT) Test Lead, Planned Systems International (PSI)
 
-And add that user information to the [Test User Dashboard](https://tud.vfs.va.gov/), Without a test user, there is no way to test out the facility's Cerner launch on staging. (Test users will not work on production.)
+And add that user information to the [Test User Dashboard](https://tud.vfs.va.gov/), Without a test user, there is no way to test out the facility's Oracle Health launch on staging. (Test users will not work on production.)
 
 Now that you have the Facility ID, exception cases, and the "go live" date, we can get started with our implementation.
 
 ### Some much needed context
 
-In an ideal world, when we fetch facilities that a user belongs to, there should exist a key-value pair on them that is `isCerner: true/false`. However, we have noticed that *every facility that has migrated to Cerner is still showing `isCerner: false`*, which is incorrect.
+In an ideal world, when we fetch facilities that a user belongs to, there should exist a key-value pair on them that is `isCerner: true/false`. However, we have noticed that *every facility that has migrated to Oracle Health is still showing `isCerner: false`*, which is incorrect.
 
-Since that `isCerner` flag is unreliable, we have resorted to maintaining a [list of Cerner facility IDs both in `vets-website`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/cerner/index.js#L5) as well as [on Flipper with `cerner_override_{facilityID}`](https://api.va.gov/flipper/features) (to test various environments before launching).
+Since that `isCerner` flag is unreliable, we have resorted to maintaining a [list of Oracle Health facility IDs both in `vets-website`](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/cerner/index.js#L5) as well as [on Flipper with `cerner_override_{facilityID}`](https://api.va.gov/flipper/features) (to test various environments before launching).
 
 ### Step 2: Create feature toggle & Exceptions
 
-**Task 1: create a Cerner feature toggle for the facility** 
+**Task 1: create a Oracle Health feature toggle for the facility** 
 
-The feature toggle should be named `cerner_override_{facilityID}` because [this code that derives a user's Cerner facilities](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/user/selectors.js#L31) is expecting that syntax.
+The feature toggle should be named `cerner_override_{facilityID}` because [this code that derives a user's Oracle Health facilities](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/user/selectors.js#L31) is expecting that syntax.
 
 Add a feature toggle [here](https://github.com/department-of-veterans-affairs/vets-api/blob/master/config/features.yml#L26). Here is an example:
 
 ```yml
   cerner_override_463:
     actor_type: user
-    description: This will show the Cerner facility 463 as `isCerner`.
+    description: This will show the Oracle Health facility 463 as `isCerner`.
 ```
 Wait until your `vets-api` Pull Request is merged **and deployed**. You will then be able to find your feature toggles at https://api.va.gov/flipper/features. Refer to [the guide on how to work with Flipper feature toggles](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/platform/tools/feature-toggles/) for more details on how to enable/disable/etc. your new feature toggles.
 
@@ -103,11 +105,11 @@ Example Pull Request: https://github.com/department-of-veterans-affairs/vets-web
 
 In **Step 1, Task 2** above, if the facility matches any of the below cases, below be sure to add their facilityID to the respective blocklist in [vets-website/src/platform/utilities/cerner/index.js](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/utilities/cerner/index.js#L20):
 
-1. Facility is Cerner but does not have Cerner prescription features.
-1. Facility is Cerner but does not have Cerner secure messaging features.
-1. Facility is Cerner but does not have Cerner appointment features.
-1. Facility is Cerner but does not have Cerner medical records features.
-1. Facility is Cerner but does not have Cerner test and lab results.
+1. Facility is Oracle Health but does not have Oracle Health prescription features.
+1. Facility is Oracle Health but does not have Oracle Health secure messaging features.
+1. Facility is Oracle Health but does not have Oracle Health appointment features.
+1. Facility is Oracle Health but does not have Oracle Health medical records features.
+1. Facility is Oracle Health but does not have Oracle Health test and lab results.
 
 
 Merge and deploy the newly created `vets-website` Pull Request. 
@@ -115,13 +117,13 @@ At this point, both the `vets-website` and `vets-api` Pull Requests should be me
 
 
 ### Step 3: Staging validation
-Merge your changes. Now that the facility ID has been added to our list of Cerner facility IDs in vets-website, the feature toggle has been created, and you have added the facility ID to all necessary blocklists, we are ready to allow stakeholders to test on Staging. 
+Merge your changes. Now that the facility ID has been added to our list of Oracle Health facility IDs in vets-website, the feature toggle has been created, and you have added the facility ID to all necessary blocklists, we are ready to allow stakeholders to test on Staging. 
 
 #### **Task 1**: Update flipper feature toggle in staging
 1. https://staging-api.va.gov/flipper/features
 2. Login with a verified ID.me account. (An account that is not properly verified will run into errors. Follow [id.me steps to Verify](https://www.va.gov/resources/verifying-your-identity-on-vagov/).)
 4. Toggle the feature toggle to on
-5. You can test on Staging with Cerner test users, but not on prod. For staging testing, staging.va.gov, log in with a user that belongs to the facility ID (from the **Step 1, Task 4** above). 
+5. You can test on Staging with Oracle Health test users, but not on prod. For staging testing, staging.va.gov, log in with a user that belongs to the facility ID (from the **Step 1, Task 4** above). 
 
 Once logged in, test that the CTA widget appears as desired for the user on the following STAGING pages:
 
@@ -139,7 +141,7 @@ If there is any issue with the content of the above pages, you can find the code
 1. [View the medical records features page code here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js)
 1. [View the test and lab results page code here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/index.js)
 
-#### **Task 2**: Update Drupal EHR value to Converting to Cerner
+#### **Task 2**: Update Drupal EHR value to Converting to Oracle Health
 As Drupal admin, in prod CMS: 
 1. Content > Filter by content type = VAMC System, identify the Healthcare System, Edit. 
 1. On the system node, go to the "VA Health Connect and Health Records System" panel.
@@ -180,17 +182,17 @@ In prod CMS:
 1. Enter a brief Revision log message.
 1. Click "Save."
 
-Post in #vagov-cerner-launch-coordination & @ mention Lauren Alexanderson and Dave Conlon to confirm that cutover tasks are complete. 
+Post in #vagov-oracle-launch-coordination & @ mention Lauren Alexanderson and Dave Conlon to confirm that cutover tasks are complete. 
 Reach out to relevant stakeholders if you need any help/advice for any questions that may come up.
 
 #### **Task 3**: Trigger Change Management email
 After launch, we must notify VA-side contacts to send a Change Management email to editors at the cutover center. Copy is documented [in this issue comment](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9338#issuecomment-1204434889).
 
 - Email to: Jeffrey.Grandon@va.gov and Steve.Tokar2@va.gov, cc. denise.eisner@civicactions.com
-- Subject: Cerner facility cutover: send editor change management email
+- Subject: Oracle Health facility cutover: send editor change management email
 - Body:
 > Hi,
-> `VAMC System name` was moved to Cerner on `cutover date`. Please inform the VA medical center internet website editor(s) at that location of the change with the standard reply we developed with your team (attached).
+> `VAMC System name` was moved to Oracle Health on `cutover date`. Please inform the VA medical center internet website editor(s) at that location of the change with the standard reply we developed with your team (attached).
 - Attachment:  [2022 Cerner cutover email notification_st_cmsteam.docx](https://github.com/department-of-veterans-affairs/va.gov-cms/files/9300517/2022.Cerner.cutover.email.notification_st_cmsteam.docx)
 
 Issue reference: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/9338#issuecomment-1204434889
@@ -210,7 +212,7 @@ For example:
 * Now find the System node: https://prod.cms.va.gov/admin/content - Filter by: VAMC System, Title: "VA Southern Oregon" <the system name you just found on the Facility node> = and now you can edit that node's EHR value.
   
 ## Drupal source of truth
-The system documented here will be updated to be managed entirely by Drupal, as Cerner widgets are updated to use Drupal as the source of truth. During this transition, both data sources will be maintained, and app/widget developers can opt in to the new data source (Drupal). Eventually, the old data source will be deprecated, and apps/widgets will then be required to adopt the new "API".
+As of Sept 2023, the system documented here is managed entirely by Drupal, and Oracle Health widgets are updated to use Drupal as the source of truth. Apps/widgets are required to adopt the new "API".
 
-[How to opt in to Drupal as the source of truth for Cerner-related apps and widgets
-](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/Cerner-Support/cms-source-of-truth/opt-in-drupal-source-of-truth.md)
+[How to opt in to Drupal as the source of truth for Oracle Health-related apps and widgets
+](https://depo-platform-documentation.scrollhelp.site/developer-docs/how-to-opt-in-to-drupal-as-the-source-of-truth-for)

--- a/products/public-websites/healthcare-widget-support/product-outline.md
+++ b/products/public-websites/healthcare-widget-support/product-outline.md
@@ -1,11 +1,12 @@
-# Cerner React Widgets - Product outline
+# Healthcare React Widgets - Product outline
 (Note: this is being completed retroactively by a successor team.)
+(As of Nov 2023, Cerner is now Oracle Health.)
 
 ## Overview
-React Widgets will enable Veterans to be directed to the correct electronic system (VistA/MyHealtheVet or Cerner/My VA Health) for 5 top tasks based on which VA medical system (geographic) is appropriate.
+React Widgets will enable Veterans to be directed to the correct electronic system (VistA/MyHealtheVet or Oracle Health (formerly Cerner)/My VA Health) for 5 top tasks based on which VA medical system (geographic) is appropriate.
 
 ## Problem Statement
-Before VA systems started cutting over to Cerner, the implementation of these common top tasks assumed that all actions would be taken through VistA. The gradual roll-out of Cerner has introduced the need to match Veterans to the correct EHR system.
+Before VA systems started cutting over to Cerner (now Oracle Health), the implementation of these common top tasks assumed that all actions would be taken through VistA. The gradual roll-out of Oracle Health has introduced the need to match Veterans to the correct EHR system.
 
 Top tasks in question:
 - Refill a prescription
@@ -29,7 +30,7 @@ _How might we enable the VA.gov user interface to intelligently send Veterans to
 
 ## Desired Business Outcomes
 
-- Roll out Cerner without negatively impacting Veterans or VA operations
+- Roll out Oracle Health without negatively impacting Veterans or VA operations
 
 ## Undesired Business Outcomes
 
@@ -71,11 +72,11 @@ _What are the measurable targets you're aiming for that delivers value for Veter
 
 - A react widget enables the combination of two data sources to conditionally change the UI for a given visitor:
   - The user object in the browser has info from an API about which medical systems the Veteran has had records/interactions with.
-  - A list of which VA Medical Systems has cut over to Cerner can be provided through the codebase (MVP) or external configuration (future iteration).
+  - A list of which VA Medical Systems has cut over to Oracle Health can be provided through the codebase (MVP) or external configuration (future iteration).
 
 ### Initiatives
 
-- Externalize the list of Cerner facilities | [CMS Source of Truth iteration](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/Cerner-Support/cms-source-of-truth/initiative-brief.md)
+- Externalize the list of Oracle Health facilities | [CMS Source of Truth iteration](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/public-websites/Cerner-Support/cms-source-of-truth/initiative-brief.md)
 
 --- 
 

--- a/products/public-websites/healthcare-widget-support/readme.md
+++ b/products/public-websites/healthcare-widget-support/readme.md
@@ -1,6 +1,6 @@
 # Readme
 
-As of June, 2022, the Public Websites team supports Cerner through react widgets, which help Vets accomplish five top tasks using the correct EHR system for the VA system they're trying to interact with:
+As of June, 2022, the Public Websites team supports five Healthcare react widgets, which help Vets accomplish five top tasks using the correct EHR system for the VA system they're trying to interact with:
 - [refill prescription](https://www.va.gov/health-care/refill-track-prescriptions/)
 - [make appointment](https://www.va.gov/health-care/schedule-view-va-appointments)
 - [get VA medical records](https://www.va.gov/health-care/get-medical-records)


### PR DESCRIPTION
* Update easy to change references to Cerner to mention Oracle Health
* Update `Cerner-Support` file path to `healthcare-widget-support`
* Update docs to reflect that old Cerner data method is now fully deprecated, and Drupal is the source of truth

Epic https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16079 tracks the rest of the possible renaming work that will need to happen. If that gets prioritized, code references to Cerner may change, and more docs will need to be updated. 
