### PR TITLE
73938 Add section on Zenhub Eng Issue Templates

### DIFF
--- a/products/accredited-representative-facing/process/engineering-agreements.md
+++ b/products/accredited-representative-facing/process/engineering-agreements.md
@@ -41,4 +41,12 @@ We adhere to the Platform guidelines: [DEPO Platform Documentation](https://depo
 
 ### Zenhub
 
+- Use an ARF Engineering ZenHub Template for creating every issue.
+- None of the sections in the templates are explicitly labeled as 'required' or 'optional.' Therefore, it is up to the person creating the issue to decide which sections to include.
+- If important sections are consistently omitted, we can consider adding 'required' labels in the next iteration of the templates.
+- To update a template edit the corresponding file:
+  - [Discovery Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md)
+  - [Feature Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md)
+  - [Bug Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md)
+  - [Epic Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-eng-epic.md)
 - Link PRs to the corresponding Zenhub issues if they exist.


### PR DESCRIPTION
An AC of this issue - [Create Zenhub engineering issue templates#73938](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/73938) - was to "Call out this Zenhub issue template capability in one of our team's engineering practice documents". This PR aims to do that.