### PR TITLE
Update link to survey in the collab cycle feedback issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/collab-cycle-feedback.md
+++ b/.github/ISSUE_TEMPLATE/collab-cycle-feedback.md
@@ -10,7 +10,7 @@ assignees: ''
 
 ## Next Steps for the VFS team
 
-_How did this touchpoint go? [Give feedback on the Collaboration Cycle](https://ows.io/qs/gb1dfnkl) at any time._
+_How did this touchpoint go? [Give feedback on the Collaboration Cycle](https://ows.io/qs/o3jkwoez) at any time._
 
 - [ ] **Assign** this ticket to the team member(s) responsible for addressing feedback provided by Platform.
 - [ ] **Comment** on this ticket:


### PR DESCRIPTION
Update link for collab cycle feedback survey and remove extraneous line at the end of the template

Part of work on #119381 