### PR TITLE
Update socks-access-request.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/socks-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/socks-access-request.yml
@@ -32,6 +32,14 @@ body:
     validations:
       required: true
   - type: input
+    id: github_handle
+    attributes:
+      label: Your Github Handle
+      description: Please provide your github handle
+      placeholder: e.g. janedoe
+    validations:
+      required: true
+  - type: input
     id: role
     attributes:
       label: Your Role and Team

--- a/.github/ISSUE_TEMPLATE/socks-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/socks-access-request.yml
@@ -34,7 +34,7 @@ body:
   - type: input
     id: github_handle
     attributes:
-      label: Your Github Handle
+      label: Your GitHub Handle
       description: Please provide your work GitHub username
       placeholder: e.g. janedoe
     validations:

--- a/.github/ISSUE_TEMPLATE/socks-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/socks-access-request.yml
@@ -35,7 +35,7 @@ body:
     id: github_handle
     attributes:
       label: Your Github Handle
-      description: Please provide your github handle
+      description: Please provide your work GitHub username
       placeholder: e.g. janedoe
     validations:
       required: true


### PR DESCRIPTION
Add github handle as a required field as part of the SOCKS access GHA to check Atlas instead of the roster spreadsheet: https://app.zenhub.com/workspaces/platform-product-team-633af4074573d06c3cda142a/issues/gh/department-of-veterans-affairs/va.gov-team/64221