### PR TITLE
73938 Create ARF Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
@@ -1,3 +1,12 @@
+---
+name: ARF Engineering Bug Issue
+about: Bug issues for the ARF Engineering team
+title: ''
+labels: 'accredited-rep-facing', 'arf-eng'
+assignees: ''
+
+---
+
 ### Description
 <!-- A brief description of the bug -->
 

--- a/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
@@ -1,5 +1,5 @@
 ### Description
-A brief description of the bug
+<!-- A brief description of the bug -->
 
 ### Steps to Reproduce
 1. 
@@ -7,13 +7,13 @@ A brief description of the bug
 3. 
 
 ### Expected vs Actual Behavior
-What you expected to happen vs what actually happened
+<!-- What you expected to happen vs what actually happened -->
 
 ### Severity
-Severity level of the bug (low, medium, high)
+<!-- Severity level of the bug (low, medium, high) -->
 
 ### Screenshots/Logs
-Attach any relevant screenshots or logs
+<!-- Attach any relevant screenshots or logs -->
 
 ### Acceptance Criteria
 - [ ] Identified the cause of the bug

--- a/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
@@ -1,0 +1,21 @@
+### Description
+A brief description of the bug
+
+### Steps to Reproduce
+1. 
+2. 
+3. 
+
+### Expected vs Actual Behavior
+What you expected to happen vs what actually happened
+
+### Severity
+Severity level of the bug (low, medium, high)
+
+### Screenshots/Logs
+Attach any relevant screenshots or logs
+
+### Acceptance Criteria
+- [ ] Identified the cause of the bug
+- [ ] Implemented a fix
+- [ ] Tested the fix

--- a/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
@@ -18,7 +18,7 @@ assignees: ''
 #### Background
 <!-- Provide relevant background information -->
 
-#### Hypotheses (optional)
+#### Hypotheses
 <!-- Include any hypotheses if applicable -->
 
 #### Resources

--- a/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
@@ -1,0 +1,20 @@
+### Description
+
+#### Key Questions
+List the main questions the ticket aims to address
+
+#### Objective
+Clearly state the goal of the ticket
+
+#### Background
+Provide relevant background information
+
+#### Hypotheses (optional)
+Include any hypotheses if applicable
+
+#### Resources
+Mention required resources such as documentation and personnel
+
+### Acceptance Criteria
+Define the expected outcome and the output to be created
+- [ ]  

--- a/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
@@ -1,3 +1,12 @@
+---
+name: ARF Engineering Discovery Issue
+about: Discovery issues for the ARF team
+title: ''
+labels: 'accredited-rep-facing', 'arf-eng'
+assignees: ''
+
+---
+
 ### Description
 
 #### Key Questions

--- a/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
@@ -1,20 +1,20 @@
 ### Description
 
 #### Key Questions
-List the main questions the ticket aims to address
+<!-- List the main questions the ticket aims to address -->
 
 #### Objective
-Clearly state the goal of the ticket
+<!-- Clearly state the goal of the ticket -->
 
 #### Background
-Provide relevant background information
+<!-- Provide relevant background information -->
 
 #### Hypotheses (optional)
-Include any hypotheses if applicable
+<!-- Include any hypotheses if applicable -->
 
 #### Resources
-Mention required resources such as documentation and personnel
+<!-- Mention required resources such as documentation and personnel -->
 
 ### Acceptance Criteria
-Define the expected outcome and the output to be created
+<!-- Define the expected outcome and the output to be created -->
 - [ ]  

--- a/.github/ISSUE_TEMPLATE/arf-eng-epic.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-epic.md
@@ -1,3 +1,11 @@
+---
+name: ARF Engineering Epic
+about: Epic template for the ARF engineering team
+title: ''
+labels: 'accredited-rep-facing', 'arf-eng'
+assignees: ''
+---
+
 ### Overview
 <!-- Brief description of the epic's purpose and scope -->
 

