### PR TITLE
chore: sync team data from va.gov-team-sensitive

### DIFF
--- a/.github/ISSUE_TEMPLATE/collaboration-cycle-request.yml
+++ b/.github/ISSUE_TEMPLATE/collaboration-cycle-request.yml
@@ -75,7 +75,6 @@ body:
     - Governance (23004)
     - Horizon (31001)
     - Hydra (32001)
-    - IVC Forms (33002)
     - Identity (20001)
     - Medical Records (31002)
     - Medications, Medical Devices and Supplies (31003)

--- a/team-lookup.json
+++ b/team-lookup.json
@@ -494,15 +494,6 @@
     "readme_path": "teams/health-portfolio/1010-health-apps/README.md",
     "manifest_url": "https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/health-portfolio/1010-health-apps/README.md"
   },
-  "33002": {
-    "team_id": 33002,
-    "team_name": "IVC Forms",
-    "short_name": "ivc-forms",
-    "portfolio": "Health Portfolio",
-    "crew_or_pod": "VA Health Applications",
-    "readme_path": "teams/health-portfolio/ivc-forms/README.md",
-    "manifest_url": "https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/health-portfolio/ivc-forms/README.md"
-  },
   "33003": {
     "team_id": 33003,
     "team_name": "VFMP Status Integration",


### PR DESCRIPTION
## Automated Team Data Sync

This PR synchronizes team-lookup.json from va.gov-team-sensitive.

### What Happens Next

1. ✅ This PR contains updated team-lookup.json
2. 🏷️ The "teams-manifest-data-sync" label triggers a workflow
3. 🤖 The workflow will regenerate collaboration-cycle-request.yml
4. ✅ The template update will be committed to THIS PR
5. 👀 Review both files together and merge

### Triggered By

- ✅ PR merge: https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/pull/5075



### Files in This PR

- `team-lookup.json` - Canonical team list with IDs
- `collaboration-cycle-request.yml` - Will be updated automatically

---
🤖 Automated by [sync-team-metadata workflow](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/actions/workflows/sync-team-metadata.yml)

Source: [teams/team-lookup.json](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/teams/team-lookup.json)