### PR TITLE
Add frontmatter to research plans using NLP

### DIFF
--- a/products/ask-va/design/User research/2024-01 Submit an inquiry/Research plan.md
+++ b/products/ask-va/design/User research/2024-01 Submit an inquiry/Research plan.md
@@ -1,4 +1,87 @@
 ---
+title: Research Plan Metadata
+date: '2026-01-07'
+last_updated: YYYY-MM-DD
+team: '[Team Name]'
+product: ', Date]"'
+product_area: '[e.g., authenticated/unauthenticated]'
+background:
+  problem_statement: '[What problem is your product trying to solve?]'
+  product_location: '[Where is this situated on VA.gov?]'
+  user_familiarity: '[New product or iteration?]'
+  product_brief_url: '[URL]'
+methodology:
+- '- "[participant-type]"'
+- '- "[research-phase]"'
+- ''
+research_format:
+  location: remote
+  in_person_details:
+    facility: '[Location name if applicable]'
+    point_of_contact: '[Name if applicable]'
+    equipment: '[Equipment details if applicable]'
+  moderated: true
+research_goals:
+- goal_1: '[First research goal]'
+- goal_2: '[Second research goal]'
+- goal_3: '[Third research goal]'
+research_questions:
+- '[Research question 1]'
+- '[Research question 2]'
+- '[Research question 3]'
+- '[Research question 4]'
+- '[Research question 5]'
+hypotheses:
+- '[Hypothesis 1]'
+- '[Hypothesis 2]'
+- '[Hypothesis 3]'
+expected_outcomes: '[How will findings advance the product?]'
+recruitment:
+  recruiting_partner: Perigean
+  approach: '[e.g., lean maximum variation]'
+  primary_criteria:
+  - '[Must-have criterion 1]'
+  - '[Must-have criterion 2]'
+  - '[Must-have criterion 3]'
+  secondary_criteria:
+  - '[Nice-to-have criterion 1]'
+  - '[Nice-to-have criterion 2]'
+  screener_questions:
+  - question: '[Screener question text]'
+    qualifying_response: '[Expected answer]'
+participants:
+  veterans: 0
+  caregivers: 0
+  dependents: 0
+  total_recruited: 0
+  completed_sessions_goal: 0
+timeline:
+  pilot_date: YYYY-MM-DD
+  pilot_participant: '[Name]'
+  research_dates: YYYY-MM-DD to YYYY-MM-DD
+  research_review_submission: YYYY-MM-DD
+session_details:
+  duration_minutes: 60
+  buffer_minutes: 30
+  max_sessions_per_day: 0
+octo_priorities:
+- objective: Objective 1
+  key_results:
+  - '[Specific KR if applicable]'
+- objective: Objective 2
+  key_results:
+  - '[Specific KR if applicable]'
+veteran_journey_phases:
+- '[e.g., Getting Out]'
+- '[e.g., Starting Up]'
+related_research:
+  previous_studies:
+  - '[Link to related past research]'
+tags:
+- '[TODO: Add tags]'
+author: '[TODO: Author]'
+---
+---
 # Research Plan Metadata
 title: "Research Plan for [Team, Product, Date]"
 date: YYYY-MM-DD


### PR DESCRIPTION
This PR was created automatically to add and populate YAML frontmatter in research plans using NLP. 

## What this PR does:
1. ✅ Added YAML frontmatter template to research plans that were missing it
2. ✅ Auto-populated frontmatter fields using NLP analysis of document content

## Files processed:
products/ask-va/design/User research/2024-01 Submit an inquiry/Research plan.md

## Review required:
Please review the changes to ensure the auto-populated frontmatter is accurate. 

/cc @sstrassberg