### PR TITLE
Add extra label check to created tickets workflow

### DIFF
--- a/.github/workflows/create-cc-completed-ticket.yml
+++ b/.github/workflows/create-cc-completed-ticket.yml
@@ -9,7 +9,12 @@ jobs:
   ticket-creation:
     name: Create Completed Ticket
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.issue.labels.*.name, 'CC-Request') && (github.event.label.name == 'cc-kickoff' || github.event.label.name == 'design-intent' || github.event.label.name == 'midpoint-review' || github.event.label.name == 'staging-review')}}
+    if: ${{ contains(github.event.issue.labels.*.name, 'CC-Request') &&
+        contains(github.event.issue.labels.*.name, 'Epic') &&
+        (github.event.label.name == 'cc-kickoff' || 
+        github.event.label.name == 'design-intent' || 
+        github.event.label.name == 'midpoint-review' || 
+        github.event.label.name == 'staging-review')}}
     steps:
 
       - name: Checkout


### PR DESCRIPTION
This PR adds an additional label check ("EPIC") to the Governance Team workflow to limit accidental creation of completed tickets.