### PR TITLE
Create documentation for adding teams and users

### DIFF
--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -22,9 +22,9 @@ configurations for client applications integrated with SiS.
 
 ### Adding a Team
 
-Follow these steps to create a team in Identity Dashboard:
+Follow these steps to create a team:
 
-* Submit request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to create a new team in Identity Dashboard.
+* Submit request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to create a new team.
 * The request should contain the following information:
   * The environment to load the users in (staging or production.)
   * `name`: the human-readable name for the team.
@@ -54,14 +54,14 @@ Follow these steps to update a team:
       * `email`: The email address associated with the admin's Login.gov account.
       * `first_name`: The first name for the admin.
       * `last_name`: The last name for the admin.
-* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team. Requests from non-admins will be denied.
 * The OCTO-Identity team will then update the specified team using the details provided.
 
 ### Removing a Team
 
 **Please note that any request to remove a team must be sent from a user who is an admin for that team.**
 
-**Removing a team is a dangerous operation as it will result in the deletion of any client configs associated with that team.**
+**Removing a team is a dangerous operation as it will result in the deletion of any client configurations associated with that team.**
 
 Follow these steps to remove a team:
 
@@ -75,7 +75,7 @@ Follow these steps to remove a team:
 
 ## Team Users
 
-Teams contain users who have roles for managing teams and client application configurations within ID. These roles provide granular access control for team members depending on their role.
+Teams contain users who have roles for managing teams and client application configurations. These roles provide granular access control for team members depending on their role.
 
 For instance, team leads will likely need the ability to administer their teams (updating team information, adding new team users, etc.), but may not require full access to update the 
 client application configurations for which their teams are responsible. Conversely, engineers will almost certainly need access to administer client application configurations, but are unlikely to require permissions for administering teams.
@@ -97,7 +97,7 @@ Follow these steps to add users to a team:
     * `last_name`: The last name for the user.
     * Should the user be able to make requests to update the team or team roster? (yes or no)
     * Should the user be able to make requests to administer client application configurations? (yes or no)
-* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team. Requests from non-admins will be denied.
 * The OCTO-Identity team will then create the requested team users using the details provided.
    
 ### Updating a Team User
@@ -118,7 +118,7 @@ Follow these steps to update a team user:
     * `last_name`: The last name for the user.
     * Should the user be able to make requests to update the team or team roster? (yes or no)
     * Should the user be able to make requests to administer client application configurations? (yes or no)
-* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team. Requests from non-admins will be denied.
 * The OCTO-Identity team will then update the specified team user(s) using the details provided.
 
 ### Removing a Team User
@@ -133,5 +133,5 @@ Follow these steps to remove a team user:
     * You may request the change apply to all environments if the user has changed roles and should be removed across all environments.
   * The `email` corresponding to the team user.
   * The `name` for each team to remove the user from.
-* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team. Requests from non-admins will be denied.
 * The OCTO-Identity team will then remove the specified team user(s).

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -1,8 +1,13 @@
 # Managing Teams and Users
 
+Identity Dashboard (ID) is an internal tool for managing client application integrations with Sign-in Service (SiS). The OCTO-Identity team 
+maintains ID and handles configuration requests from other teams who leverage SiS to provide an authenticated user experience. This document describes 
+how requests to change a client application's configuration details should be submitted for timely processing.
+
 ## Teams
 
-Teams are the organization units responsible for managing client application integrations with Sign-in Service.
+Teams are the organization units responsible for managing client application integrations with SiS. Each team has users who belong to it and 
+configurations for client applications integrated with SiS.
 
 ### Adding a Team
 
@@ -18,6 +23,7 @@ Follow these steps to create a team in Identity Dashboard:
     * `email`: The email address associated with the admin's Login.gov account.
     * `first_name`: The first name for the admin.
     * `last_name`: The last name for the admin.
+* The OCTO-Identity team will then create the requested team using the details provided.
    
 ### Updating a Team
 
@@ -37,6 +43,8 @@ Follow these steps to update a team:
       * `email`: The email address associated with the admin's Login.gov account.
       * `first_name`: The first name for the admin.
       * `last_name`: The last name for the admin.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* The OCTO-Identity team will then update the specified team using the details provided.
 
 ### Removing a Team
 
