### PR TITLE
Add regression test plan for copy of submission

### DIFF
--- a/teams/benefits-portfolio/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
+++ b/teams/benefits-portfolio/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
@@ -1,0 +1,16 @@
+# Regression test plan
+
+> A Regression Test Plan is a document that maps user stories to tests and which includes the results of executing those tests, thereby providing a strategy for verifying the functionality of your product prior to the work moving through the Collaboration Cycle.
+
+Our team planned an executed a bug-bash to thoroughly test this new feature on staging
+
+- Link to bug bash implementation epic, testing over 100 possible pages and multiple pathways: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119075#issue-3399500637
+
+A new test case has been added in test rail
+
+- C152128 - 526 Submission Experience - With new copy of submission accordion: https://dsvavsp.testrail.io/index.php?/cases/view/152128
+
+In additon to these tests, we have also introduced many front end unit tests and a cypress test.
+
+# Traceability Statement
+According to our testing, 100% of the high-level, critical use-cases are represented in our test plan. In addition to the high-level requirement, many more detailed specifics are covered by unit tests and cypress tests. In addition to TestRail, Unit test, and Cypress tests, manual end-to-end testing has taken place ensuring document flows through all systems as expected. 

--- a/teams/benefits-portfolio/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
+++ b/teams/benefits-portfolio/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
@@ -12,9 +12,10 @@ Existing test rail cases were tested
 - C107773 - 526 Submission Experience - Minimal Test
 - C107916 -	526 Submission Experience - BDD (Benefits Delivery at Discharge) - minimal
 
-## Additional resources - Bug Bash:
-Our team tested each page of the form 526. A list of every possible page in the form 526 was created and split into tickets. Testers manually verified that the data inputs displayed as expected in the copy of submission accordion [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119075)]
-<img width="1727" height="2550" alt="Image" src="https://github.com/user-attachments/assets/7bd9746e-3b91-4140-bac4-c8c040a3d971" />
+## Additional resources - Bug Bash
+Our team manually tested each page of the form 526 as part of an in-depth bug bash. A list of all possible pages in the form 526 (147 total) was created and divided into Github issues. Testers manually verified that each page's data inputs displayed as expected in the copy of submission accordion.
+  - [Bug bash plan](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119075) 26 issues were completed to test all 147 pages
+  - [Bug Bash results](https://github.com/department-of-veterans-affairs/va.gov-team/issues/122791) 11 issues were identified
 
 ## Traceability Statement
 Coverage for References
@@ -22,5 +23,5 @@ Coverage for References
 - Each page of the form has associated bug bash tickets with validation steps and screenshots.
 
 Summary (Defects) reports
-- Testing is still underway
+- Additional testing and addressing know issues is still underway
 - This is outlined in the known defects section

--- a/teams/benefits-portfolio/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
+++ b/teams/benefits-portfolio/disability-experience/team-docs/Regression Test Plans/confirmation-copy-of-submission-regression-plan.md
@@ -2,15 +2,25 @@
 
 > A Regression Test Plan is a document that maps user stories to tests and which includes the results of executing those tests, thereby providing a strategy for verifying the functionality of your product prior to the work moving through the Collaboration Cycle.
 
-Our team planned an executed a bug-bash to thoroughly test this new feature on staging
 
-- Link to bug bash implementation epic, testing over 100 possible pages and multiple pathways: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119075#issue-3399500637
+A new test case has been added in [Test Rail](https://dsvavsp.testrail.io/index.php?/suites/view/2552)
 
-A new test case has been added in test rail
+- C152128 - 526 Submission Experience - With new copy of submission accordion
 
-- C152128 - 526 Submission Experience - With new copy of submission accordion: https://dsvavsp.testrail.io/index.php?/cases/view/152128
+Existing test rail cases were tested
+- C37806 - 526 Minimal Test 
+- C107773 - 526 Submission Experience - Minimal Test
+- C107916 -	526 Submission Experience - BDD (Benefits Delivery at Discharge) - minimal
 
-In additon to these tests, we have also introduced many front end unit tests and a cypress test.
+## Additional resources - Bug Bash:
+Our team tested each page of the form 526. A list of every possible page in the form 526 was created and split into tickets. Testers manually verified that the data inputs displayed as expected in the copy of submission accordion [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/119075)]
+<img width="1727" height="2550" alt="Image" src="https://github.com/user-attachments/assets/7bd9746e-3b91-4140-bac4-c8c040a3d971" />
 
-# Traceability Statement
-According to our testing, 100% of the high-level, critical use-cases are represented in our test plan. In addition to the high-level requirement, many more detailed specifics are covered by unit tests and cypress tests. In addition to TestRail, Unit test, and Cypress tests, manual end-to-end testing has taken place ensuring document flows through all systems as expected. 
+## Traceability Statement
+Coverage for References
+- We aimed for 100% coverage.
+- Each page of the form has associated bug bash tickets with validation steps and screenshots.
+
+Summary (Defects) reports
+- Testing is still underway
+- This is outlined in the known defects section


### PR DESCRIPTION
Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/119073

This is a first draft of the test plan outline. TODOs will be addressed and updated before staging review.

New regression plan documentation:

Added a new confirmation-copy-of-submission-regression-plan.md file that describes the regression testing approach, including mapping user stories to tests, use of TestRail, unit tests, Cypress tests, and manual end-to-end testing.