### PR TITLE
Update collab-cycle-qa-findings-staging.md with PDF version validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/collab-cycle-qa-findings-staging.md
+++ b/.github/ISSUE_TEMPLATE/collab-cycle-qa-findings-staging.md
@@ -75,6 +75,22 @@ QA -
 
 ##### Explanation of failure to meet standard (if applicable):
 
+#### PDF Version Validation
+
+- [ ] Not applicable
+    - The feature is not a form with a generated PDF submission.
+- [ ] Standard has been met 
+    - The PDF has been expired for 5 months or less, or the PDF is not expired.
+- [ ] Standard has not been met 
+    - The PDF has been expired for 6 to 9 months. 
+    - **Warning, not launch-blocking**
+- [ ] Standard has not been met 
+    - The PDF has been expired for 10 months or more.
+    - **Launch-blocking**
+
+##### Explanation of failure to meet standard (if applicable):
+
+
 ---
 
 ### Next Steps for the VFS team


### PR DESCRIPTION
Add QA Standard for checking the PDF submission's expiration.

---

This pull request updates the `.github/ISSUE_TEMPLATE/collab-cycle-qa-findings-staging.md` file to include a new section for PDF version validation. This addition provides a structured checklist to evaluate whether the PDF version standard has been met, including criteria for launch-blocking and non-launch-blocking issues.

### Key Change:

* **PDF Version Validation Section Added**: Introduced a new checklist to assess the expiration status of PDFs, with clear criteria for compliance and severity levels (e.g., not applicable, standard met, or standard not met). Launch-blocking and non-launch-blocking conditions are explicitly defined.