### PR TITLE
Add symlinks for moved team directories

### DIFF
--- a/teams/ADE
+++ b/teams/ADE
@@ -1,0 +1,1 @@
+digital-experience/ADE

--- a/teams/Veteran Facing Forms
+++ b/teams/Veteran Facing Forms
@@ -1,0 +1,1 @@
+digital-experience/veteran-facing-forms

--- a/teams/cms
+++ b/teams/cms
@@ -1,0 +1,1 @@
+digital-experience/cms

--- a/teams/content-and-information-architecture
+++ b/teams/content-and-information-architecture
@@ -1,0 +1,1 @@
+digital-experience/content-and-information-architecture

--- a/teams/shared-support/trauma
+++ b/teams/shared-support/trauma
@@ -1,0 +1,1 @@
+../communities/trauma

--- a/teams/structured-data
+++ b/teams/structured-data
@@ -1,0 +1,1 @@
+health-products/vaos

--- a/teams/vaos
+++ b/teams/vaos
@@ -1,0 +1,1 @@
+health-products/vaos

--- a/teams/vsa/teams/benefits-memorials-2
+++ b/teams/vsa/teams/benefits-memorials-2
@@ -1,0 +1,1 @@
+../../benefits-portfolio/benefits-memorials-2

--- a/teams/vsa/teams/caregiver
+++ b/teams/vsa/teams/caregiver
@@ -1,0 +1,1 @@
+../../health-products/caregiver

--- a/teams/vsa/teams/cto-health-team
+++ b/teams/vsa/teams/cto-health-team
@@ -1,0 +1,1 @@
+../../health-products/cto-health-team

--- a/teams/vsa/teams/disability-experience
+++ b/teams/vsa/teams/disability-experience
@@ -1,0 +1,1 @@
+../../benefits-portfolio/disability-experience

--- a/teams/vsa/teams/health-benefits
+++ b/teams/vsa/teams/health-benefits
@@ -1,0 +1,1 @@
+../../health-products/health-benefits

--- a/teams/vsa/teams/sitewide-content
+++ b/teams/vsa/teams/sitewide-content
@@ -1,0 +1,1 @@
+../../digital-experience/sitewide-content

--- a/teams/vso/teams/accredited-representative-facing
+++ b/teams/vso/teams/accredited-representative-facing
@@ -1,0 +1,1 @@
+../../benefits-portfolio/accredited-representative-facing


### PR DESCRIPTION
Create symlinks from old VSA/VSO team locations to new portfolio locations:

VSA Teams → Portfolios:
- benefits-memorials-2 → benefits-portfolio
- disability-experience → benefits-portfolio
- sitewide-content → digital-experience
- caregiver → health-products
- cto-health-team → health-products
- health-benefits → health-products

Direct Team Moves:
- ADE → digital-experience
- cms → digital-experience
- content-and-information-architecture → digital-experience
- Veteran Facing Forms → digital-experience
- vaos → health-products
- structured-data → health-products (points to vaos)

VSO Teams:
- accredited-representative-facing → benefits-portfolio

Communities:
- shared-support/trauma → communities

These symlinks ensure that existing links and bookmarks to the old
team locations will continue to work and redirect to the new locations.
