### PR TITLE
First draft of Architecture Intent template.

### DIFF
--- a/platform/engineering/collab-cycle/README.md
+++ b/platform/engineering/collab-cycle/README.md
@@ -1,0 +1,15 @@
+# Engineering Collaboration Cycle
+
+__*** DRAFT *** DRAFT *** DRAFT ***__
+
+Building on the current [Collaboration Cycle][1], the Veteran-Facing Platforms and Platform Services and Governance crews are adding engineering touchpoints.
+
+[1]: https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/
+
+TODO: extend ["Collaboration cycle kickoff request"][2] to add engineering touchpoints
+
+[2]: https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/collaboration-cycle-kickoff
+
+The first engineering touchpoint will be an Engineering [Architecture Intent meeting][3].
+
+[3]: ./architecture-intent-template.md

--- a/platform/engineering/collab-cycle/architecture-intent-meeting.md
+++ b/platform/engineering/collab-cycle/architecture-intent-meeting.md
@@ -1,4 +1,4 @@
-# Architecture Intent Template
+# Architecture Intent Meeting
 
 __*** DRAFT *** DRAFT *** DRAFT ***__
 
@@ -8,17 +8,20 @@ The Architecture Intent meeting helps your team build a solution that meets Vete
 
 The Architecture Intent meeting is less a formal presentation and more of a discussion.  It not only provides OCTO-DE and Platform with an early understanding of the product/feature your team wants to build, but is also an opportunity to collaborate and provide feedback on the intended implementation and surface any adjustments needed to meet VSP engineering standards. The focus is on making sure your code meets user needs within the constraints of the platform your building on.
 
+TODO: emphasize that this is a low stakes, collaborative conversation to help connect eng teams with the information and resources they need to build great things
+
 ## When to schedule an Architecture Intent meeting?
 
 You should schedule an Architecture Intent meeting if any of these apply:
 
 - You have questions about one or more points on the template below.
 - You're having trouble locating or getting technical info from other stakeholders or system owners.
+- You're launching a new service or major new feature.
 - You're using an architecture pattern not currently found on the va.gov platform.
 - You plan to use a new technology, library or dependency.
 - You're integrating with a new system or API, inside or outside of the VA.
-- You need to coordinate your change with other teams or your change will add work or responsiblity to other teams.
-- You're gathering new [PII]/[PHI] or saving PII/PHI in a new place.
+- You're change requires complex coordination across teams or you need support to coordinate across teams.
+- You're gathering new Personally Identifiable Information ([PII]) and/or Protected Health Information ([PHI]) or saving PII/PHI in a new place.
 - There are cost, performance or security implications to your change.
 
 [PII]: https://en.wikipedia.org/wiki/Personal_data
@@ -28,26 +31,29 @@ You should schedule an Architecture Intent meeting if any of these apply:
 
 You should write up your Architecture Intent using the template below.  The Governance Team will need at least **2 business days** to review your materials.
 
-## Architecture Intent Template
+## Architecture Intent meeting template
 
-Your document should be brief and high-level.  One to two pages is appropriate for many changes.  Focus on the high level and link to supporting material where appropriate; this is _not_ a detailed engineering spec.
+Your document should be brief and high-level.  Please keep it to a single page.  Focus on the high level and link to supporting material where appropriate; this is _not_ a detailed engineering spec.
+
+TODO: specify format for these docs and where they should live
 
 Some of the items below may not apply to your work--that's okay.  You may not be able to fill in some items that _do_ apply to your work--that's also okay.  If you don't have answers, please come ready to ask questions.
 
 - Product description
     + Brief overview of motivation for the change
-    + Link to product doc or GitHub issue
+    + Link to product document or GitHub issue
 - UX design description
-    + For user-facing changes
-    + Link to lo-fi prototype or wireframes
+    + For user-facing changes, link to UX prototype or wireframes if available
+    + Call out any engineering challenges; UX is reviewed in the Design Intent meeting
 - Frontend changes
     + Identify any significant code changes
+    + Identify any new design system components needed or changes to current components
     + Describe any product analytics being gathered
 - Internal API changes
     + List new or modified APIs in `vets-api`
     + Describe expected call patterns
 - External API changes
-    + List new or modified APIs for upstream systems
+    + List new or modified APIs for upstream or external systems
     + Describe expected call patterns
 - Background jobs
     + List any required background processing
@@ -62,15 +68,15 @@ Some of the items below may not apply to your work--that's okay.  You may not be
     + Identify key areas to monitor
 - Infrastructure and network changes
     + List any changes or additions
-- Test plan
-    + Describe automated testing
+- Test strategy
+    + Describe automated, manual and user acceptance test strategy
     + Describe required test data and test user accounts
-    + Note any manual tests or user acceptance tests
 - Rollout plan
     + List scope of any feature flags
     + Identify other teams to coordinate with
     + Describe rollback plan
 
+TODO: provide this checklist as a document template in a separate file
 
 ## How to schedule the Architecture Intent meeting
 

