### PR TITLE
Update assign-and-move-issue-to-support-tickets-column.yml

### DIFF
--- a/.github/workflows/assign-and-move-issue-to-support-tickets-column.yml
+++ b/.github/workflows/assign-and-move-issue-to-support-tickets-column.yml
@@ -20,6 +20,7 @@ jobs:
 
   move-issue:
     runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'Platform-Support-Ticket')  # Skip job if the label doesn't exist
     steps:
       - name: Move Issue to Access Requests Column
         uses: m7kvqbe1/github-action-move-issues@v1.1.2


### PR DESCRIPTION
Added an if statement that will skip the 'move issue' job if the desired label is not present