### PR TITLE
Send slack notification GHA

### DIFF
--- a/.github/workflows/send slack notification GHA.yml
+++ b/.github/workflows/send slack notification GHA.yml
@@ -1,0 +1,21 @@
+name: Notify Slack
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  ticket-creation:
+    name: Create Completed Ticket
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.issue.labels.*.name, 'platform-tech-team-support') &&
+        (contains(github.event.issue.title, 'New VFS Team Member') || 
+        contains(github.event.issue.title, 'Platform Orientation Template'))
+        }}
+    steps:
+      - name: Send Slack message
+        uses: archive/github-actions-slack@v1.0.3
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+          slack-channel: C03JZS08VV4


### PR DESCRIPTION
This GitHub action will send a slack notification to platform-infrastructure-alerts slack channel when a "New VFS Team Member" issue is opened.