--- a/platform/engineering/collab-cycle/architecture-intent-template.md
+++ b/platform/engineering/collab-cycle/architecture-intent-template.md
@@ -1,0 +1,56 @@
+# Architecture Intent Template
+
+__*** DRAFT *** DRAFT *** DRAFT ***__
+
+The Architecture Intent meeting helps your team build a solution that meets Veteran-facing Service Platform (VSP) engineering standards and lowers the potential for launch-blocking issues later in the development cycle.
+
+## What is the purpose of Architecture Intent meeting?
+
+The Architecture Intent meeting is less a formal presentation and more of a discussion.  It not only provides OCTO-DE and Platform with an early understanding of the product/feature your team wants to build, but is also an opportunity to collaborate and provide feedback on the intended implementation and surface any adjustments needed to meet VSP engineering standards. The focus is on making sure your code meets user needs within the constraints of the platform your building on.
+
+## Preparing for the Architecture Intent meeting
+
+You should write up your Architecture Intent using the template below.The Governance Team will need at least **2 business days** to review your matierials.
+
+## Architecture Intent Template
+
+Your document should be brief and high-level.  One to two pages is appropriate for many changes.  Focus on the high level and link to supporting material where appropriate; this is not a detailed engineering spec.
+
+- Product description
+    + Brief overview of motivation for the change
+    + Link to product doc or GitHub issue
+- UX design description
+    + For user-facing changes
+    + Link to lo-fi prototype or wireframes
+- Frontend changes
+    + Identify any significant code changes
+    + Describe any product analytics being gathered
+- Internal API changes
+    + List new or modified APIs in `vets-api`
+    + Describe expected call patterns
+- External API changes
+    + List new or modified APIs for upstream systems
+    + Describe expected call patterns
+- Background jobs
+    + List any required background processing
+    + Describe error and dead letter handling
+- Data storage
+    + Describe new or modified databases, tables or columns
+    + Describe indexes and constraints
+    + Identify PII and PHI
+- Libraries and dependencies
+    + List new or updated dependences
+- Metrics, logging, observability, alerting
+    + Identify key areas to monitor
+- Infrastructure and network changes
+    + List any changes or additions
+- Rollout plan
+    + List scope of any feature flags
+    + Identify other teams to coordinate with
+
+
+## How to schedule the Architecture Intent meeting
+
+TODO: use [Design Intent][1] as a template
+
+[1]: https://depo-platform-documentation.scrollhelp.site/collaboration-cycle/design-intent

--- a/platform/engineering/collab-cycle/architecture-intent-template.md
+++ b/platform/engineering/collab-cycle/architecture-intent-template.md
@@ -44,9 +44,14 @@ Your document should be brief and high-level.  One to two pages is appropriate f
     + Identify key areas to monitor
 - Infrastructure and network changes
     + List any changes or additions
+- Test plan
+    + Describe automated testing
+    + Describe required test data and test user accounts
+    + Note any manual tests or user acceptance tests
 - Rollout plan
     + List scope of any feature flags
     + Identify other teams to coordinate with
+    + Describe rollback plan
 
 
 ## How to schedule the Architecture Intent meeting

--- a/platform/engineering/collab-cycle/architecture-intent-template.md
+++ b/platform/engineering/collab-cycle/architecture-intent-template.md
@@ -8,13 +8,31 @@ The Architecture Intent meeting helps your team build a solution that meets Vete
 
 The Architecture Intent meeting is less a formal presentation and more of a discussion.  It not only provides OCTO-DE and Platform with an early understanding of the product/feature your team wants to build, but is also an opportunity to collaborate and provide feedback on the intended implementation and surface any adjustments needed to meet VSP engineering standards. The focus is on making sure your code meets user needs within the constraints of the platform your building on.
 
+## When to schedule an Architecture Intent meeting?
+
+You should schedule an Architecture Intent meeting if any of these apply:
+
+- You have questions about one or more points on the template below.
+- You're having trouble locating or getting technical info from other stakeholders or system owners.
+- You're using an architecture pattern not currently found on the va.gov platform.
+- You plan to use a new technology, library or dependency.
+- You're integrating with a new system or API, inside or outside of the VA.
+- You need to coordinate your change with other teams or your change will add work or responsiblity to other teams.
+- You're gathering new [PII]/[PHI] or saving PII/PHI in a new place.
+- There are cost, performance or security implications to your change.
+
+[PII]: https://en.wikipedia.org/wiki/Personal_data
+[PHI]: https://en.wikipedia.org/wiki/Protected_health_information
+
 ## Preparing for the Architecture Intent meeting
 
-You should write up your Architecture Intent using the template below.The Governance Team will need at least **2 business days** to review your matierials.
+You should write up your Architecture Intent using the template below.  The Governance Team will need at least **2 business days** to review your materials.
 
 ## Architecture Intent Template
 
-Your document should be brief and high-level.  One to two pages is appropriate for many changes.  Focus on the high level and link to supporting material where appropriate; this is not a detailed engineering spec.
+Your document should be brief and high-level.  One to two pages is appropriate for many changes.  Focus on the high level and link to supporting material where appropriate; this is _not_ a detailed engineering spec.
+
+Some of the items below may not apply to your work--that's okay.  You may not be able to fill in some items that _do_ apply to your work--that's also okay.  If you don't have answers, please come ready to ask questions.
 
 - Product description
     + Brief overview of motivation for the change


### PR DESCRIPTION
Added a `platform/engineering/collab-cycle/` directory.  Added a readme file with links to the existing Collaboration Cycle docs and to the new Architecture Intent doc.

Cribbed language from the existing Design Intent meeting doc and added the template for Architecture Intent.