### PR TITLE
Update architecture-intent-meeting.md

### DIFF
--- a/platform/engineering/collab-cycle/architecture-intent-meeting.md
+++ b/platform/engineering/collab-cycle/architecture-intent-meeting.md
@@ -64,6 +64,8 @@ Some of the items below may not apply to your work--that's okay.  You may not be
     + Describe new or modified databases, tables or columns
     + Describe indexes and constraints
     + Identify PII and PHI and where and how it will be stored, processed, expired and deleted
+- VA Health and Benefits Mobile application
+    + Does your work include changes in the mobile application?
 - Libraries and dependencies
     + List new or updated dependences
 - Metrics, logging, observability, alerting


### PR DESCRIPTION
Per a request from Chris, we need to ask about VAHB mobile app explicitly at architecture intent. Open to other ways to accomplish this if we're already covering mobile in some way.