### PR TITLE
Remove frontend and operations labels in OOB request

### DIFF
--- a/.github/ISSUE_TEMPLATE/OOB-Deploy-Request.md
+++ b/.github/ISSUE_TEMPLATE/OOB-Deploy-Request.md
@@ -2,7 +2,7 @@
 name: OOB Deploy Request
 about: To request Out of band deployment
 title: OOB Deploy Request
-labels: frontend, operations, platform-tech-team-support
+labels: platform-tech-team-support
 assignees: ''
 
 ---


### PR DESCRIPTION
I don't think these are needed. They can be misleading (eg a vets-api OOB having the `frontend` and `operations` label on them)