### PR TITLE
Update Platform Orientation. Remove SOCKS, etc. 

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
+++ b/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
@@ -55,7 +55,8 @@ RA - Remote Access_
 - [ ] [Request access to tools](https://depo-platform-documentation.scrollhelp.site/getting-started/Request-access-to-tools.969605215.html) documentation on the Platform Website
 - [ ] [Confluence](https://vfs.atlassian.net/wiki/home)
   - [ ] [VA.Gov Platform Manual](https://vfs.atlassian.net/wiki/spaces/OT/pages/2354315287/Platform+Infrastructure+Manual+WIP)
-  - [ ] [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) - have a manager or leadership add you
+  - [ ] Have a manager or leadership add you to the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)
+  - [ ] Read [Confluence/Platform Website Documentation Orientation](https://vfs.atlassian.net/wiki/spaces/AP/pages/4489445378/Confluence+Platform+Website+Documentation+Orientation)
 
 **Platform overview and design**
 

--- a/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
+++ b/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
@@ -55,6 +55,7 @@ RA - Remote Access_
 - [ ] [Request access to tools](https://depo-platform-documentation.scrollhelp.site/getting-started/Request-access-to-tools.969605215.html) documentation on the Platform Website
 - [ ] [Confluence](https://vfs.atlassian.net/wiki/home)
   - [ ] [VA.Gov Platform Manual](https://vfs.atlassian.net/wiki/spaces/OT/pages/2354315287/Platform+Infrastructure+Manual+WIP)
+  - [ ] [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster) - have a manager or leadership add you
 
 **Platform overview and design**
 
@@ -65,15 +66,15 @@ RA - Remote Access_
 
 - [ ] GitHub
   - [ ] Join the ['department-of-veterans-affairs' organization](https://github.com/department-of-veterans-affairs)
+  - [ ] Even though you're Platform and not VFS, fill out the [New VFS Team Member Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=New-VFS-Team-Member.yml). By filling that out, you'll get added to the `vets.gov-write` GitHub Team which grants you write access to most repos in the org.
   - [ ] Make sure you have access to the [devops repo](https://github.com/department-of-veterans-affairs/devops)
-- [ ] [SOCKS](https://depo-platform-documentation.scrollhelp.site/getting-started/accessing-internal-tools-via-socks-proxy) - _for remote access to the following apps:_
-  - [ ] [Jenkins](http://jenkins.vfs.va.gov/)
-  - [ ] [Sentry](http://sentry.vfs.va.gov/)
-  - [ ] [Argo CD](http://argocd.vfs.va.gov/)
-- [ ] [Pagerduty](https://ecc.pagerduty.com/). Follow [these instructions](https://depo-platform-documentation.scrollhelp.site/getting-started/request-access-to-tools#Requestaccesstotools-PagerDuty) to request access. 
+- [ ] [Pagerduty](https://ecc.pagerduty.com/). Follow [these instructions](https://depo-platform-documentation.scrollhelp.site/getting-started/request-access-to-tools#Requestaccesstotools-PagerDuty) to request access.
 - [ ] [Keybase](https://keybase.io/)
 - [ ] [Datadog](https://depo-platform-documentation.scrollhelp.site/developer-docs/get-access-to-datadog) - _You may need to ask your PM or TL to submit a request on your behalf_
 - [ ] [AWS access request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2Coperations%2Cops-access-request&template=aws-access-request.yml&title=Access+for+%5Bindividual%5D) - _Wait until your EQIP submission is verified_
+- [ ] [Jenkins](http://jenkins.vfs.va.gov/) _Accessed on VA Network only_
+- [ ] [Sentry](http://sentry.vfs.va.gov/) _Accessed on VA Network only_
+- [ ] [Argo CD](http://argocd.vfs.va.gov/) _Accessed on VA Network only_
 
 _Once your PIV card has been obtained:_
 


### PR DESCRIPTION
This PR:
- Remove SOCKS reference, since we no longer offer SOCKS access.
- Adds some Confluence links.
- Adds a link to the VFS template.

Other edits welcome!