--- a/.github/ISSUE_TEMPLATE/arf-eng-epic.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-epic.md
@@ -1,0 +1,26 @@
+### Overview
+<!-- Brief description of the epic's purpose and scope -->
+
+### Business Value
+<!-- Explanation of the value this epic brings to the business or project -->
+
+### Goals
+<!-- Key goals and objectives this epic aims to achieve -->
+
+### In-Scope
+<!-- List of features, user stories, or tasks that are included in this epic -->
+
+### Out-of-Scope
+<!-- Clarification of what is not included in this epic -->
+
+### Dependencies
+<!-- Any dependencies or prerequisites for this epic -->
+
+### Risks/Assumptions
+<!-- Potential risks or assumptions associated with this epic -->
+
+### Timeline
+<!-- Proposed timeline or milestones for the epic -->
+
+### Stakeholders
+<!-- List of stakeholders involved or impacted by this epic -->

--- a/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
@@ -1,3 +1,11 @@
+---
+name: ARF Engineering Feature Issue
+about: Feature issue template for the ARF Engineering team
+title: ''
+labels: 'accredited-rep-facing', 'arf-eng'
+assignees: ''
+--
+
 ### Description
 
 #### User Story or Problem Statement

--- a/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
@@ -1,0 +1,41 @@
+### Description
+
+#### User Story or Problem Statement
+Outline the user story or the problem being addressed
+
+#### Implementation Details
+Describe how the feature or solution should be implemented
+
+#### Mockups/Designs
+Include any available mockups or design elements
+
+#### Prerequisites/Dependencies
+List any prerequisites or dependencies
+
+#### Blockers
+Identify any potential obstacles
+
+#### Specifications
+Detail the technical specifications required
+
+### Acceptance Criteria
+Specify criteria for ticket completion
+- [ ]
+
+#### Testing Criteria
+Outline the testing criteria (to be defined by the engineering team)
+
+#### Automated Testing
+Indicate the requirement for automated testing beyond unit tests
+
+#### Accessibility (A11y) Testing 
+Confirm that accessibility testing is completed
+
+#### Documentation
+Ensure relevant documentation is created or updated
+
+#### Monitoring
+Implement monitoring where appropriate (to be defined by the engineering team)
+
+#### PII/PHI Security
+Verify that personally identifiable information/protected health information is secure

--- a/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
@@ -1,41 +1,41 @@
 ### Description
 
 #### User Story or Problem Statement
-Outline the user story or the problem being addressed
+<!-- Outline the user story or the problem being addressed -->
 
 #### Implementation Details
-Describe how the feature or solution should be implemented
+<!-- Describe how the feature or solution should be implemented -->
 
 #### Mockups/Designs
-Include any available mockups or design elements
+<!-- Include any available mockups or design elements -->
 
 #### Prerequisites/Dependencies
-List any prerequisites or dependencies
+<!-- List any prerequisites or dependencies -->
 
 #### Blockers
-Identify any potential obstacles
+<!-- Identify any potential obstacles -->
 
 #### Specifications
-Detail the technical specifications required
+<!-- Detail the technical specifications required -->
 
 ### Acceptance Criteria
-Specify criteria for ticket completion
+<!-- Specify criteria for ticket completion -->
 - [ ]
 
 #### Testing Criteria
-Outline the testing criteria (to be defined by the engineering team)
+<!-- Outline the testing criteria (to be defined by the engineering team) -->
 
 #### Automated Testing
-Indicate the requirement for automated testing beyond unit tests
+<!-- Indicate the requirement for automated testing beyond unit tests -->
 
 #### Accessibility (A11y) Testing 
-Confirm that accessibility testing is completed
+<!-- Confirm that accessibility testing is completed -->
 
 #### Documentation
-Ensure relevant documentation is created or updated
+<!-- Ensure relevant documentation is created or updated -->
 
 #### Monitoring
-Implement monitoring where appropriate (to be defined by the engineering team)
+<!-- Implement monitoring where appropriate (to be defined by the engineering team) -->
 
 #### PII/PHI Security
-Verify that personally identifiable information/protected health information is secure
+<!-- Verify that personally identifiable information/protected health information is secure -->


### PR DESCRIPTION
In order to expedite Zenhub engineering issue creation and to encourage consistency we need Zenhub engineering issue templates.  The [ARF Engineering Zenhub Issue Guidelines](https://docs.google.com/document/d/10cWbnl9a8omazCbajIbTFXCDHh2kMdoDgFLkWos4OhY/edit#heading=h.cbpui75bd9v1) were used as the source material.

Zenhub Issue: https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/73938