### PR TITLE
Add directions about future rates pages to GH documentation 

### DIFF
--- a/teams/vsa/teams/sitewide-content/how-to-do-different-tasks/how-to-update-rates-pages.md
+++ b/teams/vsa/teams/sitewide-content/how-to-do-different-tasks/how-to-update-rates-pages.md
@@ -34,7 +34,7 @@ Every year, the Sitewide Content team needs to update various rates pages with n
   - **Publish** the page.
 6. Update left nav to show the rates pages for the last 3 years.
 - Order the past rates pages from newest to oldest in the left nav menu.
-- If there are more than 3 years of past rates, unclick "enabled" in the menu so that it no longer shows in the left nav.
+- If there are more than 3 years of past rates, unclick "enabled" in the menu for the oldest rates page so that it no longer shows in the left nav.
 7. Once pages are live, create an IA ticket for Best Bets to be updated to show the newest year.
 
 ## How to set up a future rates page
@@ -44,9 +44,10 @@ We need to publish future rates information for a few of our education rates pag
 1. Request future rates for the upcoming year from stakeholder by email.
   - Reach out to an OCTO content lead for the appropriate stakeholder to contact.
   - Confirm with stakeholder what date we should publish the future rates page.
-2. In Drupal, revert node to the last version that showed future rates information.
-  - Go to the Revisions tab in Drupal and find last published version of page that contained specific rates information for that year.
-  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again). This version should be labeled "OK to revert—most current actual future rates text."
+2. In Drupal, revert node to the last draft version that showed future rates information.
+**Note:** When reverting pages in Drupal, always revert to a **draft** version. Reverting to a published version will automatically cause it to publish.  
+  - Go to the Revisions tab in Drupal and find the last published version of page that contained specific rates information for that year.
+  - Use the **draft** version before the last published version and select the Revert button to the right. This version should be labeled "OK to revert—most current actual future rates text."
 3. Update draft version of future rates page.
   - Update the calendar year in the intro and meta description.
   - Update dates, rate amounts, and calculations throughout the rates page.
@@ -58,9 +59,10 @@ Click **Save as draft**.
   - **Publish** the page.
 
 ### When publishing placeholder future rates page
-1. In Drupal, revert node to the last version that showed future rates placeholder information.
+1. In Drupal, revert node to the last draft version that showed future rates placeholder information.
+**Note:** When reverting pages in Drupal, always revert to a **draft** version. Reverting to a published version will automatically cause it to publish. 
   - Go to Revisions tab in Drupal and find last published version of page that contained placeholder future rates text for that year.
-  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again). This version should be labeled "OK to revert—most current placeholder text."
+  - Use the **draft** version before the last published version and select the Revert button to the right. This version should be labeled "OK to revert—most current placeholder text."
 2. Update draft version of future rates page.
   - Update calendar year in the intro and meta description.
   - Confirm the box for including a table of contents is not selected.

--- a/teams/vsa/teams/sitewide-content/how-to-do-different-tasks/how-to-update-rates-pages.md
+++ b/teams/vsa/teams/sitewide-content/how-to-do-different-tasks/how-to-update-rates-pages.md
@@ -46,7 +46,7 @@ We need to publish future rates information for a few of our education rates pag
   - Confirm with stakeholder what date we should publish the future rates page.
 2. In Drupal, revert node to the last version that showed future rates information.
   - Go to the Revisions tab in Drupal and find last published version of page that contained specific rates information for that year.
-  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again).
+  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again). This version should be labeled "OK to revert—most current actual future rates text."
 3. Update draft version of future rates page.
   - Update the calendar year in the intro and meta description.
   - Update dates, rate amounts, and calculations throughout the rates page.
@@ -54,20 +54,21 @@ We need to publish future rates information for a few of our education rates pag
 Click **Save as draft**.
 4. Review and publish the updated future rates page. This is done by the final reviewer.
   - Confirm that the rate amounts, dates, and calculations are correct. Make sure the links work.
-  - **Publish** the page and leave a note in the Drupal log that this is the future rates page so an editor will know which version to use the next time this page needs to be updated. (Example: "OK to publish-use for actual future rates")
+  - Save a final draft version and leave this note in the Drupal log: "OK to revert—most current actual future rates text." This ensures another editor will know which version to use the next time this page needs to be updated. 
+  - **Publish** the page.
 
 ### When publishing placeholder future rates page
 1. In Drupal, revert node to the last version that showed future rates placeholder information.
   - Go to Revisions tab in Drupal and find last published version of page that contained placeholder future rates text for that year.
-  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again).
+  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again). This version should be labeled "OK to revert—most current placeholder text."
 2. Update draft version of future rates page.
   - Update calendar year in the intro and meta description.
   - Confirm the box for including a table of contents is not selected.
 Click **Save as draft**.
 3. Review and publish the updated future rates placeholder page. This is done by the final reviewer.
   - Confirm that the dates are correct. Make sure the links work.
-  - **Publish** the page and leave a note in the Drupal log that this is the placeholder future rates page so an editor will know which version to use the next time this page needs to be updated. (Example: "OK to publish-use for placeholder future rates")
-
+  - Save a final draft version and leave this note in the Drupal log: "OK to revert—most current placeholder text." This ensures another editor will know which version to use the next time this page needs to be updated. 
+  - **Publish** the page.
 ## Resources
 [Rate pages update table](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/sitewide-content/rate-page-update-audit.md_)
 