@@ -50,14 +58,20 @@ Follow these steps to remove a team:
 * The request should contain the following information:
   * The environment of the team.
   * The `name` of the team.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* If applicable, the OCTO-Identity team will inform the requestor of any client configurations that will be impacted by the removal of the team prior to executing the request.
+* The OCTO-Identity team will then remove the specified team.
 
 ## Team Users
 
-Teams contain users who have roles for managing dashboard apps within Identity Dashboard. Currently, there are two dashboard apps: Admin Portal and Client Config.
+Teams contain users who have roles for managing teams and client application configurations within ID. These roles provide granular access control for team members depending on their role.
 
-The Admin Portal dashboard app allows users to configure and manage their teams within Identity Dashboard. Users with an `admin` role can create new teams and manage the users that belong to those teams along with their roles. Users with a `member` role are restricted to viewing the existing teams and their associated users.
+For instance, team leads will likely need the ability to administer their teams (updating team information, adding new team users, etc.), but may not require full access to update the 
+client application configurations for which their teams are responsible. Conversely, engineers will almost certainly need access to administer client application configurations, but are unlikely to require permissions for administering teams.
 
-The Client Config dashboard app allows users to manage their Sign-in Service integrated client applications. Each client config belongs to a single team who is responsible for managing the integration. Users with an `admin` role can create and manage client configs, whereas users with an `member` role can only view their teams' integrations.
+With respect to teams, users with an `admin` role can create new teams and manage the users that belong to those teams along with their roles. Users with a `member` role are restricted to viewing the existing teams and their associated users.
+
+With respect to client application configurations, users with an `admin` role can create and manage client configurations, whereas users with a `member` role can only view their teams' integrations.
 
 ### Adding Users to a Team
 
@@ -67,15 +81,17 @@ Follow these steps to add users to a team:
 
 * Submit request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to add users to a team.
 * The request should contain the following information:
-  * The team the users should be added to.
-  * The environment to load the users in (staging or production.)
+  * The team the user(s) should be added to.
+  * The environment to load the user(s) in (staging or production.)
   * A list of users with the following information:
     * `logingov_uuid`: The UUID associated with the user's Login.gov account.
     * `email`: The email address associated with the user's Login.gov account.
     * `first_name`: The first name for the user.
     * `last_name`: The last name for the user.
-    * The role(s) the user should have for the Admin Portal dashboard app (`admin`, `member`, or none.)
-    * The role(s) the user should have for the Client Config dashboard app (`admin`, `member`, or none.)
+    * The role(s) the user should have with respect to teams (`admin`, `member`, or none.)
+    * The role(s) the user should have with respect to client application configurations (`admin`, `member`, or none.)
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* The OCTO-Identity team will then create the requested team users using the details provided.
    
 ### Updating a Team User
 
@@ -93,8 +109,10 @@ Follow these steps to update a team user:
     * `email`: The email address associated with the user's Login.gov account.
     * `first_name`: The first name for the user.
     * `last_name`: The last name for the user.
-    * The role(s) the user should have for the Admin Portal dashboard app (`admin`, `member`, or none.)
-    * The role(s) the user should have for the Client Config dashboard app (`admin`, `member`, or none.)
+    * The role(s) the user should have with respect to teams (`admin`, `member`, or none.)
+    * The role(s) the user should have with respect to client application configurations (`admin`, `member`, or none.)
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* The OCTO-Identity team will then update the specified team user(s) using the details provided.
 
 ### Removing a Team User
 
@@ -108,3 +126,5 @@ Follow these steps to remove a team user:
     * You may request the change apply to all environments if the user has changed roles and should be removed across all environments.
   * The `email` corresponding to the team user.
   * The `name` for each team to remove the user from.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* The OCTO-Identity team will then remove the specified team user(s).

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -27,7 +27,7 @@ Follow these steps to create a team in Identity Dashboard:
    
 ### Updating a Team
 
-**Please note that any request to update a team must be sent from a user with an `admin` role for that team.**
+**Please note that any request to update a team must be sent from a user who is an admin for that team.**
 
 Follow these steps to update a team:
 
@@ -48,7 +48,7 @@ Follow these steps to update a team:
 
 ### Removing a Team
 
