### PR TITLE
Remove email addresses from team manifest system for PII compliance

### DIFF
--- a/scripts/manifest/validate_teams.rb
+++ b/scripts/manifest/validate_teams.rb
@@ -25,7 +25,6 @@ class TeamDocumentationValidator
     /\[Current contract\]\(https:\/\/dvagov\.sharepoint\.com\/sites\/oitoctocontracts\/Contracts\/Forms\/AllItems\.aspx\)/,
     /\[Full Name\]/,
     /\[@github-username\]/,
-    /\[contact-email@va\.gov\]/,
     /\[Product \d+ Entry\]/,
     /\[product-name\]/
   ].freeze

--- a/teams/bam-portfolio/education-benefits-tools/README.md
+++ b/teams/bam-portfolio/education-benefits-tools/README.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Darla van Nieukerk
 - **GitHub:** N/A
-- **Email:** [darla.vannieukerk@va.gov]
 - **Role:** Product Owner
 
 #### Team Representative
 
 - **Name:** [Team Representative Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/bam-portfolio/memorials-self-service/README.md
+++ b/teams/bam-portfolio/memorials-self-service/README.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** [BAM Product Owner name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Product Owner
 
 #### Team Representative
 
 - **Name:** [Team Representative Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/benefits-portfolio/accredited-representation-management/README.md
+++ b/teams/benefits-portfolio/accredited-representation-management/README.md
@@ -32,26 +32,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Jen Bertsch
 - **GitHub:** [@jenniferbertsch](https://github.com/jenniferbertsch)
-- **Email:** [Jennifer.Bertsch@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Shannon Ford
 - **GitHub:** [@shannonkford](https://github.com/shannonkford)
-- **Email:** [Shannon.Ford1@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Sam Raudabaugh
 - **GitHub:** [@raudabaugh](https://github.com/raudabaugh)
-- **Email:** [samuel.raudabaugh@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/accredited-representatitive-facing-1/README.md
+++ b/teams/benefits-portfolio/accredited-representatitive-facing-1/README.md
@@ -32,26 +32,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Jen Bertsch
 - **GitHub:** [@jenniferbertsch](https://github.com/jenniferbertsch)
-- **Email:** [Jennifer.Bertsch@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Shannon Ford
 - **GitHub:** [@shannonkford](https://github.com/shannonkford)
-- **Email:** [Shannon.Ford1@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Sam Raudabaugh
 - **GitHub:** [@raudabaugh](https://github.com/raudabaugh)
-- **Email:** [samuel.raudabaugh@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/accredited-representatitive-facing-2/README.md
+++ b/teams/benefits-portfolio/accredited-representatitive-facing-2/README.md
@@ -32,26 +32,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Jen Bertsch
 - **GitHub:** [@jenniferbertsch](https://github.com/jenniferbertsch)
-- **Email:** [Jennifer.Bertsch@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Shannon Ford
 - **GitHub:** [@shannonkford](https://github.com/shannonkford)
-- **Email:** [Shannon.Ford1@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Sam Raudabaugh
 - **GitHub:** [@raudabaugh](https://github.com/raudabaugh)
-- **Email:** [samuel.raudabaugh@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/benefits-management-tools-1/README.md
+++ b/teams/benefits-portfolio/benefits-management-tools-1/README.md
@@ -31,26 +31,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Amy Lai
 - **GitHub:** [@amylai-va](https://github.com/amylai-va)
-- **Email:** [Amy.Lai2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Julie Strothman
 - **GitHub:** [@jstrothman](https://github.com/jstrothman)
-- **Email:** [julie.strothman@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/benefits-management-tools-2/README.md
+++ b/teams/benefits-portfolio/benefits-management-tools-2/README.md
@@ -30,26 +30,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Amy Lai
 - **GitHub:** [@amylai-va](https://github.com/amylai-va)
-- **Email:** [Amy.Lai2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Julie Strothman
 - **GitHub:** [@jstrothman](https://github.com/jstrothman)
-- **Email:** [julie.strothman@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/benefits-management-tools-3/README.md
+++ b/teams/benefits-portfolio/benefits-management-tools-3/README.md
@@ -31,26 +31,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Amy Lai
 - **GitHub:** [@amylai-va](https://github.com/amylai-va)
-- **Email:** [Amy.Lai2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Julie Strothman
 - **GitHub:** [@jstrothman](https://github.com/jstrothman)
-- **Email:** [julie.strothman@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/conditions/README.md
+++ b/teams/benefits-portfolio/conditions/README.md
@@ -32,31 +32,26 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Emily Theis
 - **GitHub:** [@emilytheis](https://github.com/emilytheis)
-- **Email:** [Emily.Theis@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Liz Lantz
 - **GitHub:** [@andaleliz](https://github.com/andaleliz)
-- **Email:** [Elizabeth.Lantz@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Leah Bannon
 - **GitHub:** [@leahbannon2](https://github.com/leahbannon2)
-- **Email:** [leah.bannon2@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/decision-reviews/README.md
+++ b/teams/benefits-portfolio/decision-reviews/README.md
@@ -31,26 +31,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Amy Lai
 - **GitHub:** [@amylai-va](https://github.com/amylai-va)
-- **Email:** [Amy.Lai2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Julie Strothman
 - **GitHub:** [@jstrothman](https://github.com/jstrothman)
-- **Email:** [julie.strothman@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/dependents-management/README.md
+++ b/teams/benefits-portfolio/dependents-management/README.md
@@ -31,26 +31,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Amy Lai
 - **GitHub:** [@amylai-va](https://github.com/amylai-va)
-- **Email:** [Amy.Lai2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Julie Strothman
 - **GitHub:** [@jstrothman](https://github.com/jstrothman)
-- **Email:** [julie.strothman@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/disability-benefits-1/README.md
+++ b/teams/benefits-portfolio/disability-benefits-1/README.md
@@ -31,31 +31,26 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Emily Theis
 - **GitHub:** [@emilytheis](https://github.com/emilytheis)
-- **Email:** [Emily.Theis@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Liz Lantz
 - **GitHub:** [@andaleliz](https://github.com/andaleliz)
-- **Email:** [Elizabeth.Lantz@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Leah Bannon
 - **GitHub:** [@leahbannon2](https://github.com/leahbannon2)
-- **Email:** [leah.bannon2@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/disability-benefits-2/README.md
+++ b/teams/benefits-portfolio/disability-benefits-2/README.md
@@ -32,31 +32,26 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Emily Theis
 - **GitHub:** [@emilytheis](https://github.com/emilytheis)
-- **Email:** [Emily.Theis@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Liz Lantz
 - **GitHub:** [@andaleliz](https://github.com/andaleliz)
-- **Email:** [Elizabeth.Lantz@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Leah Bannon
 - **GitHub:** [@leahbannon2](https://github.com/leahbannon2)
-- **Email:** [leah.bannon2@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/employee-experience/README.md
+++ b/teams/benefits-portfolio/employee-experience/README.md
@@ -31,26 +31,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Amy Lai
 - **GitHub:** [@amylai-va](https://github.com/amylai-va)
-- **Email:** [Amy.Lai2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Julie Strothman
 - **GitHub:** [@jstrothman](https://github.com/jstrothman)
-- **Email:** [julie.strothman@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** Cory Schrakoff
 - **GitHub:** [@CorySohrakoffUSDS](https://github.com/CorySohrakoffUSDS)
-- **Email:** [Cory.Sohrakoff@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/pension-benefits-1/README.md
+++ b/teams/benefits-portfolio/pension-benefits-1/README.md
@@ -31,26 +31,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Sanja Bajovic
 - **GitHub:** [@sanjabaj2](https://github.com/sanjabaj2)
-- **Email:** [Sanja.Bajovic2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Ben Guhin Delphine
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** TBD
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/benefits-portfolio/pension-benefits-2/README.md
+++ b/teams/benefits-portfolio/pension-benefits-2/README.md
@@ -32,26 +32,22 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Sanja Bajovic
 - **GitHub:** [@sanjabaj2](https://github.com/sanjabaj2)
-- **Email:** [Sanja.Bajovic2@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 #### OCTO Leads
 
 - **Name:** Ben Guhin Delphine
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** OCTO Design/Research Lead
 
 - **Name:** TBD
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** OCTO Engineering Lead
 
 ## About This Team

--- a/teams/digital-experience/ADE/readme.md
+++ b/teams/digital-experience/ADE/readme.md
@@ -150,7 +150,6 @@ You can also reach us by attending our weekly office hours on Wednesdays at 3:00
 
 - **Name:** Martha Wilkes
 - **GitHub:** [@artsymartha68](https://github.com/artsymartha68)
-- **Email:** Martha.Wilkes@va.gov
 - **Role:** OCTO-DE Lead
 
 ## Products We Own

--- a/teams/digital-experience/analytics-and-insights/README.md
+++ b/teams/digital-experience/analytics-and-insights/README.md
@@ -30,14 +30,12 @@
 
 - **Name:** Michael Land
 - **GitHub:** [@mikefland](https://github.com/mikefland)
-- **Email:** Michael.Land2@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Adam Oyenuga
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/authenticated-experience/README.md
+++ b/teams/digital-experience/authenticated-experience/README.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Chante Lantos-Swett
 - **GitHub:** [@clantosswett](https://github.com/clantosswett)
-- **Email:** Chante.LantosSwett@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Anneliese LaTempa
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/cms/README.md
+++ b/teams/digital-experience/cms/README.md
@@ -32,21 +32,18 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Erika Washburn
 - **GitHub:** [@EWashb](https://github.com/EWashb)
-- **Email:** Erika.Washburn@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Grace Kretschmer Tran
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 #### Team Representative
 
 - **Name:** Kelly Lein
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/content-and-information-architecture/README.md
+++ b/teams/digital-experience/content-and-information-architecture/README.md
@@ -30,14 +30,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Danielle Thierry
 - **GitHub:** [@DanielleThierryUSDSVA](https://github.com/DanielleThierryUSDSVA)
-- **Email:** Danielle.Thierry@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Misty Milliron-Grant
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/design-forms-systems/README.md
+++ b/teams/digital-experience/design-forms-systems/README.md
@@ -30,14 +30,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Matt Dingee
 - **GitHub:** [@humancompanion-usds](https://github.com/humancompanion-usds)
-- **Email:** <matthew.dingee@va.gov>
 - **Role:** OCTO-DE Lead
 
 #### Program Manager
 
 - **Name:** Megan Siddle
 - **GitHub:** @megansiddle
-- **Email:** <megan.siddle@va.gov>
 - **Role:** Program Manager
 
 #### Additional Team Members

--- a/teams/digital-experience/digital-notifications/README.md
+++ b/teams/digital-experience/digital-notifications/README.md
@@ -31,34 +31,28 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Dave Conlon
 - **GitHub:** [@davidconlon](https://github.com/davidconlon)
-- **Email:** David.Conlon@va.gov
 - **Role:** OCTO-DE Lead
 
 - **Name:** Shane Elliott
 - **GitHub:** [@shanemelliott](https://github.com/shanemelliott)
-- **Email:** shane.elliott@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representatives
 
 - **Name:** Justin
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 - **Name:** Samantha
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 - **Name:** Ksenia
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 - **Name:** Nick
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/financial-management/README.md
+++ b/teams/digital-experience/financial-management/README.md
@@ -31,19 +31,16 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Denise Coveyduc
 - **GitHub:** [@denisecoveyduc](https://github.com/denisecoveyduc)
-- **Email:** Denise.Coveyduc@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representatives
 
 - **Name:** Heather Rienks
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 - **Name:** Tom Davis
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/governance/README.md
+++ b/teams/digital-experience/governance/README.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Matt Dingee
 - **GitHub:** [@humancompanion-usds](https://github.com/humancompanion-usds)
-- **Email:** matthew.dingee@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Shira Goodman
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/identity/README.md
+++ b/teams/digital-experience/identity/README.md
@@ -32,33 +32,28 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Samara Strauss
 - **GitHub:** [@Samara-Strauss](https://github.com/samara-strauss)
-- **Email:** Samara.Strauss@va.gov
 - **Role:** OCTO-DE Lead
 
 - **Name:** Tom Black
 - **GitHub:** [@tomblackgov](https://github.com/tomblackgov)
-- **Email:** Thomas.Black2@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Jon Knotts
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 #### Team Lead
 
 - **Name:** Joelle Wells
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 #### Team Lead
 
 - **Name:** Lainey Trahan
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/iterate-innovate-and-run/README.md
+++ b/teams/digital-experience/iterate-innovate-and-run/README.md
@@ -31,35 +31,30 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Dave Conlon
 - **GitHub:** [@davidconlon](https://github.com/davidconlon)
-- **Email:** David.Conlon@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Megan
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 #### Team Representative
 
 - **Name:** Mike
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 #### Team Representative
 
 - **Name:** Pete
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 #### Team Representative
 
 - **Name:** Tabinda
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/mobile-app-and-platform/README.md
+++ b/teams/digital-experience/mobile-app-and-platform/README.md
@@ -32,14 +32,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Ryan Thurlwell
 - **GitHub:** [@rtwell](https://github.com/rtwell)
-- **Email:** Ryan.Thurlwell@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Becca Tupaj
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/mobile-feature-support/readme.md
+++ b/teams/digital-experience/mobile-feature-support/readme.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Michelle Middaugh
 - **GitHub:** [@mmiddaugh](https://github.com/mmiddaugh)
-- **Email:** [Suzanne.Middaugh@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 ## About This Team

--- a/teams/digital-experience/platform-infrastructure-services/README.md
+++ b/teams/digital-experience/platform-infrastructure-services/README.md
@@ -32,19 +32,16 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Erika Washburn
 - **GitHub:** [@EWashb](https://github.com/EWashb)
-- **Email:** Erika.Washburn@va.gov
 - **Role:** OCTO-DE Lead
 
 - **Name:** Steve Albers
 - **GitHub:** [@va-albers](https://github.com/va-albers)
-- **Email:** Steve.Albers@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** David Petras
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/platform-security/README.md
+++ b/teams/digital-experience/platform-security/README.md
@@ -32,19 +32,16 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Ray Wang
 - **GitHub:** [@raywangoctova](https://github.com/raywangoctova)
-- **Email:** gang.wang@va.gov
 - **Role:** OCTO-DE Lead
 
 - **Name:** Andrew Mo
 - **GitHub:** [@amo-va-octo](https://github.com/amo-va-octo)
-- **Email:** Andrew.Mo@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Kelly Argyros
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/platform-sre/README.md
+++ b/teams/digital-experience/platform-sre/README.md
@@ -32,14 +32,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Erika Washburn
 - **GitHub:** [@EWashb](https://github.com/EWashb)
-- **Email:** Erika.Washburn@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Ashley Guerrant
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/platform-support/README.md
+++ b/teams/digital-experience/platform-support/README.md
@@ -32,14 +32,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Matthew Dingee
 - **GitHub:** [@humancompanion-usds](https://github.com/humancompanion-usds)
-- **Email:** matthew.dingee@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Alyssa Gallion
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/digital-experience/veteran-support/README.md
+++ b/teams/digital-experience/veteran-support/README.md
@@ -30,14 +30,12 @@
 
 - **Name:** Chante Lantos-Swett
 - **GitHub:** [@clantosswett](https://github.com/clantosswett)
-- **Email:** Chante.LantosSwett@va.gov
 - **Role:** OCTO-DE Lead
 
 #### Team Representative
 
 - **Name:** Anita Middleton
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/health-portfolio/1010-health-apps/README.md
+++ b/teams/health-portfolio/1010-health-apps/README.md
@@ -29,19 +29,16 @@
 
 - **Name:** Patrick Bateman
 - **GitHub:** [@batemapf](https://github.com/batemapf)
-- **Email:** Patrick.Bateman@va.gov
 - **Role:** OCTO PO
 
 #### Team Representatives
 
 - **Name:** Heather Justice
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 - **Name:** Alex Parker
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Representative
 
 ## About This Team

--- a/teams/health-portfolio/horizon/README.md
+++ b/teams/health-portfolio/horizon/README.md
@@ -31,44 +31,36 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Marci McGuire
 - **GitHub:** [@MarciMcGuire](https://github.com/MarciMcGuire)
-- **Email:** Marci.McGuire@va.gov
 - **Role:** OCTO PO
 
 #### Team Members
 
 - **Name:** Bryan Ivie
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Daniel Cloud
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Florence McCafferty
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Cara Frissell
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Sara Sterkenburg
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Marcello Antosh
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Lauren Ernest
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 ## About This Team

--- a/teams/health-portfolio/hydra/README.md
+++ b/teams/health-portfolio/hydra/README.md
@@ -32,36 +32,30 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Kay Lawyer
 - **GitHub:** [@klawyer](https://github.com/klawyer)
-- **Email:** katherine.lawyer@va.gov
 - **Role:** OCTO PO
 
 - **Name:** Kristen McConnell
 - **GitHub:** [@kristenmcconnell](https://github.com/kristenmcconnell)
-- **Email:** Kristen.Mcconnell@va.gov
 - **Role:** OCTO PO
 
 - **Name:** Mark Dewey
 - **GitHub:** [@mdewey](https://github.com/mdewey)
-- **Email:** Mark.Dewey@va.gov
 - **Role:** OCTO PO
 
 #### Tech Leads
 
 - **Name:** Lee Delarm
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Tech Lead
 
 - **Name:** Nathan Douglas
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Tech Lead
 
 #### Product Manager
 
 - **Name:** Mike Marinos
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Product Manager
 
 ## About This Team

--- a/teams/health-portfolio/ivc-forms/README.md
+++ b/teams/health-portfolio/ivc-forms/README.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Premal Shah
 - **GitHub:** [@pshahVA](https://github.com/pshahVA)
-- **Email:** [Premal.Shah@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 ## About This Team

--- a/teams/health-portfolio/medical-records/README.md
+++ b/teams/health-portfolio/medical-records/README.md
@@ -31,44 +31,36 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Marci McGuire
 - **GitHub:** [@MarciMcGuire](https://github.com/MarciMcGuire)
-- **Email:** Marci.McGuire@va.gov
 - **Role:** OCTO PO
 
 #### Team Members
 
 - **Name:** David Koger
 - **GitHub:** [@davidkoger](https://github.com/davidkoger)
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Mike Moyer
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Ni Chia
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Napoleon Kernessant
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Aswin Malla
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Elwood Gary
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Liz Townsend
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 ## About This Team

--- a/teams/health-portfolio/medications-medical-devices-supplies/README.md
+++ b/teams/health-portfolio/medications-medical-devices-supplies/README.md
@@ -32,59 +32,48 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Kay Lawyer
 - **GitHub:** [@klawyer](https://github.com/klawyer)
-- **Email:** katherine.lawyer@va.gov
 - **Role:** OCTO PO
 
 #### Team Members
 
 - **Name:** Michael Brodsky
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Richard Davis
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Chris Donelson
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Cam Keif
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Ian Seabock
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Langston Payne
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Andrea Uhr
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Timothy Powell
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Amy Cashbaugh
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Geoff Winner
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 ## About This Team

--- a/teams/health-portfolio/messaging/README.md
+++ b/teams/health-portfolio/messaging/README.md
@@ -32,64 +32,52 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Patrick Bateman
 - **GitHub:** [@batemapf](https://github.com/batemapf)
-- **Email:** Patrick.Bateman@va.gov
 - **Role:** OCTO PO
 
 #### Team Members
 
 - **Name:** Stacy Blackwood
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Alex Morgun
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Kevin Suarez
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Adam Stoler
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Jason Conigliari
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Clint Wilde
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Mario Williams
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Jayson Perkins
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Sofia Cordero
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Fiona Tang
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 - **Name:** Espy Thomson
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Member
 
 ## About This Team

--- a/teams/health-portfolio/orion/README.md
+++ b/teams/health-portfolio/orion/README.md
@@ -32,31 +32,26 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Kay Lawyer
 - **GitHub:** [@klawyer](https://github.com/klawyer)
-- **Email:** katherine.lawyer@va.gov
 - **Role:** OCTO PO
 
 - **Name:** Kristen McConnell
 - **GitHub:** [@kristenmcconnell](https://github.com/kristenmcconnell)
-- **Email:** Kristen.Mcconnell@va.gov
 - **Role:** OCTO PO
 
 - **Name:** Mark Dewey
 - **GitHub:** [@mdewey](https://github.com/mdewey)
-- **Email:** Mark.Dewey@va.gov
 - **Role:** OCTO PO
 
 #### Tech Lead
 
 - **Name:** Simi Adebowale
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Tech Lead
 
 #### Product Manager
 
 - **Name:** Alayna Abel
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Product Manager
 
 ## About This Team

--- a/teams/health-portfolio/ursa-minor/README.md
+++ b/teams/health-portfolio/ursa-minor/README.md
@@ -31,31 +31,26 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** Kay Lawyer
 - **GitHub:** [@klawyer](https://github.com/klawyer)
-- **Email:** katherine.lawyer@va.gov
 - **Role:** OCTO PO
 
 - **Name:** Kristen McConnell
 - **GitHub:** [@kristenmcconnell](https://github.com/kristenmcconnell)
-- **Email:** Kristen.Mcconnell@va.gov
 - **Role:** OCTO PO
 
 - **Name:** Mark Dewey
 - **GitHub:** [@mdewey](https://github.com/mdewey)
-- **Email:** Mark.Dewey@va.gov
 - **Role:** OCTO PO
 
 #### Tech Lead
 
 - **Name:** Kevin Duensing
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Tech Lead
 
 #### Product Manager
 
 - **Name:** Charlotte Reid
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Product Manager
 
 ## About This Team

--- a/teams/team-readme-template.md
+++ b/teams/team-readme-template.md
@@ -31,14 +31,12 @@ Directory system will parse this section to display team member contact informat
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** OCTO PO
 
 #### Team Lead
 
 - **Name:** [Full Name]
 - **GitHub:** [@github-username]
-- **Email:** [contact-email@va.gov]
 - **Role:** Team Lead
 
 ## About This Team


### PR DESCRIPTION
## Summary

This PR removes all email addresses from the team manifest system to ensure PII compliance in the public repository.

## Changes Made

### 🔧 System Updates
- **Template**: Removed email fields from `teams/team-readme-template.md`
- **Validation**: Removed email pattern validation from `scripts/manifest/validate_teams.rb`
- **Team READMEs**: Removed email fields from 43 team README files across all portfolios

### 📊 Impact
- **Files modified**: 45 total files
- **Team files updated**: 43 README files
- **Portfolios affected**: Digital Experience, Benefits, Health, BAM
- **Deletions**: 175 lines containing email addresses

### ✅ Validation
- All team manifest system components remain functional
- Validation script updated to no longer require email fields
- Manifest generation continues to work correctly
- No broken links or system functionality issues

## Security & Compliance

- ✅ **PII Removed**: All email addresses removed from public repository
- ✅ **Future Prevention**: Template updated to prevent future email additions
- ✅ **System Integrity**: Full functionality maintained throughout

## Testing

- Validated manifest generation with `generate_manifest.rb --dry-run`
- Confirmed team validation works correctly with updated patterns
- Tested on multiple teams across different portfolios

This change ensures the team manifest system is fully PII-compliant while maintaining all existing functionality for team documentation and directory generation.