### PR TITLE
Add blockers to product team template

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-product-validation.md
+++ b/.github/ISSUE_TEMPLATE/platform-product-validation.md
@@ -25,3 +25,8 @@ _Describe what success looks like for this work. Define specific, measurable out
 
 ## Validation
 _Assignee to add steps to this section. List the actions that need to be taken to confirm this issue is complete. Include any necessary links or context. State the expected outcome._
+
+
+## Blocked By
+
+## Blocks Issue(s)


### PR DESCRIPTION
When writing stories, it's often in conjunction with another story that either blocks or is blocked by this story. This PR adds sections to the Product Team's issue template to add this additional context in the description.