### PR TITLE
Initial README for accredited rep facing product

### DIFF
--- a/products/accredited-representative-facing/README.md
+++ b/products/accredited-representative-facing/README.md
@@ -1,0 +1,20 @@
+# Accredited Representative Facing (ARF)
+
+The Accredited Representative Facing (ARF) team is part of the Accredited Reps Crew in the OCTO Benefits Portfolio.
+
+**Mission**:
+
+## Product Resources
+
+#### [Zenhub board](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/board)
+
+## Team Members
+
+- Product Owner: Jennifer Bertsch, jennifer.bertsch@va.gov
+- Engineering Lead: Sam Raudabaugh, samuel.raudabaugh@va.gov
+- Design Lead: Lesley Ropp, lesley.ropp@va.gov
+- Product Manager: Rivka Gates, riva.gates@agile6.com
+- [Full ARF team roster](https://github.com/orgs/department-of-veterans-affairs/projects/947/views/4)
+
+## Communication
+Questions?  You can find us on the DSVA slack channel **#benefits-representative-facing**


### PR DESCRIPTION
[Zenhub issue 72493](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/72493)

Engineering is starting to have some completed / static documentation that we would put in a team folder in the `va.gov-team` repository if we as a team decide to use this as a repository of team and product artifacts. This commit spikes a `README.md` markdown file that I derived from ARM's folder in this repo. If the team likes this approach, we can start with this. I know that some engineers have already said they would be happy with using the `va.gov-team` repo.