### PR TITLE
Update QA Standards template

### DIFF
--- a/.github/ISSUE_TEMPLATE/collab-cycle-qa-findings-staging.md
+++ b/.github/ISSUE_TEMPLATE/collab-cycle-qa-findings-staging.md
@@ -21,6 +21,7 @@ assignees: ''
 
 ---
 ### [QA Standards](https://depo-platform-documentation.scrollhelp.site/developer-docs/quality-assurance-standards) 
+**Note**: all standards are launch-bocking.
 #### Regression Test Plan 
 - [ ] Standard has been met
 - [ ] Standard has not been met


### PR DESCRIPTION
Update template to add a note that all standards are now launch-blocking: https://github.com/orgs/department-of-veterans-affairs/projects/1491/views/3?pane=issue&itemId=92885241&issue=department-of-veterans-affairs%7Cva.gov-team%7C100295