### PR TITLE
74915 Create Zenhub design issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
@@ -2,7 +2,7 @@
 name: ARF Design 'Design' Issue
 about: Design issue for the ARF Design Team
 title: ''
-labels: 'accredited-rep-facing', 'arf-des'
+labels: ['accredited-rep-facing', 'arf-des']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!-- Title ^^ : Provide a concise summary of the task. For tasks related to specific studies, prepend the study's abbreviation to the title. -->
+<!-- Title ^^ : Provide a concise summary of the task. For tasks related to specific studies, prepend the study's abbreviation to the title: [user][phase of work/method] -->
 
 ### Description
 
@@ -17,6 +17,8 @@ assignees: ''
 #### What’s the solution or plan to address the problem
 <!-- Detailed Plan: Outline the proposed solution in detail, ensuring the description is clear enough for anyone to be able to pick up the task. -->
 <!-- Expected Output: Specify what the final output should look like. -->
+<!-- Fidelity -->
+<!-- Resources -->
 <!-- What screens or what the artifact type is, research output links for research being used for this ticket, and/or design library/CAIA’s content outlines -->
 
 ### Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
@@ -1,6 +1,6 @@
 ---
-name: ARF Design 'Design' Issue
-about: 'Design' issue for the ARF Design Team
+name: ARF Des Design Issue
+about: Design issue for the ARF Des Team
 title: ''
 labels: ['accredited-rep-facing', 'arf-des']
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
@@ -1,23 +1,23 @@
 ---
 name: ARF Design 'Design' Issue
-about: Design issue for the ARF Design Team
+about: 'Design' issue for the ARF Design Team
 title: ''
 labels: ['accredited-rep-facing', 'arf-des']
 assignees: ''
 
 ---
 
-<!-- Title ^^ : Short form of what needs to be done, if it’s part of a specific study use the abbreviation of the study at the front of the ticket -->
+<!-- Title ^^ : Provide a concise summary of the task. For tasks related to specific studies, prepend the study's abbreviation to the title. -->
 
 ### Description
 
 #### What’s the problem
-<!-- User Story -->
+<!-- Include user stories -->
 
 #### What’s the solution or plan to address the problem
-<!-- This should be as detailed as possible so that anyone would be able to pick up this issue up -->
-<!-- What’s the output -->
-<!-- Can include: What screens or what the artifact type is, Research output links for research being used for this ticket, Design library/CAIA’s content outlines -->
+<!-- Detailed Plan: Outline the proposed solution in detail, ensuring the description is clear enough for anyone to be able to pick up the task. -->
+<!-- Expected Output: Specify what the final output should look like. -->
+<!-- What screens or what the artifact type is, research output links for research being used for this ticket, and/or design library/CAIA’s content outlines -->
 
 ### Acceptance Criteria
-<!-- Define fidelity of output, User story satisfied by the output, Meets style guide requirements -->
+<!-- Define fidelity of output, user story satisfied by the output, and/or meets style guide requirements -->

--- a/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-design-issue.md
@@ -1,0 +1,23 @@
+---
+name: ARF Design 'Design' Issue
+about: Design issue for the ARF Design Team
+title: ''
+labels: 'accredited-rep-facing', 'arf-des'
+assignees: ''
+
+---
+
+<!-- Title ^^ : Short form of what needs to be done, if it’s part of a specific study use the abbreviation of the study at the front of the ticket -->
+
+### Description
+
+#### What’s the problem
+<!-- User Story -->
+
+#### What’s the solution or plan to address the problem
+<!-- This should be as detailed as possible so that anyone would be able to pick up this issue up -->
+<!-- What’s the output -->
+<!-- Can include: What screens or what the artifact type is, Research output links for research being used for this ticket, Design library/CAIA’s content outlines -->
+
+### Acceptance Criteria
+<!-- Define fidelity of output, User story satisfied by the output, Meets style guide requirements -->

--- a/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
@@ -1,0 +1,23 @@
+---
+name: ARF Design Research Issue
+about: Research issue for the ARF Design Team
+title: ''
+labels: 'accredited-rep-facing', 'arf-des'
+assignees: ''
+
+---
+
+<!-- Title ^^ : Short form of what needs to be done, if it’s part of a specific study use the abbreviation of the study at the front of the ticket -->
+
+### Description
+
+#### What’s the problem
+<!-- Problem statement -->
+
+#### What’s the solution or plan to address the problem
+<!-- This should be as detailed as possible so that anyone would be able to pick up this issue up -->
+<!-- What’s the output -->
+<!-- Can Include: High level methodology, Research goal or hypothesis, Reference links, What user group/persona -->
+
+### Acceptance Criteria
+<!-- Whatever the artifact is is created -->

--- a/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
@@ -2,7 +2,7 @@
 name: ARF Design Research Issue
 about: Research issue for the ARF Design Team
 title: ''
-labels: 'accredited-rep-facing', 'arf-des'
+labels: ['accredited-rep-facing', 'arf-eng']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
@@ -2,7 +2,7 @@
 name: ARF Design Research Issue
 about: Research issue for the ARF Design Team
 title: ''
