### PR TITLE
Adds a validation report for manifest

### DIFF
--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -2,8 +2,8 @@ name: Weekly Team Documentation Validation Report
 
 on:
   schedule:
-    # Run every day at 9:00 AM UTC (adjust timezone as needed)
-    - cron: '0 9 * * *'
+    # Run every day at 9:02 AM UTC (adjust timezone as needed)
+    - cron: '02 9 * * *'
   workflow_dispatch: # Allow manual triggering
   pull_request:
     paths:
@@ -169,7 +169,7 @@ jobs:
           
           console.log(`Created validation report issue: ${newIssue.html_url}`);
           
-          // Save issue info for potential future use
+          // Save issue info for future reference
           core.setOutput('issue_number', newIssue.number);
           core.setOutput('issue_url', newIssue.html_url);
         

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -124,7 +124,7 @@ jobs:
           
           ---
           
-          *This issue was automatically created by the [Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/team-validation-report.yml)*`;
+          *This issue was automatically created by the [Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/manifest-team-validation-report.yml)*`;
           
           // Close previous validation report issues
           const { data: existingIssues } = await github.rest.issues.listForRepo({

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -2,8 +2,8 @@ name: Weekly Team Documentation Validation Report
 
 on:
   schedule:
-    # Run every Monday at 9:02 AM UTC (adjust timezone as needed)
-    - cron: '02 9 * * 1'
+    # Run every day at 9:00 AM UTC (adjust timezone as needed)
+    - cron: '0 9 * * *'
   workflow_dispatch: # Allow manual triggering
   pull_request:
     paths:
@@ -89,7 +89,7 @@ jobs:
       id: create-issue
       uses: actions/github-script@v7
       with:
-        github-token: ${{ secrets.MANIFEST_TEAM_VALIDATION_TOKEN }}
+        github-token: ${{ secrets.TEAM_VALIDATION_TOKEN }}
         script: |
           const fs = require('fs');
           
@@ -124,7 +124,7 @@ jobs:
           
           ---
           
-          *This issue was automatically created by the [Manifest Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/manifest-team-validation-report.yml)*`;
+          *This issue was automatically created by the [Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/team-validation-report.yml)*`;
           
           // Close previous validation report issues
           const { data: existingIssues } = await github.rest.issues.listForRepo({
@@ -151,7 +151,7 @@ jobs:
           }
           
           // Create new issue
-          const labels = ['manifest-team-validation-report'];
+          const labels = ['team-validation-report', 'documentation', 'automated-report'];
           if (isTestRun) {
             labels.push('test-run');
           } else {
@@ -169,80 +169,9 @@ jobs:
           
           console.log(`Created validation report issue: ${newIssue.html_url}`);
           
-          // Save issue info for Slack notification
+          // Save issue info for potential future use
           core.setOutput('issue_number', newIssue.number);
           core.setOutput('issue_url', newIssue.html_url);
-        
-    - name: Send Slack notification
-      if: always() # Send notification for all runs (including PR tests) for now
-      continue-on-error: true # Don't fail the workflow if Slack notification fails
-      uses: slackapi/slack-github-action@v1.26.0
-      with:
-        channel-id: 'C09CFKZ5TMK' # Slack channel ID for #platform-manifest-notifications
-        payload: |
-          {
-            "text": "📋 ${{ github.event_name == 'pull_request' && '[TEST] ' || '' }}Team Documentation Validation Report",
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "📋 ${{ github.event_name == 'pull_request' && '[TEST] ' || '' }}Team Documentation Validation Report"
-                }
-              },
-              ${{ github.event_name == 'pull_request' && '{"type": "section", "text": {"type": "mrkdwn", "text": "> ⚠️ *This is a TEST run* triggered by pull request changes"}}, ' || '' }}{
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Total Teams:* ${{ steps.validate.outputs.total_teams }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Completion Rate:* ${{ steps.validate.outputs.completion_rate }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Fully Completed:* ${{ steps.validate.outputs.completed_teams }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Needs Attention:* ${{ steps.validate.outputs.needs_attention }}"
-                  }
-                ]
-              },
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": "📊 *Progress Update:* ${{ steps.validate.outputs.completed_teams }} out of ${{ steps.validate.outputs.total_teams }} teams have completed their documentation (${{ steps.validate.outputs.completion_rate }} completion rate)."
-                }
-              },
-              {
-                "type": "actions",
-                "elements": [
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "View GitHub Issue"
-                    },
-                    "url": "${{ steps.create-issue.outputs.issue_url }}"
-                  },
-                  {
-                    "type": "button",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "View Team Manifest"
-                    },
-                    "url": "https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/README.md"
-                  }
-                ]
-              }
-            ]
-          }
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
         
     - name: Create GitHub issue on failures
       if: failure()

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        token: ${{ secrets.WORKFLOWS_PERMISSIONS }}
+        token: ${{ secrets.MANIFEST_TEAM_VALIDATION_TOKEN }}
         sparse-checkout: |
           teams/
           scripts/manifest/