-**Please note that any request to remove a team must be sent from a user with an `admin` role for that team.**
+**Please note that any request to remove a team must be sent from a user who is an admin for that team.**
 
 **Removing a team is a dangerous operation as it will result in the deletion of any client configs associated with that team.**
 
@@ -69,13 +69,9 @@ Teams contain users who have roles for managing teams and client application con
 For instance, team leads will likely need the ability to administer their teams (updating team information, adding new team users, etc.), but may not require full access to update the 
 client application configurations for which their teams are responsible. Conversely, engineers will almost certainly need access to administer client application configurations, but are unlikely to require permissions for administering teams.
 
-With respect to teams, users with an `admin` role can create new teams and manage the users that belong to those teams along with their roles. Users with a `member` role are restricted to viewing the existing teams and their associated users.
-
-With respect to client application configurations, users with an `admin` role can create and manage client configurations, whereas users with a `member` role can only view their teams' integrations.
-
 ### Adding Users to a Team
 
-**Please note that any request to add users to a team must be sent from a user with an `admin` role for that team.**
+**Please note that any request to add users to a team must be sent from a user who is an admin for that team.**
 
 Follow these steps to add users to a team:
 
@@ -88,14 +84,14 @@ Follow these steps to add users to a team:
     * `email`: The email address associated with the user's Login.gov account.
     * `first_name`: The first name for the user.
     * `last_name`: The last name for the user.
-    * The role(s) the user should have with respect to teams (`admin`, `member`, or none.)
-    * The role(s) the user should have with respect to client application configurations (`admin`, `member`, or none.)
+    * Should the user be able to make requests to update the team or team roster? (yes or no)
+    * Should the user be able to make requests to administer client application configurations? (yes or no)
 * Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
 * The OCTO-Identity team will then create the requested team users using the details provided.
    
 ### Updating a Team User
 
-**Please note that any request to update a team user must be sent from a user with an `admin` role for that team.**
+**Please note that any request to update a team user must be sent from a user who is an admin for that team.**
 
 Follow these steps to update a team user:
 
@@ -109,14 +105,14 @@ Follow these steps to update a team user:
     * `email`: The email address associated with the user's Login.gov account.
     * `first_name`: The first name for the user.
     * `last_name`: The last name for the user.
-    * The role(s) the user should have with respect to teams (`admin`, `member`, or none.)
-    * The role(s) the user should have with respect to client application configurations (`admin`, `member`, or none.)
+    * Should the user be able to make requests to update the team or team roster? (yes or no)
+    * Should the user be able to make requests to administer client application configurations? (yes or no)
 * Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
 * The OCTO-Identity team will then update the specified team user(s) using the details provided.
 
 ### Removing a Team User
 
-**Please note that any request to remove a team user must be sent from a user with an `admin` role for that team.**
+**Please note that any request to remove a team user must be sent from a user who is an admin for that team.**
 
 Follow these steps to remove a team user:
 

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -1,8 +1,8 @@
 # Managing Teams and Users
 
-Identity Dashboard (ID) is an internal tool for managing client application integrations with Sign-in Service (SiS). The OCTO-Identity team 
-maintains ID and handles configuration requests from other teams who leverage SiS to provide an authenticated user experience. This document describes 
-how requests to change a client application's configuration details should be submitted for timely processing.
+Applications that serve veterans in the VA.gov ecosystem can leverage Sign-in Service (SiS) to provide an authenticated user experience. To ensure the security of 
+client application integrations, the OCTO-Identity team maintains a roster of development teams and team members; each team has ownership over their client application configuration, 
+and team members have different permissions based on their team role. This document describes how requests to manage teams and users should be submitted for timely processing.
 
 ## Table of Contents
 

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -4,6 +4,16 @@ Identity Dashboard (ID) is an internal tool for managing client application inte
 maintains ID and handles configuration requests from other teams who leverage SiS to provide an authenticated user experience. This document describes 
 how requests to change a client application's configuration details should be submitted for timely processing.
 
