### PR TITLE
Remove outdated links and point to specific spot on Platform Website

### DIFF
--- a/platform/vsp-offboarding/product-breif.md
+++ b/platform/vsp-offboarding/product-breif.md
@@ -1,49 +1,11 @@
----- 
+----
 
 
 # We've moved our docs!
 
 ### This document is no longer maintained.
 
-### Please visit the [Platform website](https://depo-platform-documentation.scrollhelp.site/) for the latest information or contact the Platform Support Team via [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1).
+### Please visit the [Platform website](https://depo-platform-documentation.scrollhelp.site/) (specifically [this page](https://depo-platform-documentation.scrollhelp.site/getting-started/offboarding)) for the latest information or contact the Platform Support Team via [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1).
 
 
 ----
-
-
-
-# VSP’s Offboarding Process Product Brief 
-
-### What is it?
-
-This is a process to remove access from individuals that are/ will be no longer working on VA.gov. We ask that a member of their team or the person themselves that is leaving follow this process to ensure that their access has been successfully removed after leaving.  
-
-### How does it work?
-
-Follow the process for letting the platform know when you or your colleague will be leaving. Once a offboarding request is filed the team will look at the user’s last day on VA.gov and work to remove their access after that day.  
-
-———
-
-### Product documentation
-
-Documentation: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/contractoroffboarding.md
-
-Offboarding Request template: https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=product+support%2C+operations%2C+Offboarding&template=offboarding-request.md&title=Offboarding+of+%5Bindividual%5D 
-
-------
-
-### Point of contact
-
-Have question orneed help? Reach out to vfs-platform-support.
-
-———
-
-### Examples or references of usage
-
-https://github.com/department-of-veterans-affairs/va.gov-team/issues/11403
-
-------
-
-### Version Notes
-
-------

--- a/platform/working-with-vsp/contractoroffboarding.md
+++ b/platform/working-with-vsp/contractoroffboarding.md
@@ -1,36 +1,11 @@
----- 
+----
 
 
 # We've moved our docs!
 
 ### This document is no longer maintained.
 
-### Please visit the [Platform website](https://depo-platform-documentation.scrollhelp.site/) for the latest information or contact the Platform Support Team via [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1).
+### Please visit the [Platform website](https://depo-platform-documentation.scrollhelp.site/) (specifically [this page](https://depo-platform-documentation.scrollhelp.site/getting-started/offboarding)) for the latest information or contact the Platform Support Team via [#vfs-platform-support](https://dsva.slack.com/archives/CBU0KDSB1).
 
 
 ----
-
-
-
-# Offboarding instructions for contractors
-
-## Applicability
-This applies to persons who are not Federal employees (e.g. VA or OMB), have access to this team repository, and will be leaving their project.
-
-## Instructions
-The VSP platform team is your offboarding concierge. All you need to do is:
-
-1. Drop a message in the [#vfs-platform-support](https://dsva.slack.com/messages/CBU0KDSB1) Slack channel stating that you will be leaving us with the following information:
-- Your last day
-- Your Github username
-- Your email address(es), including your va.gov address if applicable
-- Your project(s) team lead
-
-2. Please fill out the [Offboarding Request template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=vsp-product-support%2C+operations%2C+Offboarding%2C+analytics-insights&template=offboarding-request.md&title=Offboarding+of+%5Bindividual%5D).
-
-3. Be available to answer any questions the platform team may have.
-
-Other than that, thank you for your service and have an excellent day!
-
-In the event you need to offboard someone else because they have already left, please follow the above instructions on their behalf.
-


### PR DESCRIPTION
Labels for github issues are embedded within the URL. The URL for offboarding template linked on one of these pages was outdated. People occasionally use this link to create an offboarding request and it doesn't have the `analytics-insights` label on it, which would mean that the ticket would never show up on the Analytics and Insights team's board unless someone noticed and the label was added manually. This PR removes the outdated documentation and adds a link directly to the offboarding page of the platform website. 