--- a/teams/vsa/teams/sitewide-content/how-to-do-different-tasks/how-to-update-rates-pages.md
+++ b/teams/vsa/teams/sitewide-content/how-to-do-different-tasks/how-to-update-rates-pages.md
@@ -1,12 +1,12 @@
 # Rates updates process 
 
-Every year, the Sitewide Content team needs to update various rates pages with new numbers and information. When we do this, we also turn the current rates page into a past rates page. This document outlines this process so that any content team member will know how to do this going forward.
+Every year, the Sitewide Content team needs to update various rates pages with new numbers and information. When we do this, we also turn the current rates page into a past rates page. For certain education rates pages, we also need to publish future rates pages as well. This document outlines this process so that any content team member will know how to do this going forward.
 
 ## How to update the current rates page and create a past rates page
 
 1. Request rates for the upcoming year from stakeholder by email.
-  - Reach out to Beth or Danielle for the appropriate stakeholder to contact.
-  - **Tip:** For rate pages where the new rates go into effect on January 1 or another holiday, reach out to the stakeholder to see if the pages can be published earlier.
+  - Reach out to an OCTO content lead for the appropriate stakeholder to contact.
+  - **Tip:** For rate pages where the new rates go into effect on January 1 or a weekend day, reach out to the stakeholder to see if the pages can be published earlier.
 2. In Drupal, clone the current rates page to create the past rates page.
   - On the Drupal login page, click on the **Content** tab. 
   - Enter the current rates page title in the "Title" field and click **Filter**.
@@ -23,7 +23,7 @@ Every year, the Sitewide Content team needs to update various rates pages with n
   - Click **Save as draft**.
     - **Tip:** Do this before updating the current page. You’ll need this Node ID/page title to add to the Past rates section on the current page. 
  4. Update current page.
-  - Update calendar year in page title, page intro and meta tags
+  - Update calendar year in page title, page intro, and meta tags
   - Update dates, rate amounts, and calculations throughout the rates page.
     - **Tip:** For more complicated/rates heavy pages such as the VA DIC rates for parents page, save as you go! You can also coordinate with a team member to get on a call to tackle the updates together. One of you can recite the rate amount, while the other enters the new rate amount in Drupal.
   - In the **Past rates** section, add the newly created past rates page link to the top of list.
@@ -37,7 +37,38 @@ Every year, the Sitewide Content team needs to update various rates pages with n
 - If there are more than 3 years of past rates, unclick "enabled" in the menu so that it no longer shows in the left nav.
 7. Once pages are live, create an IA ticket for Best Bets to be updated to show the newest year.
 
+## How to set up a future rates page
+We need to publish future rates information for a few of our education rates pages several months before they go into effect. These nodes already exist in Drupal and we only need to make updates to them with specific rate information or general content letting users know future rates will be coming.
+
+### When publishing future rates
+1. Request future rates for the upcoming year from stakeholder by email.
+  - Reach out to an OCTO content lead for the appropriate stakeholder to contact.
+  - Confirm with stakeholder what date we should publish the future rates page.
+2. In Drupal, revert node to the last version that showed future rates information.
+  - Go to the Revisions tab in Drupal and find last published version of page that contained specific rates information for that year.
+  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again).
+3. Update draft version of future rates page.
+  - Update the calendar year in the intro and meta description.
+  - Update dates, rate amounts, and calculations throughout the rates page.
+    - **Tip:** For more complicated/rates heavy pages such as the VA DIC rates for parents page, save as you go! You can also coordinate with a team member to get on a call to tackle the updates together. One of you can recite the rate amount, while the other enters the new rate amount in Drupal.
+Click **Save as draft**.
+4. Review and publish the updated future rates page. This is done by the final reviewer.
+  - Confirm that the rate amounts, dates, and calculations are correct. Make sure the links work.
+  - **Publish** the page and leave a note in the Drupal log that this is the future rates page so an editor will know which version to use the next time this page needs to be updated. (Example: "OK to publish-use for actual future rates")
+
+### When publishing placeholder future rates page
+1. In Drupal, revert node to the last version that showed future rates placeholder information.
+  - Go to Revisions tab in Drupal and find last published version of page that contained placeholder future rates text for that year.
+  - Use the **draft** version before the last published version and select the Revert button to the right. (If you select the last published version, the node will automatically be published again).
+2. Update draft version of future rates page.
+  - Update calendar year in the intro and meta description.
+  - Confirm the box for including a table of contents is not selected.
+Click **Save as draft**.
+3. Review and publish the updated future rates placeholder page. This is done by the final reviewer.
+  - Confirm that the dates are correct. Make sure the links work.
+  - **Publish** the page and leave a note in the Drupal log that this is the placeholder future rates page so an editor will know which version to use the next time this page needs to be updated. (Example: "OK to publish-use for placeholder future rates")
+
 ## Resources
 [Rate pages update table](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/sitewide-content/rate-page-update-audit.md_)
 
-[Editorial calendar](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/vsa/teams/sitewide-content/editorial-calendar)
+[Editorial calendar](https://dvagov.sharepoint.com/:x:/r/sites/SitewideCAIA/Shared%20Documents/3.0%20Static%[…]x?d=we014b0aafd534ffeb13f5af992ab79c2&csf=1&web=1&e=F6l14Y)


### PR DESCRIPTION
We've added directions to our GH documentation for how to create and update future rates pages for education rates. 