### PR TITLE
fix: add helpful pointer to team manifest guide in collab cycle template

### DIFF
--- a/scripts/manifest/sync-collab-cycle-teams.rb
+++ b/scripts/manifest/sync-collab-cycle-teams.rb
@@ -68,7 +68,7 @@ class CollabCycleTeamSync
     # Convert from input to dropdown
     team_field['type'] = 'dropdown'
     team_field['attributes']['label'] = 'VFS team name'
-    team_field['attributes']['description'] = 'Select your team from the list (sorted alphabetically)'
+    team_field['attributes']['description'] = 'Select your team from the list (sorted alphabetically). Not seeing your team here? [Add your team to the manifest](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/teams-manifest-user-guide.md)'
     # Remove input-specific attributes that aren't valid for dropdowns
     team_field['attributes'].delete('placeholder')
     team_field['attributes']['options'] = dropdown_options


### PR DESCRIPTION
## Problem

The collaboration cycle team dropdown description doesn't provide guidance for users whose team is missing from the list.

## Solution

Updated the `sync-collab-cycle-teams.rb` script to include a helpful link to the team manifest user guide in the dropdown description.

## Changes

- Updated description from:
  ```
  Select your team from the list (sorted alphabetically)
  ```
  
- To:
  ```
  Select your team from the list (sorted alphabetically). Not seeing your team here? [Add your team to the manifest](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/teams-manifest-user-guide.md)
  ```

## Impact

When the next team data sync runs, the collaboration cycle request template will show this updated description, helping users self-serve when their team is missing.

## Testing

- [ ] Merge this PR
- [ ] Wait for next team data sync (or manually trigger sync-team-metadata workflow in va.gov-team-sensitive)
- [ ] Verify updated description appears in .github/ISSUE_TEMPLATE/collaboration-cycle-request.yml

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)