### PR TITLE
[DRAFT] Create regression test plan for 526 confirmation view feature

### DIFF
--- a/teams/vsa/teams/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
+++ b/teams/vsa/teams/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
@@ -1,0 +1,12 @@
+# Regression test plan
+
+> A Regression Test Plan is a document that maps user stories to tests and which includes the results of executing those tests, thereby providing a strategy for verifying the functionality of your product prior to the work moving through the Collaboration Cycle.
+
+TODO: Create test cases in TestRail that map to the functionality described by our testing plan. Add link or screenshot in this doc
+
+In additon to these TestRail tests, we have also introduced many unit tests in both the frontend and backend and a cypress test.
+
+# Traceability Statement
+TODO: Before staging review, update the draft traceability statement below with the outcome of the bug bash testing  
+
+According to our testing, 100% of the high-level, critical use-cases are represented in our test plan. In addition to the high-level requirement, many more detailed specifics are covered by unit tests and cypress tests. In addition to TestRail, Unit test, and Cypress tests, manual end-to-end testing has taken place ensuring document flows through all systems as expected. 

--- a/teams/vsa/teams/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
+++ b/teams/vsa/teams/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
@@ -2,11 +2,15 @@
 
 > A Regression Test Plan is a document that maps user stories to tests and which includes the results of executing those tests, thereby providing a strategy for verifying the functionality of your product prior to the work moving through the Collaboration Cycle.
 
-TODO: Create test cases in TestRail that map to the functionality described by our testing plan. Add link or screenshot in this doc
+Our team planned an executed a bug-bash to thoroughly test this new feature on staging
 
-In additon to these TestRail tests, we have also introduced many unit tests in both the frontend and backend and a cypress test.
+- Link to bug bash implementation epic, testing over 100 possible pages and multiple pathways: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119075#issue-3399500637
+
+A new test case has been added in test rail
+
+- C152128 - 526 Submission Experience - With new copy of submission accordion: https://dsvavsp.testrail.io/index.php?/cases/view/152128
+
+In additon to these tests, we have also introduced many front end unit tests and a cypress test.
 
 # Traceability Statement
-TODO: Before staging review, update the draft traceability statement below with the outcome of the bug bash testing  
-
 According to our testing, 100% of the high-level, critical use-cases are represented in our test plan. In addition to the high-level requirement, many more detailed specifics are covered by unit tests and cypress tests. In addition to TestRail, Unit test, and Cypress tests, manual end-to-end testing has taken place ensuring document flows through all systems as expected. 


### PR DESCRIPTION
This is a first draft of the test plan outline. TODOs will be addressed and updated before staging review.

New regression plan documentation:

* Added a new `confirmation-copy-of-submission-regression-plan.md` file that describes the regression testing approach, including mapping user stories to tests, use of TestRail, unit tests, Cypress tests, and manual end-to-end testing.