+# Table of contents
+- [Teams](#teams)
+  - [Adding a Team](#adding-a-team)
+  - [Updating a Team](#updating-a-team)
+  - [Removing a Team](#removing-a-team)
+- [Team Users](#team-users)
+  - [Adding Users to a Team](#adding-users-to-a-team)
+  - [Updating a Team User](#updating-a-team-user)
+  - [Removing a Team User](#removing-a-team-user)
+
 ## Teams
 
 Teams are the organization units responsible for managing client application integrations with SiS. Each team has users who belong to it and 

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -69,7 +69,7 @@ Follow these steps to remove a team:
 * The request should contain the following information:
   * The environment of the team.
   * The `name` of the team.
-* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team; requests from non-admins will be denied.
+* Prior to executing the request, the OCTO-Identity team will verify the requestor is an admin for the specified team. Requests from non-admins will be denied.
 * If applicable, the OCTO-Identity team will inform the requestor of any client configurations that will be impacted by the removal of the team prior to executing the request.
 * The OCTO-Identity team will then remove the specified team.
 

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -8,7 +8,7 @@ Teams are the organization units responsible for managing client application int
 
 Follow these steps to create a team in Identity Dashboard:
 
-* Submit request to the OCTO-Identity team to create a new team in Identity Dashboard.
+* Submit request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to create a new team in Identity Dashboard.
 * The request should contain the following information:
   * The environment to load the users in (staging or production.)
   * `name`: the human-readable name for the team.
@@ -25,7 +25,7 @@ Follow these steps to create a team in Identity Dashboard:
 
 Follow these steps to update a team:
 
-* Submit a request to the OCTO-Identity team to update a team.
+* Submit a request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to update a team.
 * The request should contain the following information:
   * The environment of the team.
   * The `name` of the team.
@@ -46,7 +46,7 @@ Follow these steps to update a team:
 
 Follow these steps to remove a team:
 
-* Submit a request to the OCTO-Identity team to remove a team.
+* Submit a request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to remove a team.
 * The request should contain the following information:
   * The environment of the team.
   * The `name` of the team.
@@ -65,7 +65,7 @@ The Client Config dashboard app allows users to manage their Sign-in Service int
 
 Follow these steps to add users to a team:
 
-* Submit request to the OCTO-Identity team to add users to a team.
+* Submit request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to add users to a team.
 * The request should contain the following information:
   * The team the users should be added to.
   * The environment to load the users in (staging or production.)
@@ -83,7 +83,7 @@ Follow these steps to add users to a team:
 
 Follow these steps to update a team user:
 
-* Submit a request to the OCTO-Identity team to update a team user.
+* Submit a request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to update a team user.
 * The request should contain the following information:
   * The environment of the team and team user.
   * The `name` of the team the user belongs to.
@@ -102,7 +102,7 @@ Follow these steps to update a team user:
 
 Follow these steps to remove a team user:
 
-* Submit a request to the OCTO-Identity team to remove a team user.
+* Submit a request to the OCTO-Identity team via the [#vsp-identity Slack channel](https://dsva.slack.com/archives/CSFV4QTKN) to remove a team user.
 * The request should contain the following information:
   * The environment of the team and user.
     * You may request the change apply to all environments if the user has changed roles and should be removed across all environments.

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -1,0 +1,110 @@
+# Managing Teams and Users
+
+## Teams
+
+Teams are the organization units responsible for managing client application integrations with Sign-in Service.
+
+### Adding a Team
+
+Follow these steps to create a team in Identity Dashboard:
+
+* Submit request to the OCTO-Identity team to create a new team in Identity Dashboard.
+* The request should contain the following information:
+  * The environment to load the users in (staging or production.)
+  * `name`: the human-readable name for the team.
+  * `description`: a brief description of the team, including the systems, processes, or verticals the team supports.
+  * Admin details, including:
+    * `logingov_uuid`: The UUID associated with the admin's Login.gov account.
+    * `email`: The email address associated with the admin's Login.gov account.
+    * `first_name`: The first name for the admin.
+    * `last_name`: The last name for the admin.
+   
+### Updating a Team
+
+**Please note that any request to update a team must be sent from a user with an `admin` role for that team.**
+
+Follow these steps to update a team:
+
+* Submit a request to the OCTO-Identity team to update a team.
+* The request should contain the following information:
+  * The environment of the team.
+  * The `name` of the team.
+  * Any details that need to be updated for the team, which may include:
+    * `name`: the human-readable name for the team.
+    * `description`: a brief description of the team, including the systems, processes, or verticals the team supports.
+    * Admin details, including:
+      * `logingov_uuid`: The UUID associated with the admin's Login.gov account.
+      * `email`: The email address associated with the admin's Login.gov account.
+      * `first_name`: The first name for the admin.
+      * `last_name`: The last name for the admin.
+
+### Removing a Team
+
+**Please note that any request to remove a team must be sent from a user with an `admin` role for that team.**
+
+**Removing a team is a dangerous operation as it will result in the deletion of any client configs associated with that team.**
+
+Follow these steps to remove a team:
+
+* Submit a request to the OCTO-Identity team to remove a team.
+* The request should contain the following information:
+  * The environment of the team.
+  * The `name` of the team.
+
+## Team Users
+
+Teams contain users who have roles for managing dashboard apps within Identity Dashboard. Currently, there are two dashboard apps: Admin Portal and Client Config.
+
+The Admin Portal dashboard app allows users to configure and manage their teams within Identity Dashboard. Users with an `admin` role can create new teams and manage the users that belong to those teams along with their roles. Users with a `member` role are restricted to viewing the existing teams and their associated users.
+
+The Client Config dashboard app allows users to manage their Sign-in Service integrated client applications. Each client config belongs to a single team who is responsible for managing the integration. Users with an `admin` role can create and manage client configs, whereas users with an `member` role can only view their teams' integrations.
+
+### Adding Users to a Team
+
+**Please note that any request to add users to a team must be sent from a user with an `admin` role for that team.**
+
+Follow these steps to add users to a team:
+
+* Submit request to the OCTO-Identity team to add users to a team.
+* The request should contain the following information:
+  * The team the users should be added to.
+  * The environment to load the users in (staging or production.)
+  * A list of users with the following information:
+    * `logingov_uuid`: The UUID associated with the user's Login.gov account.
+    * `email`: The email address associated with the user's Login.gov account.
+    * `first_name`: The first name for the user.
+    * `last_name`: The last name for the user.
+    * The role(s) the user should have for the Admin Portal dashboard app (`admin`, `member`, or none.)
+    * The role(s) the user should have for the Client Config dashboard app (`admin`, `member`, or none.)
+   
+### Updating a Team User
+
+**Please note that any request to update a team user must be sent from a user with an `admin` role for that team.**
+
+Follow these steps to update a team user:
+
+* Submit a request to the OCTO-Identity team to update a team user.
+* The request should contain the following information:
+  * The environment of the team and team user.
+  * The `name` of the team the user belongs to.
+  * The `email` corresponding to the team user.
+  * Any details that need to be updated for the user, which may include:
+    * `logingov_uuid`: The UUID associated with the user's Login.gov account.
+    * `email`: The email address associated with the user's Login.gov account.
+    * `first_name`: The first name for the user.
+    * `last_name`: The last name for the user.
+    * The role(s) the user should have for the Admin Portal dashboard app (`admin`, `member`, or none.)
+    * The role(s) the user should have for the Client Config dashboard app (`admin`, `member`, or none.)
+
+### Removing a Team User
+
+**Please note that any request to remove a team user must be sent from a user with an `admin` role for that team.**
+
+Follow these steps to remove a team user:
+
+* Submit a request to the OCTO-Identity team to remove a team user.
+* The request should contain the following information:
+  * The environment of the team and user.
+    * You may request the change apply to all environments if the user has changed roles and should be removed across all environments.
+  * The `email` corresponding to the team user.
+  * The `name` for each team to remove the user from.

--- a/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
+++ b/products/identity/Products/Identity Dashboard/Identity_Dashboard/Managing Teams and Users.md
@@ -4,7 +4,8 @@ Identity Dashboard (ID) is an internal tool for managing client application inte
 maintains ID and handles configuration requests from other teams who leverage SiS to provide an authenticated user experience. This document describes 
 how requests to change a client application's configuration details should be submitted for timely processing.
 
-# Table of contents
+## Table of Contents
+
 - [Teams](#teams)
   - [Adding a Team](#adding-a-team)
   - [Updating a Team](#updating-a-team)


### PR DESCRIPTION
This PR adds documentation to manage teams and team users in Identity Dashboard. It is written with external teams as the primary audience, and the processes described herein should be considered temporary until such a time that the Identity Dashboard UI has been fully implemented, tested, and rolled out.

#74903 