-labels: ['accredited-rep-facing', 'arf-eng']
+labels: ['accredited-rep-facing', 'arf-des']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
@@ -17,6 +17,7 @@ assignees: ''
 #### What’s the solution or plan to address the problem
 <!-- Detailed Plan: Outline the proposed solution in detail, ensuring the description is clear enough for anyone to be able to pick up the task. -->
 <!-- Expected Output: Specify what the final output should look like. -->
+<!-- Fidelity -->
 <!-- High level methodology, research goal or hypothesis, reference links, and/or what user group/persona -->
 
 ### Acceptance Criteria

--- a/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-des-research-issue.md
@@ -7,17 +7,17 @@ assignees: ''
 
 ---
 
-<!-- Title ^^ : Short form of what needs to be done, if it’s part of a specific study use the abbreviation of the study at the front of the ticket -->
+<!-- Title ^^ : Provide a concise summary of the task. For tasks related to specific studies, prepend the study's abbreviation to the title. -->
 
 ### Description
 
 #### What’s the problem
-<!-- Problem statement -->
+<!-- Include problem statement -->
 
 #### What’s the solution or plan to address the problem
-<!-- This should be as detailed as possible so that anyone would be able to pick up this issue up -->
-<!-- What’s the output -->
-<!-- Can Include: High level methodology, Research goal or hypothesis, Reference links, What user group/persona -->
+<!-- Detailed Plan: Outline the proposed solution in detail, ensuring the description is clear enough for anyone to be able to pick up the task. -->
+<!-- Expected Output: Specify what the final output should look like. -->
+<!-- High level methodology, research goal or hypothesis, reference links, and/or what user group/persona -->
 
 ### Acceptance Criteria
-<!-- Whatever the artifact is is created -->
+- [ ] The artifact is created

--- a/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
@@ -2,7 +2,7 @@
 name: ARF Engineering Bug Issue
 about: Bug issues for the ARF Engineering team
 title: ''
-labels: 'accredited-rep-facing', 'arf-eng'
+labels: ['accredited-rep-facing', 'arf-eng']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-discovery-issue.md
@@ -1,8 +1,8 @@
 ---
 name: ARF Engineering Discovery Issue
-about: Discovery issues for the ARF team
+about: Discovery issues for the ARF Engineering team
 title: ''
-labels: 'accredited-rep-facing', 'arf-eng'
+labels: ['accredited-rep-facing', 'arf-eng']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/arf-eng-epic.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-epic.md
@@ -2,7 +2,7 @@
 name: ARF Engineering Epic
 about: Epic template for the ARF engineering team
 title: ''
-labels: 'accredited-rep-facing', 'arf-eng'
+labels: ['accredited-rep-facing', 'arf-eng']
 assignees: ''
 ---
 

--- a/.github/ISSUE_TEMPLATE/arf-eng-epic.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-epic.md
@@ -1,9 +1,10 @@
 ---
 name: ARF Engineering Epic
-about: Epic template for the ARF engineering team
+about: Epic template for the ARF Engineering team
 title: ''
 labels: ['accredited-rep-facing', 'arf-eng']
 assignees: ''
+
 ---
 
 ### Overview

--- a/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
+++ b/.github/ISSUE_TEMPLATE/arf-eng-feature-issue.md
@@ -2,9 +2,10 @@
 name: ARF Engineering Feature Issue
 about: Feature issue template for the ARF Engineering team
 title: ''
-labels: 'accredited-rep-facing', 'arf-eng'
+labels: ['accredited-rep-facing', 'arf-eng']
 assignees: ''
---
+
+---
 
 ### Description
 

--- a/.github/ISSUE_TEMPLATE/arf-epic.md
+++ b/.github/ISSUE_TEMPLATE/arf-epic.md
@@ -1,8 +1,8 @@
 ---
-name: ARF Engineering Epic
-about: Epic template for the ARF Engineering team
+name: ARF Epic
+about: Epic template for the ARF team
 title: ''
-labels: ['accredited-rep-facing', 'arf-eng']
+labels: ['accredited-rep-facing', 'arf-eng', 'arf-des']
 assignees: ''
 
 ---


### PR DESCRIPTION
### Description
In order to expedite Zenhub design issue creation and to encourage consistency we need Zenhub design issue templates.

### Acceptance Criteria
- [x] [Design]() Zenhub issue template created (prefixed with team label)
- [x] [Research]() Zenhub issue template created (prefixed with team label)
- [x] Epic template created (prefixed with team label) - DECIDED to make one Epic for both design and engineering so I renamed the "Epic Eng" to just "Epic"
- [x] Fix Zenhub labels YAML syntax issue in Engineering templates

### Output:
#### Fix Zenhub labels YAML syntax issue in Engineering templates
Main Branch (Has YAML Error): https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-eng-bug-issue.md
![image](https://github.com/department-of-veterans-affairs/va.gov-team/assets/22990386/e1ec5ba3-6e0d-4724-afae-03ddd2cd8267)

PR Branch (No Error): https://github.com/department-of-veterans-affairs/va.gov-team/blob/74915-arf-des-issue-templates/.github/ISSUE_TEMPLATE/arf-eng-epic.md
![image](https://github.com/department-of-veterans-affairs/va.gov-team/assets/22990386/76c36fb5-a936-461c-a985-b9b8801e05ff)