### PR TITLE
Update VAOS issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/vaos-bug.md
+++ b/.github/ISSUE_TEMPLATE/vaos-bug.md
@@ -2,7 +2,7 @@
 name: VAOS Bug Template
 about: For filing VAOS bugs found
 title: ''
-labels: appointments, bug
+labels: appointments, bug, needs-grooming
 assignees: ''
 
 ---
@@ -11,14 +11,14 @@ assignees: ''
 _Describe what went wrong_
 
 ## Specs
-- Device: 
-- Browser: 
+- Device:
+- Browser:
 
 ## Steps to Reproduce
-**Test User:** 
+**Test User:**
 
 1. Go to: _URL_
-2. 
+2.
 
 ### Actual Result
 _Describe what happened that was unexpected or undesired; including screenshots is encouraged_
@@ -32,7 +32,5 @@ _Describe what was supposed to happen; reference existing Github issue that cont
 
 ---
 ## How to configure this issue
-- [ ] **Labeled with Team** (`appointments`)
-- [ ] **Labeled with Practice Area** (`backend`, `frontend`, `design`, `product`)
-- [ ] **Labeled with** `bug`
+- [ ] **Labeled with Practice Area** (`vets-website`, `vets-api`, `backend`, `design`, `product`)
 - [ ] **Assigned to** Product for prioritization

--- a/.github/ISSUE_TEMPLATE/vaos-small-feature.md
+++ b/.github/ISSUE_TEMPLATE/vaos-small-feature.md
@@ -11,13 +11,13 @@ assignees: ''
 _Provide the description of the feature_
 
 
-## Requirements 
+## Requirements
 
 - [ ] TBD
 - [ ] TBD
 
 ### Design Assets
-[Figma File]() (put N/A if not needed) 
+[Figma File]() (put N/A if not needed)
 
 ---
 ### Development Checklist
@@ -36,6 +36,6 @@ _Provide the description of the feature_
 
 ## How to configure this issue (Delete this section before creating the ticket)
 - [ ] **Attached to an Epic** (what body of work is this a part of?)
-- [ ] **If work needs to be split up, create the additional ticket(s) and keep the same format and update the checklist (just to keep it consistent and the requirements are listed in each ticket).** 
-- [ ] **Labeled with Practice Area** (`backend`, `frontend`, `devops`, `design`, `research`, `product`, `ia`, `qa`, `analytics`, `contact center`, `research`, `accessibility`, `content`)
+- [ ] **If work needs to be split up, create the additional ticket(s) and keep the same format and update the checklist (just to keep it consistent and the requirements are listed in each ticket).**
+- [ ] **Labeled with Practice Area** (`vets-website`, `vets-api`, `backend`, `devops`, `design`, `research`, `product`, `ia`, `qa`, `analytics`, `contact center`, `research`, `accessibility`, `content`)
 - [ ] **Labeled with Type** (`bug`, `request`, `discovery`, `documentation`, etc.)

--- a/.github/ISSUE_TEMPLATE/vaos-spike.md
+++ b/.github/ISSUE_TEMPLATE/vaos-spike.md
@@ -31,4 +31,4 @@ _ hours
 ---
 ## How to configure this issue
 - [ ] **Attached to an Epic** (what body of work is this a part of?)
-- [ ] **Labeled with Practice Area** (`backend`, `frontend`, `devops`, `design`, `research`, `product`, `ia`, `qa`, `analytics`, `contact center`, `research`, `accessibility`, `content`)
+- [ ] **Labeled with Practice Area** (`vets-website`, `vets-api`, `backend`, `devops`, `design`, `research`, `product`, `ia`, `qa`, `analytics`, `contact center`, `research`, `accessibility`, `content`)

--- a/.github/ISSUE_TEMPLATE/vaos-story-task.md
+++ b/.github/ISSUE_TEMPLATE/vaos-story-task.md
@@ -13,13 +13,13 @@ _What details are necessary for understanding the specific work or request track
 ---
 
 ## Development Checklist
-Background: the `toggle` toggle is on (remove if not needed) 
+Background: the `toggle` toggle is on (remove if not needed)
 
 - [ ] Task 1
 - [ ] Task 2
 
 ### Design Assets
-- [Figma file]() (put N/A if not needed) 
+- [Figma file]() (put N/A if not needed)
 
 ### Developer Reference
 
@@ -28,7 +28,7 @@ Background: the `toggle` toggle is on (remove if not needed)
 
 ## Definition of Done
 - [ ] All tasks criteria are met
-- [ ] [Technical Documentation]() is updated (must confirm if needed/or remove) 
+- [ ] [Technical Documentation]() is updated (must confirm if needed/or remove)
 - [ ] [Feature Reference (GitHub)](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/health-care/appointments/va-online-scheduling/feature-reference) is updated
 - [ ] UX - [Feature Reference (Figma)](https://www.figma.com/design/eonNJsp57eqfPqx7ydsJY9/Feature-Reference-%7C-Appointments-FE?node-id=1150-105402&t=zRNPBqgPDVU0dDP8-1) is updated
 
@@ -36,5 +36,5 @@ Background: the `toggle` toggle is on (remove if not needed)
 
 ## How to configure this issue (Delete this section before creating the ticket)
 - [ ] **Attached to a Feature** (what body of work is this a part of?)
-- [ ] **Labeled with Practice Area** (`backend`, `frontend`, `devops`, `design`, `research`, `product`, `ia`, `qa`, `analytics`, `contact center`, `research`, `accessibility`, `content`)
+- [ ] **Labeled with Practice Area** (`vets-website`, `vets-api`, `backend`, `devops`, `design`, `research`, `product`, `ia`, `qa`, `analytics`, `contact center`, `research`, `accessibility`, `content`)
 - [ ] **Labeled with Type** (`bug`, `request`, `discovery`, `documentation`, etc.)

--- a/.github/ISSUE_TEMPLATE/vaos-test-issue.md
+++ b/.github/ISSUE_TEMPLATE/vaos-test-issue.md
@@ -53,7 +53,5 @@ _Describe the error that was encountered. Stack traces, logs and videos (for e2e
 
 ---
 ## How to configure this issue
-- [ ] **Labeled with Team** (`appointments`)
-- [ ] **Labeled with Practice Area** (`backend`, `frontend`, `design`, `product`)
-- [ ] **Labeled with** `testing`
+- [ ] **Labeled with Practice Area** (`vets-website`, `vets-api`)
 - [ ] **Assigned to** Product for prioritization


### PR DESCRIPTION
Updating VAOS issue templates:
- update the default issue labels and label requirements to account for the switch from `frontend, backend` to `vets-website, vets-api, backend`