### PR TITLE
Revise procedures for resolving missing Pega statuses

### DIFF
--- a/products/health-care/champva/resolving-missing-pega-status.md
+++ b/products/health-care/champva/resolving-missing-pega-status.md
@@ -4,20 +4,28 @@
 
 The "Missing Pega Status" dashboard widget indicates that certain forms haven't been processed by the Pega system. This can lead to delays and potential errors in the form processing workflow.
 
+> [!TIP]
+> Most of the time, missing statuses automatically resolve after Pega has ingested the submission and our [sidekiq job](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb) re-runs
+
 ## Resolving the Issue:
 
-1. Gather information about the submission in question using the `MissingStatusCleanup` utility (see [here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md) for detailed commands)
-    - Access a Vets-API Pod:
-        * Open a web browser and navigate to [Argo CD](https://argocd.vfs.va.gov/applications/vets-api-prod?resource=) to get access to a running instance of the backend
-        * Select application `vets-api-prod`
-        * Select a pod with a name beginning with `vets-api-web-` and start a console session in it
-    - Using the guide [here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md), search for submissions with missing Pega statuses
-2. Check the [production Pega instance](https://pega.docmp.vaec.va.gov/prweb/PRAuth/app/daper) (you must be on the VA Network) for a submission with the same name/email as the flagged submssion. If no records match, this may be [common scenario 1](#common-scenarios).
-    - Notify the DOCMP team in the appropriate Teams chat on the VA network and provide them the submission details as output by the `MissingStatusCleanup` [utility](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md).
-3. If a cause has been determined, documented, and approved by product manager(s), the missing status may be [manually cleared](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md#to-clear-a-missing-status)
+### Current Procedure
+This is the current procedure as of November 2025.
 
-> [!TIP]
-> If the cause is determined to be on the DOCMP side, missing statuses should automatically resolve after Pega has ingested the submission and our [sidekiq job](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/ivc_champva/app/jobs/ivc_champva/missing_form_status_job.rb) re-runs
+1. Wait an hour or two and see if the missing status resolves on its own.  This is [common scenario 2](#common-scenarios) which happens most of the time.
+2. Notify the DOCMP team in the `DOCMP PEGA and VA.GOV Sync` Teams channel that we have missing statuses.  This may be [common scenario 1](#common-scenarios), in which case the DOCMP team is typically able to identify submissions that were not ingested and reprocess them.
+3. If Pega is unable to ingest a submission because it failed to upload to S3, [create an incident ticket](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/ivc-forms-monitoring-playbook.md#best-practices#general-datadog-alerts-500-status-status-other-than-a-200) to investigate why.
+4. If a missing status is still being reported after Pega has ingested a submission, something went wrong and we need to manually clear the status in our database.  [Create an incident ticket](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/ivc-forms-monitoring-playbook.md#best-practices#general-datadog-alerts-500-status-status-other-than-a-200) to investigate what happened.  If a cause has been determined, documented, and approved by product manager(s), the missing status may be [manually cleared](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md#to-clear-a-missing-status)
+
+### Old Procedure
+This procedure was followed until November 2025.  It requires Rails console acces in the production environment.
+
+1. Wait an hour or two and see if the missing status resolves on its own.  This is what typically happens.
+2. Gather information about the submission in question using the `MissingStatusCleanup` utility
+    - Using the guide [here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md), search for submissions with missing Pega statuses
+3. Check the [production Pega instance](https://pega.docmp.vaec.va.gov/prweb/PRAuth/app/daper) (you must be on the VA Network) for a submission with the same name/email as the flagged submssion. If no records match, this may be [common scenario 1](#common-scenarios).
+    - Notify the DOCMP team in the `DOCMP PEGA and VA.GOV Sync` Teams channel and provide them the submission details as output by the `MissingStatusCleanup` [utility](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md).
+4. If a cause has been determined, documented, and approved by product manager(s), the missing status may be [manually cleared](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/champva/team/on-call-procedures.md#to-clear-a-missing-status)
 
 ## Additional Considerations:
 


### PR DESCRIPTION
Updated the procedures for resolving missing Pega statuses, including current and old procedures, and added a timestamp for the current procedure.

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/121441
