### PR TITLE
Try to add clarity about what a transmittal notice is

### DIFF
--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -109,7 +109,10 @@ body:
   - type: textarea
     attributes:
       label: E-QIP Transmittal Confirmation
-      description: Attach a screenshot of your transmittal confirmation email by clicking this area to highlight and dragging the file in.
+      description: |
+        Attach a screenshot of your transmittal confirmation email by clicking this area to highlight and dragging the file in.
+
+        Your transmittal confirmation should contain the words "Transmittal Notice" in the subject of the email. If it doesn't, your E-QIP has not begun processing on the VA side. **NOTE: Do not submit PDF copies of your E-QIP document! These usually contain your social security number and other PII**
       placeholder: Drag your transmittal confirmation email screenshot here
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -48,14 +48,6 @@ body:
         - Other - please specify in 'Additional Notes'
     validations:
      required: true
-  - type: checkboxes
-    attributes:
-      label: E-QIP Transmittal Date
-      description: Have you started your E-QIP process? If not, do not submit this ticket. Ask your Vendor Onboarding Representative to confirm
-      options:
-      - label: Check this box if you have an E-QIP transmittal date.
-    validations:
-      required: true
   - type: input
     id: requestor-name
     attributes:

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -110,8 +110,6 @@ body:
     attributes:
       label: E-QIP Transmittal Confirmation
       description: |
-        Attach a screenshot of your transmittal confirmation email by clicking this area to highlight and dragging the file in.
-
         Your transmittal confirmation should contain the words "Transmittal Notice" in the subject of the email. If it doesn't, your E-QIP has not begun processing on the VA side. **NOTE: Do not submit PDF copies of your E-QIP document! These usually contain your social security number and other PII**
       placeholder: Drag your transmittal confirmation email screenshot here
     validations:

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -110,7 +110,9 @@ body:
     attributes:
       label: E-QIP Transmittal Confirmation
       description: |
-        Your transmittal confirmation should contain the words "Transmittal Notice" in the subject of the email. If it doesn't, your E-QIP has not begun processing on the VA side. **NOTE: Do not submit PDF copies of your E-QIP document! These usually contain your social security number and other PII**
+        **NOTE: Do not submit PDF copies of your E-QIP document! These usually contain your social security number and other PII**
+
+        Your transmittal confirmation should contain the words "Transmittal Notice" in the subject of the email. If it doesn't, your E-QIP has not begun processing on the VA side.
       placeholder: Drag your transmittal confirmation email screenshot here
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -110,10 +110,8 @@ body:
     attributes:
       label: E-QIP Transmittal Confirmation
       description: |
-        **NOTE: Do not submit PDF copies of your E-QIP document! These usually contain your social security number and other PII**
-
-        Your transmittal confirmation should contain the words "Transmittal Notice" in the subject of the email. If it doesn't, your E-QIP has not begun processing on the VA side.
-      placeholder: Drag your transmittal confirmation email screenshot here
+        :warning:**NOTE: Do not submit PDF copies of your E-QIP document! These usually contain your social security number and other PII**:warning:
+      placeholder: Drag your transmittal confirmation EMAIL screenshot here. This should contain the words "Transmittal Notice" in the subject. If it doesn't, your E-QIP has not begun processing on the VA side.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
We've had another [AWS Access Request with PII in it](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72319#issuecomment-1869678794). This PR is intended to help prevent that.

For a preview of the change, see [file at the last commit - 45d55c0cb26bf189167717b9fb58165c2e03b285](https://github.com/department-of-veterans-affairs/va.gov-team/blob/45d55c0cb26bf189167717b9fb58165c2e03b285/.github/ISSUE_TEMPLATE/aws-access-request.yml).

Adds a note about:
- That PDF documents are usually their personal documents **with PII** in them.
- The "subject" of a transmittal email

Removed:
- Requirement for an E-QIP transmittal date, which should now be covered by the checks and warnings about the "E-QIP Transmittal Confirmation"
