### PR TITLE
Create design-agreements.md and add Zenhub section with template content

### DIFF
--- a/products/accredited-representative-facing/process/design-agreements.md
+++ b/products/accredited-representative-facing/process/design-agreements.md
@@ -1,0 +1,8 @@
+# Design Agreements
+
+## Zenhub
+- Use an ARF Design ZenHub Template for creating issues and epics.
+- To update a template: edit the corresponding file, create a branch, and then merge the change.
+  - [Research Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-des-research-issue.md)
+  - [Design Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-des-design-issue.md)
+  - [Epic Template](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/.github/ISSUE_TEMPLATE/arf-epic.md)


### PR DESCRIPTION
Part of [Create Zenhub design issue templates#74915](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/74915)

Fulfills this AC -  "Call out this Zenhub issue template capability in one of our team's practice documents"