### PR TITLE
Update assign-and-move-issue-to-platform-onboarding-column.yml

### DIFF
--- a/.github/workflows/assign-and-move-issue-to-platform-onboarding-column.yml
+++ b/.github/workflows/assign-and-move-issue-to-platform-onboarding-column.yml
@@ -20,6 +20,10 @@ jobs:
 
   move-issue:
     runs-on: ubuntu-latest
+    if: |
+     contains(github.event.issue.labels.*.name, 'new-vfs-team-member') ||
+     contains(github.event.issue.labels.*.name, 'new-vfs-team')
+
     steps:
       - name: Move Issue to Access Requests Column
         uses: m7kvqbe1/github-action-move-issues@v1.1.2


### PR DESCRIPTION
Added an if statement that will skip the 'move issue' job if the desired label is not present