### PR TITLE
Fix additional broken links after team directory moves

### DIFF
--- a/teams/communities/trauma/facilitation-instructions.md
+++ b/teams/communities/trauma/facilitation-instructions.md
@@ -4,7 +4,7 @@ Signed up to facilitate or scribe a Community of Practice meeting? We got you co
 ## Community of Practice meetings
 
 ### Facilitators
-1. [**Review our community guidelines.**](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/community-guidelines.md) 
+1. [**Review our community guidelines.**](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/community-guidelines.md) 
 2. **Join 5 minutes early to the meeting.**
 3. **Turn on closed captions.** Use Zoom’s live transcription feature.
 4. **Welcome folks as they enter** Introduce yourself when/as you feel comfortable.
@@ -13,21 +13,21 @@ Signed up to facilitate or scribe a Community of Practice meeting? We got you co
 7. **Invite new attendees to introduce themselves in [the meeting doc](https://docs.google.com/document/d/1z5OsfMtlnVp-ntPUi3zPUzw__1mwECqR9bMJygN04h0/edit#)** Be sure to say this is completely optional.
 8. **Review the topics of the week** in the order they were added (or by importance).
 9. **Find a facilitator for the next Community of Practice meeting, if needed.** Everyone should get an opt-in shot at facilitating the big meeting. If you can’t find someone, you’ll be responsible for running it next time.
-10. [**Add yourself to our record of facilitator service.**](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/shared-support/trauma) Our meetings are possible thanks to volunteers like you, and we want to publicly thank you for your service! Note: this is 100% optional. 
+10. [**Add yourself to our record of facilitator service.**](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/communities/trauma) Our meetings are possible thanks to volunteers like you, and we want to publicly thank you for your service! Note: this is 100% optional. 
 
 ### Scribes
-1. [**Read our community guidelines.**](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/community-guidelines.md) 
-2. [**Read past shared learnings and notes.**](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/shared-support/trauma/notes) It may give you a better idea as to what to capture.
+1. [**Read our community guidelines.**](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/community-guidelines.md) 
+2. [**Read past shared learnings and notes.**](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/communities/trauma/notes) It may give you a better idea as to what to capture.
 3. **Join 5 minutes early to the meeting.** 
 4. **Start a slack discussion thread in #trauma-practice.** Ideally we will want to use this, not the built in zoom chat so that our conversation is in a spot others who miss our sync can still reference. 
 5. **Take notes of key discussion points.** Focus on collecting key quotes, themes, stories, and action items. You don't have to take verbatim notes, but try to take note of anything that will help you write out a shared learning summary. People who didn't attend the meeting should have an idea as to what happened, key takeaways, and action items.
 6. **Write a shared learnings summary based on the meeting.**
-  - Add and create a new .md file with the date of the meeting (e.g. 2023/01/11.md) to our [notes folder on github ](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/shared-support/trauma/notes). You can copy and paste the [contents of this template as a reference.](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/YYYY-MM-DD.md)
-  - Update the [notes readme](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/readme.md) with the latest meeting and a link to the notes
+  - Add and create a new .md file with the date of the meeting (e.g. 2023/01/11.md) to our [notes folder on github ](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/communities/trauma/notes). You can copy and paste the [contents of this template as a reference.](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/YYYY-MM-DD.md)
+  - Update the [notes readme](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/readme.md) with the latest meeting and a link to the notes
   - Email the shared learnings to everyone who is signed up for our big meetings
   - Post the shared learnings to our #trauma-practice channel
 8. **Find a scribe for the next Community of Practice meeting.** Everyone should get an opt-in shot at scribing the big meeting. If you can’t find someone, you’ll be responsible for running it next time.
-9. [**Add yourself to our record of scribe service.**](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/shared-support/trauma) Our meetings are possible thanks to volunteers like you, and we want to publicly thank you for your service! Note: this is 100% optional. 
+9. [**Add yourself to our record of scribe service.**](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/communities/trauma) Our meetings are possible thanks to volunteers like you, and we want to publicly thank you for your service! Note: this is 100% optional. 
 
 ## Practice Circles
 

--- a/teams/communities/trauma/gatherings.md
+++ b/teams/communities/trauma/gatherings.md
@@ -13,7 +13,7 @@ The Community of Practice is:
 
 **Interested in joining a Community of Practice meeting?** Reach out on `#trauma-practice` and tag Martha Wilkes. You can also [read or add to our shared agenda](https://docs.google.com/document/d/1z5OsfMtlnVp-ntPUi3zPUzw__1mwECqR9bMJygN04h0/edit?usp=sharing) before you join.
 
-**Interested in facilitating or scribing a Community of Practice meeting?** [Read our instructions here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/facilitation-instructions.md#community-of-practice-meetings).
+**Interested in facilitating or scribing a Community of Practice meeting?** [Read our instructions here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/facilitation-instructions.md#community-of-practice-meetings).
 
 ## Practice Circle
 This is a **new** monthly meeting, held every 4th Friday of the month at 2:05pm EST (55 minutes).

--- a/teams/communities/trauma/notes/readme.md
+++ b/teams/communities/trauma/notes/readme.md
@@ -1,72 +1,72 @@
-## [May 10, 2024](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2024-05-10.md)
+## [May 10, 2024](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2024-05-10.md)
 `Big Meeting` `Reflections`
 - Reflected on our conversation with our guest, Victor Udoewa, at our last practice circle
 
-## [November 13, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-11-13.md)
+## [November 13, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-11-13.md)
 `Big Meeting` `Strategy`
 - Discussed tips on how to do active listening with Veterans
 
-## [August 7, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-08-07.md)
+## [August 7, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-08-07.md)
 `Big Meeting` `Strategy`
 - Discussed how to share what we're learning as a community
 
-## [June 26, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-06-26.md)
+## [June 26, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-06-26.md)
 `Big Meeting` `Onboarding`
 - Discussed how to embed trauma informed guidance into VA onboarding
 
-## [May 23, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-05-23.md)
+## [May 23, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-05-23.md)
 `Big Meeting` `Shareout`
 - Usability testing with homeless Veterans
 - Turning the doorknob moments
 
-## [May 1, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-05-01.md)
+## [May 1, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-05-01.md)
 `Big Meeting` `Community Guidelines` `Strategy`
 - Shared why we joined this community to contribute to our vision and strategy
 - Discussed how best to grow small groups
 
-## [April 17, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-04-17.md)
+## [April 17, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-04-17.md)
 `Big Meeting` `Participant Safety` `Community Guidelines`
 - We'll be meeting on May 1 for a community guidelines activity, be there (or if not, no worries, we'll have async stuff prepared!)
 - We had a conversation about participant safety in the Perigean recruitment process
 
-## [April 3, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-04-03.md)
+## [April 3, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-04-03.md)
 `Big Meeting` `Strategy` `Community Guidelines`
 - Discussed how to push for trauma-informed work as contractors against the inertia of non-trauma informed practices
 - Figured out next steps for determining our community guidelines
 
-## [March 20, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-03-20.md)
+## [March 20, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-03-20.md)
 `Big Meeting` `Strategy` `Community Guidelines`
 - Talked about how to maintain and protect our community guidelines and people
 - Discussed ways we can measure trauma informed design's impact and value
 
-## [March 6, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-03-06.md)
+## [March 6, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-03-06.md)
 `Big Meeting` `Research Shareout` `MST`
 - Karen Cutright's part 2 of her shareout on her research on MST
 - We learned about the care and intention required to set up sessions, the delivery of those sessions, and trauma-responsive methods which might be seen as “atypical” 
 
-## [February 27, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-02-27.md)
+## [February 27, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-02-27.md)
 `Big Meeting` `Research Shareout` `MST`
 - Karen Cutright shared her research process as a social worker on a challenging topic around MST
 - We learned how to set boundaries with stakeholders and create better outcomes of transparency and trust with participants
 
-## [January 23, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-01-23.md)
+## [January 23, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-01-23.md)
 `Big Meeting` `Strategy` 
 
 Talked about the purpose of our VA trauma practice:
 - Began defining what we wanted to focus on now, next, and later
 - Discussed three ways of meeting: practice meetings, small support groups, and drop in hours
 
-## [January 13, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-01-13.md)
+## [January 13, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-01-13.md)
 `Small Group` `Shared Learning`
 
 A second private group also talked about intuition which unfolded into a conversation around confronting the uncomfortable, marinating our instincts, focusing on the next best thing, and considering an airing of greivances.
 
-## [January 11, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-01-11.md)
+## [January 11, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-01-11.md)
 `Small Group` `Shared Learning`
 
 A small, private group of 7 talked about intuition which bloomed into a conversation around unlearning, navigating cloudy language, taking on the unplanned, having grace for oneself, and contracting.
 
-## [January 9, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-01-09.md)
+## [January 9, 2023](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-01-09.md)
 `Big Meeting` `Q&A` 
 
 Hosted an open Q&A with Rachael Dietkus. Some questions included:
@@ -74,19 +74,19 @@ Hosted an open Q&A with Rachael Dietkus. Some questions included:
 - How do we maintain our energy and not burn out? 🌵
 - Do breathing techniques actually work mid-session? 🔥
 
-## [December 12, 2022](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2022-12-12.md)
+## [December 12, 2022](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2022-12-12.md)
 `Big Meeting` `Strategy` 
 
 We talked about our purpose again, but this time more as an open conversation and less in a google doc. 
 - We realized researchers want a space to practice, learn, and debrief. 
 - We also started talking about our future vision.
 
-## [November 28, 2022](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2022-11-28.md)
+## [November 28, 2022](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2022-11-28.md)
 `Big Meeting` `Strategy` 
 
 Our first meeting on the purpose of our trauma practice. We agreed there were unique needs for both current and new practitioners.
 
-## [November 7, 2022](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2022-11-07.md)
+## [November 7, 2022](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2022-11-07.md)
 `Big Meeting` `Strategy` 
 
 Our first meeting ever! Lots of introductions, defining meeting norms, reviewing existing work, and an open discussion on how we move forwards including:

--- a/teams/communities/trauma/readme.md
+++ b/teams/communities/trauma/readme.md
@@ -1,16 +1,16 @@
 # VA Trauma Community
 Welcome to the VA trauma community ✨
 We're a grassroots, volunteer led multi-disciplinary community focused on maturing our approach to trauma from facilitating research to caring for practitioners. 
-For more on our purpose, check out our [takeaways from a collaborative discussion about our purpose](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/notes/2023-01-23.md#4-patterns-emerged-from-our-conversation-around-our-purpose-).
+For more on our purpose, check out our [takeaways from a collaborative discussion about our purpose](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/notes/2023-01-23.md#4-patterns-emerged-from-our-conversation-around-our-purpose-).
 
 ## How do I join?
 Anyone can join, regardless of role, title, or status. There's no "official" way of joining, but we usually recommend to:
 - [ ] Join our Slack channel at `#trauma-practice`. Or reach out to Martha (martha.wilkes@va.gov) if you don't have Slack.
-- [ ] Read [how we work together and our community guidelines](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/community-guidelines.md).
+- [ ] Read [how we work together and our community guidelines](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/community-guidelines.md).
 - [ ] Introduce yourself in `#trauma-practice`. This is 100% optional. 💙
-- [ ] Learn more about our [gatherings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/gatherings.md).
+- [ ] Learn more about our [gatherings](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/gatherings.md).
 - [ ] Reach out on `#trauma-practice` and tag Martha Wilkes if you'd like an invite to our gatherings.
-- [ ] In your own time, we encourage you to check out this [introduction to trauma (and resource list)](https://docs.google.com/document/d/11W66cjxCgguF_ulVOxet-CszfJB3aTBl-OxJTEeloGg/edit?usp=sharing) and skim through our [past shared learnings in our notes folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/shared-support/trauma/notes).
+- [ ] In your own time, we encourage you to check out this [introduction to trauma (and resource list)](https://docs.google.com/document/d/11W66cjxCgguF_ulVOxet-CszfJB3aTBl-OxJTEeloGg/edit?usp=sharing) and skim through our [past shared learnings in our notes folder](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/teams/communities/trauma/notes).
 
 ## Participate and connect with our community
 We value everyone in our community, and encourage _anyone_ who has the time, resources, and comfort to share their talents in the following roles:
@@ -97,7 +97,7 @@ Facilitated a Community of Practice meeting or Practice Circle? You've helped se
 
 #### How do I serve as a facilitator?
 1. Volunteer to facilitate our next Community of Practice meeting
-2. [Follow facilitator instructions here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/facilitation-instructions.md)
+2. [Follow facilitator instructions here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/facilitation-instructions.md)
 3. Reach out to the last meeting's facilitator if you have questions or need guidance
 
 <hr/>
@@ -115,6 +115,6 @@ Took notes for a Community of Practice meeting? You've helped share and grow our
 
 #### How do I serve as a scribe?
 1. Volunteer to scribe our next Community of Practice meeting
-2. [Follow scribe instructions here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/shared-support/trauma/facilitation-instructions.md)
+2. [Follow scribe instructions here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/communities/trauma/facilitation-instructions.md)
 3. Reach out to the last meeting's scribe if you have questions or need guidance
 

--- a/teams/health-products/caregiver/README.md
+++ b/teams/health-products/caregiver/README.md
@@ -21,6 +21,6 @@ Create a online experience for Caregivers to apply for, track, and manage benefi
 
 ### Key Documents
 
-- [Team Charter](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/caregiver/team-charter.md)
+- [Team Charter](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/health-products/caregiver/team-charter.md)
 - [Product Outline](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/caregivers/10-10CG%20Caregiver%20application%20product-outline.md)
 - [Former Research](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/products/caregivers)

--- a/teams/health-products/health-benefits/healthcare-application/product-outline.md
+++ b/teams/health-products/health-benefits/healthcare-application/product-outline.md
@@ -129,25 +129,25 @@
  <details>
   <summary>How to apply</summary>
  
-![How to Apply](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/health-benefits/healthcare-application/screenshots/How%20to%20Apply.png)
+![How to Apply](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/health-products/health-benefits/healthcare-application/screenshots/How%20to%20Apply.png)
 </details>
 
  <details>
   <summary>Start your application</summary>
  
-![Start your application](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/health-benefits/healthcare-application/screenshots/Apply%20for%20heatlh%20care%20benefits.png)
+![Start your application](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/health-products/health-benefits/healthcare-application/screenshots/Apply%20for%20heatlh%20care%20benefits.png)
 </details>
  
  <details>
   <summary>Subway map</summary>
  
-![Subway map](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/health-benefits/healthcare-application/screenshots/Subway%20Map.png)
+![Subway map](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/health-products/health-benefits/healthcare-application/screenshots/Subway%20Map.png)
 </details>
  
  <details>
   <summary>Review page</summary>
  
-![Review page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/health-benefits/healthcare-application/screenshots/Review%20Page.png)
+![Review page](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/health-products/health-benefits/healthcare-application/screenshots/Review%20Page.png)
 </details>
  
 


### PR DESCRIPTION
Updated 38 broken internal links across additional moved team directories discovered during investigation:

Path updates:
- teams/shared-support/trauma → teams/communities/trauma
- teams/vsa/teams/caregiver → teams/health-products/caregiver
- teams/vsa/teams/health-benefits → teams/health-products/health-benefits

Fixed links in:
- 4 files in communities/trauma/ (33 links)
- 1 file in health-products/caregiver/ (1 link)
- 1 file in health-products/health-benefits/ (4 links)

All cross-references and internal documentation now correctly point to the new team structure.

Resolves #117088