### PR TITLE
Update Add Team Review PR Checker.yml

### DIFF
--- a/.github/workflows/Add Team Review PR Checker.yml
+++ b/.github/workflows/Add Team Review PR Checker.yml
@@ -1,8 +1,9 @@
 name: Add Team Reviewer CoP Checker
-
 on:
   pull_request_review:
     types: [submitted]
+  issue_comment:
+    types: [created]
     
 jobs:
   add-team-reviewer:
@@ -48,6 +49,55 @@ jobs:
                 console.log(`Added ${teamSlug} as reviewer`);
               } else {
                 console.log(`${reviewer} is not a member of ${teamSlug}. No action taken.`);
+              }
+            } catch (error) {
+              console.error('Error:', error);
+              core.setFailed(`Action failed with error: ${error}`);
+            }
+
+  re-add-team-reviewer:
+    # Only run this job when a comment is created on a PR
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Check if commenter is team member and re-add team
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          script: |
+            const commenter = context.payload.comment.user.login;
+            const teamSlug = 'platform-support';
+            const prNumber = context.payload.issue.number;
+            
+            console.log(`Comment made by: ${commenter} on PR #${prNumber}`);
+            
+            try {
+              // Check if the commenter is a member of the specified team
+              const { data: teamMembers } = await github.rest.teams.listMembersInOrg({
+                org: context.repo.owner,
+                team_slug: teamSlug
+              });
+              
+              const isTeamMember = teamMembers.some(member => member.login === commenter);
+              
+              if (isTeamMember) {
+                console.log(`${commenter} is a member of ${teamSlug}. Re-adding team as reviewer.`);
+                
+                // Re-add the team as a reviewer
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: prNumber,
+                  team_reviewers: [teamSlug]
+                });
+                
+                console.log(`Re-added ${teamSlug} as reviewer to PR #${prNumber}`);
+              } else {
+                console.log(`${commenter} is not a member of ${teamSlug}. No action taken.`);
               }
             } catch (error) {
               console.error('Error:', error);


### PR DESCRIPTION
Adding new job for "Add team review if commenter is a member of team"

This is an addition to the existing workflow. The new job will follow similar steps except will trigger on a PR comment