### PR TITLE
Adds a checkbox for prod expiration for AWS

### DIFF
--- a/.github/ISSUE_TEMPLATE/aws-access-request.yml
+++ b/.github/ISSUE_TEMPLATE/aws-access-request.yml
@@ -132,3 +132,5 @@ body:
       - label: "If user is on a VFS team but not a team member in Atlas, add the 'NOT YET' label and instruct them to start the [Platform orientation process](https://depo-platform-documentation.scrollhelp.site/getting-started/Platform-Orientation.1877344532.html)"
       - label: "If a user is on a Platform team but not on the Platform Team Roster in Confluence, add the 'NOT YET' label and instruct them to reach out to their Product Manager to be added."
       - label: "Comment in this issue saying which roster the user is listed in."
+      - label: |
+          :warning: Is production access being requested or extended? Be sure to communicate to the Tier 1 Team that they need to set a reminder for the access expiration :warning:


### PR DESCRIPTION
Because revoking AWS access requires work from Devops Tier 2, Devops Tier 2 needs to coordinate with Tier 1 to set reminders for production access revocation. 

This PR adds a checkbox to address this.