### PR TITLE
Update platform onboarding checklist with current tooling and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
+++ b/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
@@ -52,7 +52,7 @@ RA - Remote Access_
 
 ### Documentation
 
-- [ ] [Request access to tools](https://depo-platform-documentation.scrollhelp.site/getting-started/Request-access-to-tools.969605215.html) documentation on the Platform Website
+- [ ] [Request access to tools](https://depo-platform-documentation.scrollhelp.site/getting-started/request-access-to-tools) documentation on the Platform Website
 - [ ] [Confluence](https://vfs.atlassian.net/wiki/home)
   - [ ] [VA.Gov Platform Manual](https://vfs.atlassian.net/wiki/spaces/OT/pages/2354315287/Platform+Infrastructure+Manual+WIP)
   - [ ] Have a manager or leadership add you to the [Platform Roster](https://vfs.atlassian.net/wiki/spaces/AP/pages/1908834623/Platform+Roster)
@@ -67,17 +67,26 @@ RA - Remote Access_
 
 - [ ] GitHub
   - [ ] Join the ['department-of-veterans-affairs' organization](https://github.com/department-of-veterans-affairs)
-  - [ ] Even though you're Platform and not VFS, fill out the [New VFS Team Member Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=New-VFS-Team-Member.yml). By filling that out, you'll get added to the `vets.gov-write` GitHub Team which grants you write access to most repos in the org.
+  - [ ] Even though you're Platform and not VFS, fill out the [New VFS Team Member Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=New-VFS-Team-Member.yml). By filling that out, you'll get added to the `vets-gov-write` GitHub Team which grants you write access to most repos in the org.
   - [ ] Make sure you have access to the [devops repo](https://github.com/department-of-veterans-affairs/devops)
+  - [ ] [GitHub Copilot](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=github-copilot-onboarding.yml) - _AI pair programming assistant, available after GitHub org access_
 - [ ] [Pagerduty](https://ecc.pagerduty.com/). Follow [these instructions](https://depo-platform-documentation.scrollhelp.site/getting-started/request-access-to-tools#Requestaccesstotools-PagerDuty) to request access.
 - [ ] [Keybase](https://keybase.io/)
-- [ ] [Datadog](https://depo-platform-documentation.scrollhelp.site/developer-docs/get-access-to-datadog) - _You may need to ask your PM or TL to submit a request on your behalf_
+- [ ] [Datadog](https://depo-platform-documentation.scrollhelp.site/developer-docs/get-access-to-datadog) - _Primary monitoring platform for logs, metrics, and APM. You may need to ask your PM or TL to submit a request on your behalf_
 - [ ] [AWS access request](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?assignees=&labels=external-request%2Coperations%2Cops-access-request&template=aws-access-request.yml&title=Access+for+%5Bindividual%5D) - _Wait until your EQIP submission is verified_
 - [ ] [Jenkins](http://jenkins.vfs.va.gov/) _Accessed on VA Network only_
-- [ ] [Sentry](http://sentry.vfs.va.gov/) _Accessed on VA Network only_
-- [ ] [Argo CD](http://argocd.vfs.va.gov/) _Accessed on VA Network only_
+- [ ] [Sentry](http://sentry.vfs.va.gov/) _Legacy error tracking - being replaced by DataDog. VA Network only_
+- [ ] [Argo CD](http://argocd.vfs.va.gov/) - _GitOps deployment tool for Kubernetes. VA Network only_
 
 _Once your PIV card has been obtained:_
 
 - [ ] [Citrix Access Gateway (CAG)](https://citrixaccess.va.gov/vpn/index_citrix_splash.html) or [Azure Windows Virtual Desktop](https://client.wvd.microsoft.com/arm/webclient/index.html)
 - [ ] [Venafi](https://vfs.atlassian.net/wiki/spaces/OT/pages/1719009302/Venafi+Gain+access+to+manage+internal+TLS+certificates) _DevOps Only_
+- [ ] [Test User Dashboard](https://tud.vfs.va.gov/) - _For testing with synthetic test users. VA Network only_
+
+### Developer onboarding
+
+- [ ] [Platform Developer Documentation](https://depo-platform-documentation.scrollhelp.site/) - _Start here for vets-api and vets-website development guidance_
+- [ ] [vets-api local development setup](https://github.com/department-of-veterans-affairs/vets-api#readme) _Backend_
+- [ ] [vets-website local development setup](https://github.com/department-of-veterans-affairs/vets-website#readme) _Frontend_
+- [ ] [PII Guidelines](https://depo-platform-documentation.scrollhelp.site/developer-docs/personal-identifiable-information-pii-guidelines) - _Required reading for handling Veteran data_

--- a/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
+++ b/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
@@ -67,7 +67,7 @@ RA - Remote Access_
 
 - [ ] GitHub
   - [ ] Join the ['department-of-veterans-affairs' organization](https://github.com/department-of-veterans-affairs)
-  - [ ] Even though you're Platform and not VFS, fill out the [New VFS Team Member Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=New-VFS-Team-Member.yml). By filling that out, you'll get added to the `vets-gov-write` GitHub Team which grants you write access to most repos in the org.
+  - [ ] Even though you're Platform and not VFS, fill out the [New VFS Team Member Template](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=New-VFS-Team-Member.yml). By filling that out, you'll get added to the `vets.gov-write` GitHub Team which grants you write access to most repos in the org.
   - [ ] Make sure you have access to the [devops repo](https://github.com/department-of-veterans-affairs/devops)
   - [ ] [GitHub Copilot](https://github.com/department-of-veterans-affairs/va.gov-team/issues/new?template=github-copilot-onboarding.yml) - _AI pair programming assistant, available after GitHub org access_
 - [ ] [Pagerduty](https://ecc.pagerduty.com/). Follow [these instructions](https://depo-platform-documentation.scrollhelp.site/getting-started/request-access-to-tools#Requestaccesstotools-PagerDuty) to request access.
@@ -77,16 +77,16 @@ RA - Remote Access_
 - [ ] [Jenkins](http://jenkins.vfs.va.gov/) _Accessed on VA Network only_
 - [ ] [Sentry](http://sentry.vfs.va.gov/) _Legacy error tracking - being replaced by DataDog. VA Network only_
 - [ ] [Argo CD](http://argocd.vfs.va.gov/) - _GitOps deployment tool for Kubernetes. VA Network only_
+- [ ] [Test User Dashboard](https://tud.vfs.va.gov/) - _Legacy tool for testing with synthetic test users. VA Network only_
 
 _Once your PIV card has been obtained:_
 
 - [ ] [Citrix Access Gateway (CAG)](https://citrixaccess.va.gov/vpn/index_citrix_splash.html) or [Azure Windows Virtual Desktop](https://client.wvd.microsoft.com/arm/webclient/index.html)
 - [ ] [Venafi](https://vfs.atlassian.net/wiki/spaces/OT/pages/1719009302/Venafi+Gain+access+to+manage+internal+TLS+certificates) _DevOps Only_
-- [ ] [Test User Dashboard](https://tud.vfs.va.gov/) - _For testing with synthetic test users. VA Network only_
 
 ### Developer onboarding
 
 - [ ] [Platform Developer Documentation](https://depo-platform-documentation.scrollhelp.site/) - _Start here for vets-api and vets-website development guidance_
 - [ ] [vets-api local development setup](https://github.com/department-of-veterans-affairs/vets-api#readme) _Backend_
 - [ ] [vets-website local development setup](https://github.com/department-of-veterans-affairs/vets-website#readme) _Frontend_
-- [ ] [PII Guidelines](https://depo-platform-documentation.scrollhelp.site/developer-docs/personal-identifiable-information-pii-guidelines) - _Required reading for handling Veteran data_
+- [ ] [What is PII](https://depo-platform-documentation.scrollhelp.site/research-design/what-is-pii) - _Required reading for handling Veteran data_

--- a/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
+++ b/.github/ISSUE_TEMPLATE/platform-onboarding-checklist.md
@@ -89,4 +89,4 @@ _Once your PIV card has been obtained:_
 - [ ] [Platform Developer Documentation](https://depo-platform-documentation.scrollhelp.site/) - _Start here for vets-api and vets-website development guidance_
 - [ ] [vets-api local development setup](https://github.com/department-of-veterans-affairs/vets-api#readme) _Backend_
 - [ ] [vets-website local development setup](https://github.com/department-of-veterans-affairs/vets-website#readme) _Frontend_
-- [ ] [What is PII](https://depo-platform-documentation.scrollhelp.site/research-design/what-is-pii) - _Required reading for handling Veteran data_
+- [ ] [What is PII?](https://depo-platform-documentation.scrollhelp.site/research-design/what-is-pii) - _Required reading for handling Veteran data_


### PR DESCRIPTION
- Fix outdated tool access URL format
- Add Sentry deprecation note (being replaced by DataDog)
- Emphasize DataDog as primary monitoring platform
- Add GitHub Copilot onboarding reference
- Fix vets-gov-write team name (was vets.gov-write)
- Add Argo CD context (GitOps deployment tool)
- Add Test User Dashboard reference
- Add Developer onboarding section with Platform docs, local setup guides, and PII Guidelines