@@ -89,7 +89,7 @@ jobs:
       id: create-issue
       uses: actions/github-script@v7
       with:
-        github-token: ${{ secrets.WORKFLOWS_PERMISSIONS }}
+        github-token: ${{ secrets.MANIFEST_TEAM_VALIDATION_TOKEN }}
         script: |
           const fs = require('fs');
           
@@ -124,7 +124,7 @@ jobs:
           
           ---
           
-          *This issue was automatically created by the [Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/team-validation-report.yml)*`;
+          *This issue was automatically created by the [Manifest Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/manifest-team-validation-report.yml)*`;
           
           // Close previous validation report issues
           const { data: existingIssues } = await github.rest.issues.listForRepo({
@@ -151,7 +151,7 @@ jobs:
           }
           
           // Create new issue
-          const labels = ['team-validation-report', 'documentation', 'automated-report'];
+          const labels = ['manifest-team-validation-report'];
           if (isTestRun) {
             labels.push('test-run');
           } else {

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -177,6 +177,7 @@ jobs:
       if: failure()
       uses: actions/github-script@v7
       with:
+        github-token: ${{ secrets.MANIFEST_TEAM_VALIDATION_TOKEN }}
         script: |
           github.rest.issues.create({
             owner: context.repo.owner,

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - 'scripts/manifest/**'
-      - '.github/workflows/team-validation-report.yml'
+      - '.github/workflows/manifest-team-validation-report.yml'
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -151,7 +151,7 @@ jobs:
           }
           
           // Create new issue
-          const labels = ['team-validation-report', 'documentation', 'automated-report'];
+          const labels = ['manifest-team-validation-report'];
           if (isTestRun) {
             labels.push('test-run');
           } else {
@@ -192,6 +192,6 @@ jobs:
             Please check the workflow logs and fix any issues with the team validation scripts.
             
           cc: @humancompanion-usds`,
-            labels: ['bug', 'team-manifest-tool'],
+            labels: ['bug', 'manifest-team-validation-report'],
             assignees: ['humancompanion-usds']
           })

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -1,0 +1,264 @@
+name: Weekly Team Documentation Validation Report
+
+on:
+  schedule:
+    # Run every Monday at 9:00 AM UTC (adjust timezone as needed)
+    - cron: '0 9 * * 1'
+  workflow_dispatch: # Allow manual triggering
+  pull_request:
+    paths:
+      - 'scripts/manifest/**'
+      - '.github/workflows/team-validation-report.yml'
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  validate-teams:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.WORKFLOWS_PERMISSIONS }}
+        sparse-checkout: |
+          teams/
+          scripts/manifest/
+        sparse-checkout-cone-mode: false
+        
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0'
+        bundler-cache: false
+        
+    - name: Generate team manifest
+      run: |
+        echo "📋 Generating team manifest..."
+        ruby scripts/manifest/generate_manifest.rb --verbose
+        
+    - name: Validate team documentation
+      id: validate
+      run: |
+        echo "🔍 Validating team documentation..."
+        ruby scripts/manifest/validate_teams.rb --output=team_validation_report.md --verbose
+        
+        # Capture summary stats for GitHub issue and Slack notification
+        TOTAL_TEAMS=$(grep "Total Teams:" team_validation_report.md | grep -o '[0-9]\+')
+        COMPLETED_TEAMS=$(grep "Fully Completed:" team_validation_report.md | grep -o '[0-9]\+')
+        NEEDS_ATTENTION=$(grep "Needs Attention:" team_validation_report.md | grep -o '[0-9]\+')
+        COMPLETION_RATE=$(grep "Completion Rate:" team_validation_report.md | grep -o '[0-9.]\+%')
+        
+        echo "total_teams=$TOTAL_TEAMS" >> $GITHUB_OUTPUT
+        echo "completed_teams=$COMPLETED_TEAMS" >> $GITHUB_OUTPUT
+        echo "needs_attention=$NEEDS_ATTENTION" >> $GITHUB_OUTPUT
+        echo "completion_rate=$COMPLETION_RATE" >> $GITHUB_OUTPUT
+        
+        # Create a brief summary for the GitHub issue body
+        cat > issue_summary.txt << EOF
+        Weekly Team Documentation Validation Report
+        ==========================================
+        
+        📊 Summary:
+        - Total Teams: $TOTAL_TEAMS
+        - Fully Completed: $COMPLETED_TEAMS
+        - Needs Attention: $NEEDS_ATTENTION
+        - Completion Rate: $COMPLETION_RATE
+        
+        📋 Full validation report is included below in the collapsible section
+        
+        🔗 View the current team manifest: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/README.md
+        
+        Generated on: $(date -u)
+        EOF
+        
+    - name: Upload validation report as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: team-validation-report
+        path: |
+          team_validation_report.md
+          issue_summary.txt
+        retention-days: 30
+        
+    - name: Create GitHub issue with validation report
+      id: create-issue
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ secrets.WORKFLOWS_PERMISSIONS }}
+        script: |
+          const fs = require('fs');
+          
+          // Read the validation report
+          const reportContent = fs.readFileSync('team_validation_report.md', 'utf8');
+          const summaryContent = fs.readFileSync('issue_summary.txt', 'utf8');
+          
+          // Create issue body with summary and collapsible full report
+          const isTestRun = '${{ github.event_name }}' === 'pull_request';
+          const testPrefix = isTestRun ? '> ⚠️ **This is a TEST run** triggered by a pull request\n\n' : '';
+          
+          const issueBody = `${testPrefix}${summaryContent}
+          
+          ## 📋 Actions Needed
+          
+          Teams with incomplete documentation should complete their README files according to the template.
+          
+          ## 🔗 Quick Links
+          
+          - [Current Team Manifest](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/README.md)
+          - [Team Manifest Scripts](https://github.com/department-of-veterans-affairs/va.gov-team/tree/master/scripts/manifest)
+          - [GitHub Actions](https://github.com/department-of-veterans-affairs/va.gov-team/actions)
+          
+          <details>
+          <summary>📄 Full Validation Report (Click to expand)</summary>
+          
+          \`\`\`markdown
+          ${reportContent}
+          \`\`\`
+          
+          </details>
+          
+          ---
+          
+          *This issue was automatically created by the [Team Validation Workflow](https://github.com/department-of-veterans-affairs/va.gov-team/actions/workflows/team-validation-report.yml)*`;
+          
+          // Close previous validation report issues
+          const { data: existingIssues } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: 'team-validation-report',
+            state: 'open'
+          });
+          
+          for (const issue of existingIssues) {
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed'
+            });
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: '🔄 Closed automatically - new validation report available'
+            });
+          }
+          
+          // Create new issue
+          const labels = ['team-validation-report', 'documentation', 'automated-report'];
+          if (isTestRun) {
+            labels.push('test-run');
+          } else {
+            labels.push('production');
+          }
+          
+          const { data: newIssue } = await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `${isTestRun ? '[TEST] ' : ''}Team Documentation Validation Report - ${{ steps.validate.outputs.completion_rate }} Complete (${{ steps.validate.outputs.completed_teams }}/${{ steps.validate.outputs.total_teams }})`,
+            body: issueBody,
+            labels: labels,
+            assignees: ['humancompanion-usds']
+          });
+          
+          console.log(`Created validation report issue: ${newIssue.html_url}`);
+          
+          // Save issue info for Slack notification
+          core.setOutput('issue_number', newIssue.number);
+          core.setOutput('issue_url', newIssue.html_url);
+        
+    - name: Send Slack notification
+      if: always() # Send notification for all runs (including PR tests) for now
+      uses: slackapi/slack-github-action@v1.26.0
+      with:
+        channel-id: 'C09CFKZ5TMK' # Slack channel ID for #platform-manifest-notifications
+        payload: |
+          {
+            "text": "📋 ${{ github.event_name == 'pull_request' && '[TEST] ' || '' }}Team Documentation Validation Report",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "📋 ${{ github.event_name == 'pull_request' && '[TEST] ' || '' }}Team Documentation Validation Report"
+                }
+              },
+              ${{ github.event_name == 'pull_request' && '{"type": "section", "text": {"type": "mrkdwn", "text": "> ⚠️ *This is a TEST run* triggered by pull request changes"}}, ' || '' }}{
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Total Teams:* ${{ steps.validate.outputs.total_teams }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Completion Rate:* ${{ steps.validate.outputs.completion_rate }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Fully Completed:* ${{ steps.validate.outputs.completed_teams }}"
+                  },
+                  {
+                    "type": "mrkdwn",
+                    "text": "*Needs Attention:* ${{ steps.validate.outputs.needs_attention }}"
+                  }
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "📊 *Progress Update:* ${{ steps.validate.outputs.completed_teams }} out of ${{ steps.validate.outputs.total_teams }} teams have completed their documentation (${{ steps.validate.outputs.completion_rate }} completion rate)."
+                }
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View GitHub Issue"
+                    },
+                    "url": "${{ steps.create-issue.outputs.issue_url }}"
+                  },
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View Team Manifest"
+                    },
+                    "url": "https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/README.md"
+                  }
+                ]
+              }
+            ]
+          }
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_USER_OAUTH_ACCESS_TOKEN }}
+        
+    - name: Create GitHub issue on failures
+      if: failure()
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.create({
+            owner: humancompanion-usds,
+            repo: context.repo.repo,
+            title: 'Team Validation Workflow Failed',
+            body: `The weekly team validation workflow failed to complete successfully.
+            
+            **Workflow Run:** ${context.payload.workflow_run?.html_url || 'Manual trigger'}
+            **Failed Job:** ${context.job}
+            **Timestamp:** ${new Date().toISOString()}
+            
+            Please check the workflow logs and fix any issues with the team validation scripts.
+            
+          cc: @department-of-veterans-affairs/platform-support`,
+            labels: ['bug', 'team-manifest-tool']
+          })

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -89,7 +89,7 @@ jobs:
       id: create-issue
       uses: actions/github-script@v7
       with:
-        github-token: ${{ secrets.TEAM_VALIDATION_TOKEN }}
+        github-token: ${{ secrets.MANIFEST_TEAM_VALIDATION_TOKEN }}
         script: |
           const fs = require('fs');
           

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -27,6 +27,7 @@ jobs:
         sparse-checkout: |
           teams/
           scripts/manifest/
+          products/
         sparse-checkout-cone-mode: false
         
     - name: Set up Ruby

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -174,6 +174,7 @@ jobs:
         
     - name: Send Slack notification
       if: always() # Send notification for all runs (including PR tests) for now
+      continue-on-error: true # Don't fail the workflow if Slack notification fails
       uses: slackapi/slack-github-action@v1.26.0
       with:
         channel-id: 'C09CFKZ5TMK' # Slack channel ID for #platform-manifest-notifications
@@ -248,7 +249,7 @@ jobs:
       with:
         script: |
           github.rest.issues.create({
-            owner: humancompanion-usds,
+            owner: context.repo.owner,
             repo: context.repo.repo,
             title: 'Team Validation Workflow Failed',
             body: `The weekly team validation workflow failed to complete successfully.
@@ -259,6 +260,7 @@ jobs:
             
             Please check the workflow logs and fix any issues with the team validation scripts.
             
-          cc: @department-of-veterans-affairs/platform-support`,
-            labels: ['bug', 'team-manifest-tool']
+          cc: @humancompanion-usds`,
+            labels: ['bug', 'team-manifest-tool'],
+            assignees: ['humancompanion-usds']
           })

--- a/.github/workflows/manifest-team-validation-report.yml
+++ b/.github/workflows/manifest-team-validation-report.yml
@@ -2,8 +2,8 @@ name: Weekly Team Documentation Validation Report
 
 on:
   schedule:
-    # Run every Monday at 9:00 AM UTC (adjust timezone as needed)
-    - cron: '0 9 * * 1'
+    # Run every Monday at 9:02 AM UTC (adjust timezone as needed)
+    - cron: '02 9 * * 1'
   workflow_dispatch: # Allow manual triggering
   pull_request:
     paths:

--- a/teams/digital-experience/governance/README.md
+++ b/teams/digital-experience/governance/README.md
@@ -8,8 +8,8 @@
 ### Basic Details
 
 - **Team Name:** Governance
-- **Short Name:** governance _(Used for directory URLs and should ideally match your GitHub team name below)_
-- **GitHub Team Name:** [github-team-name] _(Exact name of GitHub team which is also found in your GitHub team link below)_
+- **Short Name:** governance
+- **GitHub Team Name:** platform-governance-team
 - **GitHub Team Labels:**
   - [governance-team]
 - **GitHub Team Link:** [https://github.com/orgs/department-of-veterans-affairs/teams/platform-governance-team]


### PR DESCRIPTION
This adds a workflow to run each day to file an issue with a report in it on how we're doing getting teams to fill out a README in their teams file. Once we make progress on this we'll restrain this to running just once a week.

It's a task for this issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/117283

The workflow, finally, runs correctly. I have #platform-manfiest-notifications subscribed to issues with the appropriate label on them: https://dsva.slack.com/archives/C09CFKZ5TMK

Manifest is the latest attempt at a team and product roster which I am working on.