### PR TITLE
Update slack-request-template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/slack-request-template.md
+++ b/.github/ISSUE_TEMPLATE/slack-request-template.md
@@ -3,11 +3,17 @@ name: Slack Request template
 about: To request adjustments in dsva.slack.com
 title: Adding [individual] to DSVA Slack
 labels: Slack Request
-assignees: LEHigley, KevinMHoffmanUSDS, lkoenigsberg
+assignees: 
 
 ---
 
 # Description
+
+**This form is now Deprecated*** 
+Administration of Slack has now transitioned to AES and is handled in JIRA. The link for the JIRA board is 
+[https://jira.devops.va.gov/servicedesk/customer/portal/1](https://jira.devops.va.gov/servicedesk/customer/portal/1)
+
+You should provide the information below in the request and you do not need to submit this ticket.  This template will remain active while documentation is being updated. 
 
 **new user requests**: please verify that the user does not already exist in dsva.slack.com (it may be the account exists, but is not in a particular channel)
 


### PR DESCRIPTION
This pull request will adjust the Slack GIthub Issues template to deprecate this process and point users to JIRA.  

The documentation still needs to be updated to reflect this change and this template will serve to redirect in the mean time.