### PR TITLE
Adjust Decision Review templates labels and project name

### DIFF
--- a/.github/ISSUE_TEMPLATE/Decision-Reviews-Bug-Template.md
+++ b/.github/ISSUE_TEMPLATE/Decision-Reviews-Bug-Template.md
@@ -1,9 +1,10 @@
 ---
-name: Decision Reviews Bug Issue
-about: Bug issues for the Decision Reviews team
+name: Decision Reviews Bug Template
+about: Bug template for the Decision Reviews team
 title: ''
-labels: bug, Decision-Reviews-Team, needs-grooming, needs-refinement
+labels: bug, Decision-Reviews-Team, team-DRAGONS, needs-refinement
 assignees: ''
+projects: ["department-of-veterans-affairs/1434"]
 
 ---
 
@@ -20,7 +21,7 @@ assignees: ''
 
 ## How severe is the problem?
 
-- [ ] **Critical**: User is block or significantly hindered from submitting the form, data is lost, or claim and evidence test coverage is missing. Fix ASAP.
+- [ ] **Critical**: User is blocked or significantly hindered from submitting the form, data is lost, or claim and evidence test coverage is missing. Fix ASAP.
 - [ ] **Moderate**: User is not blocked, but the happy path is interrupted. Fix after critical bugs.
 - [ ] **Minor**: Cosmetic bugs and minor language inconsistencies. Defer to a later sprint.
 

--- a/.github/ISSUE_TEMPLATE/Decision-Reviews-Issue-Template.md
+++ b/.github/ISSUE_TEMPLATE/Decision-Reviews-Issue-Template.md
@@ -2,8 +2,9 @@
 name: Decision Reviews Issue Template
 about: Issue template for the Decision Reviews team
 title: ''
-labels: Decision-Reviews-Team, needs-refinement
+labels: Decision-Reviews-Team, team-DRAGONS, needs-refinement
 assignees: ''
+projects: ["department-of-veterans-affairs/1434"]
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/Decision-Reviews-Spike-Template.md
+++ b/.github/ISSUE_TEMPLATE/Decision-Reviews-Spike-Template.md
@@ -2,8 +2,9 @@
 name: Decision Reviews Spike Template
 about: Spike template for the Decision Reviews team
 title: ''
-labels: Decision-Reviews-Team, needs-refinement
+labels: Decision-Reviews-Team, team-DRAGONS, needs-refinement
 assignees: ''
+projects: ["department-of-veterans-affairs/1434"]
 
 ---
 


### PR DESCRIPTION
Add the project name to the Decision Reviews templates as well as make the bug template consistent with the other two templates.