### PR TITLE
[TASK]: Add voice command to accessibility template options

### DIFF
--- a/.github/ISSUE_TEMPLATE/a11y-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/a11y-issue.yaml
@@ -79,6 +79,7 @@ body:
       - label: Axe-core
       - label: Screenreader | assistive tech & device support
       - label: Keyboard
+      - label: Voice command
       - label: Zoom
       - label: Color, typography, & visual elements
       - label: Components and pattern standards


### PR DESCRIPTION
Voice command has become a first-pass test for a large number of accessibility practitioners. I'd like to add it as a specific option for what type of issue is being reported.