### PR TITLE
chore: Update platform-infrastructure-team.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-infrastructure-team.md
+++ b/.github/ISSUE_TEMPLATE/platform-infrastructure-team.md
@@ -2,7 +2,7 @@
 name: Platform Infrastructure Services Issue
 about: For VA.gov Platform Infrastructure Services Team
 title: '[Product] Thing to be done'
-labels: Infrastructure-Services, needs-refinement
+labels: Infrastructure-Services
 assignees: ''
 
 ---
@@ -17,8 +17,7 @@ _What details are necessary to understand the work that this issue is tracking?_
 - [ ] _What will be created or happen as a result of this issue?_
 
 ## Refinement Guidance - Check the following before working on this issue: 
-- [ ] _Epic assigned (if needed)_ 
+- [ ] _Milestone assigned (if needed)_
 - [ ] _Estimated (points assigned)_
-- [ ] _Sprint assigned (once planned)_
-- [ ] _Team member(s) assigned_
+- [ ] _Sprint assigned_
 - [ ] _Understands how this work aligns with the overall platform_


### PR DESCRIPTION
- Update refinement guide
- We no longer need the label since anything in `status:Backlog` is considered needing refinement, and anything in `status:Sprint` has been refined
- Assigning the issue during refinement feels premature